### PR TITLE
Fix for "localhost" problem reported on the mailing list on 17 June.

### DIFF
--- a/HardwareObjects/InstanceServer.py
+++ b/HardwareObjects/InstanceServer.py
@@ -189,8 +189,11 @@ class InstanceServer(Procedure):
         local_hostname=socket.gethostname()
         local_full_hostname=socket.getfqdn(local_hostname)
 
-        if self.getProperty('host') is not None:
-            host_full_hostname=socket.getfqdn(self.getProperty('host'))
+       host_property = self.getProperty('host')
+       if host_property is not None:
+           if host_property == 'localhost' or host_property == '127.0.0.1':
+               return True
+            host_full_hostname=socket.getfqdn(host_property)
             if host_full_hostname!=local_full_hostname:
                 return False
 


### PR DESCRIPTION
Needed for systems where the hostname does not resolve to an
interface address where a socket can be created. This can happen
when the machine is not connected to any network, or where the
hostname is not set or available by DHCP
