### PR TITLE
Replace fields DHLM and DLLM with HLM and LLM

### DIFF
--- a/mxcubecore/HardwareObjects/LNLS/EPICSMotor.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICSMotor.py
@@ -30,8 +30,8 @@ class EPICSMotor(AbstractMotor, EPICSActuator):
     MOTOR_STOP = 'epicsMotor_stop'
     MOTOR_RLV = 'epicsMotor_rlv'
     MOTOR_VELO = 'epicsMotor_velo'
-    MOTOR_DLLM = 'epicsMotor_dllm'
-    MOTOR_DHLM = 'epicsMotor_dhlm'
+    MOTOR_HLM = 'epicsMotor_hlm'
+    MOTOR_LLM = 'epicsMotor_llm'
     MOTOR_EGU = 'epicsMotor_egu'
 
     def __init__(self, name):
@@ -67,8 +67,9 @@ class EPICSMotor(AbstractMotor, EPICSActuator):
     def get_limits(self):
         """Override method."""
         try:
-            low_limit = float(self.get_channel_value(self.MOTOR_DLLM))
-            high_limit = float(self.get_channel_value(self.MOTOR_DHLM))
+            low_limit = float(self.get_channel_value(self.MOTOR_LLM))
+            high_limit = float(self.get_channel_value(self.MOTOR_HLM))
+
             self._nominal_limits = (low_limit, high_limit)
         except BaseException:
             self._nominal_limits = (None, None)

--- a/mxcubecore/configuration/lnls_manaca/dtox.xml
+++ b/mxcubecore/configuration/lnls_manaca/dtox.xml
@@ -6,8 +6,8 @@
   <channel type="epics" name="epicsMotor_dmov" polling="500">MNC:B:PB04:m5.DMOV</channel>
   <channel type="epics" name="epicsMotor_stop">MNC:B:PB04:m5.STOP</channel>
   <channel type="epics" name="epicsMotor_velo">MNC:B:PB04:m5.VELO</channel>
-  <channel type="epics" name="epicsMotor_dllm">nope</channel>
-  <channel type="epics" name="epicsMotor_dhlm">nope</channel>
+  <channel type="epics" name="epicsMotor_llm">MNC:B:PB04:m5.LLM</channel>
+  <channel type="epics" name="epicsMotor_hlm">MNC:B:PB04:m5.HLM</channel>
   <channel type="epics" name="epicsMotor_egu">MNC:B:PB04:m5.EGU</channel>
   <!-- Pmac channels -->
   <channel type="epics" name="pmac_sendcmd">MNC:B:PB04:SendCmd</channel>

--- a/mxcubecore/configuration/lnls_manaca/udiff_kappa.xml
+++ b/mxcubecore/configuration/lnls_manaca/udiff_kappa.xml
@@ -5,8 +5,8 @@
     <channel type="epics" name="epicsMotor_dmov" polling="500">MNC:B:PB05:m7.DMOV</channel>
     <channel type="epics" name="epicsMotor_stop">MNC:B:PB05:m7.STOP</channel>
     <channel type="epics" name="epicsMotor_velo">MNC:B:PB05:m7.VELO</channel>
-    <channel type="epics" name="epicsMotor_dllm">MNC:B:PB05:m7.DLLM</channel>
-    <channel type="epics" name="epicsMotor_dhlm">MNC:B:PB05:m7.DHLM</channel>
+    <channel type="epics" name="epicsMotor_llm">MNC:B:PB05:m7.LLM</channel>
+    <channel type="epics" name="epicsMotor_hlm">MNC:B:PB05:m7.HLM</channel>
     <channel type="epics" name="epicsMotor_egu">MNC:B:PB05:m7.EGU</channel>
     <username>Kappa</username>
     <motor_name>Kappa</motor_name>

--- a/mxcubecore/configuration/lnls_manaca/udiff_kappaphi.xml
+++ b/mxcubecore/configuration/lnls_manaca/udiff_kappaphi.xml
@@ -5,8 +5,8 @@
     <channel type="epics" name="epicsMotor_dmov" polling="500">MNC:B:PB05:m6.DMOV</channel>
     <channel type="epics" name="epicsMotor_stop">MNC:B:PB05:m6.STOP</channel>
     <channel type="epics" name="epicsMotor_velo">MNC:B:PB05:m6.VELO</channel>
-    <channel type="epics" name="epicsMotor_dllm">MNC:B:PB05:m6.DLLM</channel>
-    <channel type="epics" name="epicsMotor_dhlm">MNC:B:PB05:m6.DHLM</channel>
+    <channel type="epics" name="epicsMotor_llm">MNC:B:PB05:m6.LLM</channel>
+    <channel type="epics" name="epicsMotor_hlm">MNC:B:PB05:m6.HLM</channel>
     <channel type="epics" name="epicsMotor_egu">MNC:B:PB05:m6.EGU</channel>
     <username>Kappa Phi</username>
     <motor_name>Phi</motor_name>

--- a/mxcubecore/configuration/lnls_manaca/udiff_omega.xml
+++ b/mxcubecore/configuration/lnls_manaca/udiff_omega.xml
@@ -5,8 +5,8 @@
     <channel type="epics" name="epicsMotor_dmov" polling="500">MNC:B:PB05:m8.DMOV</channel>
     <channel type="epics" name="epicsMotor_stop">MNC:B:PB05:m8.STOP</channel>
     <channel type="epics" name="epicsMotor_velo">MNC:B:PB05:m8.VELO</channel>
-    <channel type="epics" name="epicsMotor_dllm">MNC:B:PB05:m8.DLLM</channel>
-    <channel type="epics" name="epicsMotor_dhlm">MNC:B:PB05:m8.DHLM</channel>
+    <channel type="epics" name="epicsMotor_llm">MNC:B:PB05:m8.LLM</channel>
+    <channel type="epics" name="epicsMotor_hlm">MNC:B:PB05:m8.HLM</channel>
     <channel type="epics" name="epicsMotor_egu">MNC:B:PB05:m8.EGU</channel>
     <username>Omega</username>
     <motor_name>Omega</motor_name>

--- a/mxcubecore/configuration/lnls_manaca/udiff_phix.xml
+++ b/mxcubecore/configuration/lnls_manaca/udiff_phix.xml
@@ -5,8 +5,8 @@
     <channel type="epics" name="epicsMotor_dmov" polling="500">MNC:B:PB05:m1.DMOV</channel>
     <channel type="epics" name="epicsMotor_stop">MNC:B:PB05:m1.STOP</channel>
     <channel type="epics" name="epicsMotor_velo">MNC:B:PB05:m1.VELO</channel>
-    <channel type="epics" name="epicsMotor_dllm">MNC:B:PB05:m1.DLLM</channel>
-    <channel type="epics" name="epicsMotor_dhlm">MNC:B:PB05:m1.DHLM</channel>
+    <channel type="epics" name="epicsMotor_llm">MNC:B:PB05:m1.LLM</channel>
+    <channel type="epics" name="epicsMotor_hlm">MNC:B:PB05:m1.HLM</channel>
     <channel type="epics" name="epicsMotor_egu">MNC:B:PB05:m1.EGU</channel>
     <username>PhiX</username>
     <motor_name>AlignmentX</motor_name>

--- a/mxcubecore/configuration/lnls_manaca/udiff_phiy.xml
+++ b/mxcubecore/configuration/lnls_manaca/udiff_phiy.xml
@@ -5,8 +5,8 @@
     <channel type="epics" name="epicsMotor_dmov" polling="500">MNC:B:PB05:m2.DMOV</channel>
     <channel type="epics" name="epicsMotor_stop">MNC:B:PB05:m2.STOP</channel>
     <channel type="epics" name="epicsMotor_velo">MNC:B:PB05:m2.VELO</channel>
-    <channel type="epics" name="epicsMotor_dllm">MNC:B:PB05:m2.DLLM</channel>
-    <channel type="epics" name="epicsMotor_dhlm">MNC:B:PB05:m2.DHLM</channel>
+    <channel type="epics" name="epicsMotor_llm">MNC:B:PB05:m2.LLM</channel>
+    <channel type="epics" name="epicsMotor_hlm">MNC:B:PB05:m2.HLM</channel>
     <channel type="epics" name="epicsMotor_egu">MNC:B:PB05:m2.EGU</channel>
     <username>PhiY</username>
     <motor_name>AlignmentY</motor_name>

--- a/mxcubecore/configuration/lnls_manaca/udiff_phiz.xml
+++ b/mxcubecore/configuration/lnls_manaca/udiff_phiz.xml
@@ -5,8 +5,8 @@
     <channel type="epics" name="epicsMotor_dmov" polling="500">MNC:B:PB05:m3.DMOV</channel>
     <channel type="epics" name="epicsMotor_stop">MNC:B:PB05:m3.STOP</channel>
     <channel type="epics" name="epicsMotor_velo">MNC:B:PB05:m3.VELO</channel>
-    <channel type="epics" name="epicsMotor_dllm">MNC:B:PB05:m3.DLLM</channel>
-    <channel type="epics" name="epicsMotor_dhlm">MNC:B:PB05:m3.DHLM</channel>
+    <channel type="epics" name="epicsMotor_llm">MNC:B:PB05:m3.LLM</channel>
+    <channel type="epics" name="epicsMotor_hlm">MNC:B:PB05:m3.HLM</channel>
     <channel type="epics" name="epicsMotor_egu">MNC:B:PB05:m3.EGU</channel>
     <username>PhiZ</username>
     <motor_name>AlignmentZ</motor_name>

--- a/mxcubecore/configuration/lnls_manaca/udiff_sampx.xml
+++ b/mxcubecore/configuration/lnls_manaca/udiff_sampx.xml
@@ -5,8 +5,8 @@
     <channel type="epics" name="epicsMotor_dmov" polling="500">MNC:B:PB05:m4.DMOV</channel>
     <channel type="epics" name="epicsMotor_stop">MNC:B:PB05:m4.STOP</channel>
     <channel type="epics" name="epicsMotor_velo">MNC:B:PB05:m4.VELO</channel>
-    <channel type="epics" name="epicsMotor_dllm">MNC:B:PB05:m4.DLLM</channel>
-    <channel type="epics" name="epicsMotor_dhlm">MNC:B:PB05:m4.DHLM</channel>
+    <channel type="epics" name="epicsMotor_llm">MNC:B:PB05:m4.LLM</channel>
+    <channel type="epics" name="epicsMotor_hlm">MNC:B:PB05:m4.HLM</channel>
     <channel type="epics" name="epicsMotor_egu">MNC:B:PB05:m4.EGU</channel>
     <username>sampx</username>
     <motor_name>CentringX</motor_name>

--- a/mxcubecore/configuration/lnls_manaca/udiff_sampy.xml
+++ b/mxcubecore/configuration/lnls_manaca/udiff_sampy.xml
@@ -5,8 +5,8 @@
     <channel type="epics" name="epicsMotor_dmov" polling="500">MNC:B:PB05:m5.DMOV</channel>
     <channel type="epics" name="epicsMotor_stop">MNC:B:PB05:m5.STOP</channel>
     <channel type="epics" name="epicsMotor_velo">MNC:B:PB05:m5.VELO</channel>
-    <channel type="epics" name="epicsMotor_dllm">MNC:B:PB05:m5.DLLM</channel>
-    <channel type="epics" name="epicsMotor_dhlm">MNC:B:PB05:m5.DHLM</channel>
+    <channel type="epics" name="epicsMotor_llm">MNC:B:PB05:m5.LLM</channel>
+    <channel type="epics" name="epicsMotor_hlm">MNC:B:PB05:m5.HLM</channel>
     <channel type="epics" name="epicsMotor_egu">MNC:B:PB05:m5.EGU</channel>
     <username>sampy</username>
     <motor_name>CentringY</motor_name>

--- a/mxcubecore/configuration/lnls_sol/dtox.xml
+++ b/mxcubecore/configuration/lnls_sol/dtox.xml
@@ -6,8 +6,8 @@
   <channel type="epics" name="epicsMotor_dmov" polling="500">SOL:S:m4.DMOV</channel>
   <channel type="epics" name="epicsMotor_stop">SOL:S:m4.STOP</channel>
   <channel type="epics" name="epicsMotor_velo">SOL:S:m4.VELO</channel>
-  <channel type="epics" name="epicsMotor_dllm">SOL:S:m4.DLLM</channel>
-  <channel type="epics" name="epicsMotor_dhlm">SOL:S:m4.DHLM</channel>
+  <channel type="epics" name="epicsMotor_llm">SOL:S:m4.LLM</channel>
+  <channel type="epics" name="epicsMotor_hlm">SOL:S:m4.HLM</channel>
   <channel type="epics" name="epicsMotor_egu">SOL:S:m4.EGU</channel>
   <channel type="epics" name="pmac_sendcmd">SOL:S:m4.DESC</channel>
   <!-- Properties -->

--- a/mxcubecore/configuration/lnls_sol/udiff_kappa.xml
+++ b/mxcubecore/configuration/lnls_sol/udiff_kappa.xml
@@ -5,8 +5,8 @@
     <channel type="epics" name="epicsMotor_dmov" polling="500">SOL:S:m2.DMOV</channel>
     <channel type="epics" name="epicsMotor_stop">SOL:S:m2.STOP</channel>
     <channel type="epics" name="epicsMotor_velo">SOL:S:m2.VELO</channel>
-    <channel type="epics" name="epicsMotor_dllm">SOL:S:m2.DLLM</channel>
-    <channel type="epics" name="epicsMotor_dhlm">SOL:S:m2.DHLM</channel>
+    <channel type="epics" name="epicsMotor_llm">SOL:S:m2.LLM</channel>
+    <channel type="epics" name="epicsMotor_hlm">SOL:S:m2.HLM</channel>
     <channel type="epics" name="epicsMotor_egu">SOL:S:m2.EGU</channel>
     <username>Kappa</username>
     <motor_name>Kappa</motor_name>

--- a/mxcubecore/configuration/lnls_sol/udiff_kappaphi.xml
+++ b/mxcubecore/configuration/lnls_sol/udiff_kappaphi.xml
@@ -5,8 +5,8 @@
     <channel type="epics" name="epicsMotor_dmov" polling="500">SOL:S:m3.DMOV</channel>
     <channel type="epics" name="epicsMotor_stop">SOL:S:m3.STOP</channel>
     <channel type="epics" name="epicsMotor_velo">SOL:S:m3.VELO</channel>
-    <channel type="epics" name="epicsMotor_dllm">SOL:S:m3.DLLM</channel>
-    <channel type="epics" name="epicsMotor_dhlm">SOL:S:m3.DHLM</channel>
+    <channel type="epics" name="epicsMotor_llm">SOL:S:m3.LLM</channel>
+    <channel type="epics" name="epicsMotor_hlm">SOL:S:m3.HLM</channel>
     <channel type="epics" name="epicsMotor_egu">SOL:S:m3.EGU</channel>
     <username>Kappa Phi</username>
     <motor_name>Phi</motor_name>

--- a/mxcubecore/configuration/lnls_sol/udiff_omega.xml
+++ b/mxcubecore/configuration/lnls_sol/udiff_omega.xml
@@ -5,8 +5,8 @@
     <channel type="epics" name="epicsMotor_dmov" polling="500">SOL:S:m1.DMOV</channel>
     <channel type="epics" name="epicsMotor_stop">SOL:S:m1.STOP</channel>
     <channel type="epics" name="epicsMotor_velo">SOL:S:m1.VELO</channel>
-    <channel type="epics" name="epicsMotor_dllm">SOL:S:m1.DLLM</channel>
-    <channel type="epics" name="epicsMotor_dhlm">SOL:S:m1.DHLM</channel>
+    <channel type="epics" name="epicsMotor_llm">SOL:S:m1.LLM</channel>
+    <channel type="epics" name="epicsMotor_hlm">SOL:S:m1.HLM</channel>
     <channel type="epics" name="epicsMotor_egu">SOL:S:m1.EGU</channel>
     <username>Omega</username>
     <motor_name>Omega</motor_name>

--- a/mxcubecore/configuration/lnls_sol/udiff_phix.xml
+++ b/mxcubecore/configuration/lnls_sol/udiff_phix.xml
@@ -1,13 +1,15 @@
-<device class="LNLS.EPICSMotor">
-    <channel type="epics" name="epicsActuator_val">SOL:S:m1.VAL</channel>
-    <channel type="epics" name="epicsActuator_rbv" polling="500">SOL:S:m1.RBV</channel>
-    <channel type="epics" name="epicsMotor_rlv">SOL:S:m1.RLV</channel>
-    <channel type="epics" name="epicsMotor_dmov" polling="500">SOL:S:m1.DMOV</channel>
-    <channel type="epics" name="epicsMotor_stop">SOL:S:m1.STOP</channel>
-    <channel type="epics" name="epicsMotor_velo">SOL:S:m1.VELO</channel>
-    <channel type="epics" name="epicsMotor_dllm">SOL:S:m1.DLLM</channel>
-    <channel type="epics" name="epicsMotor_dhlm">SOL:S:m1.DHLM</channel>
-    <channel type="epics" name="epicsMotor_egu">SOL:S:m1.EGU</channel>
+<device class="LNLS.LNLSMotor">
+    <!-- Channels -->
+    <channel type="epics" name="epicsActuator_val">SOL:S:m4.VAL</channel>
+    <channel type="epics" name="epicsActuator_rbv" polling="500">SOL:S:m4.RBV</channel>
+    <channel type="epics" name="epicsMotor_rlv">SOL:S:m4.RLV</channel>
+    <channel type="epics" name="epicsMotor_dmov" polling="500">SOL:S:m4.DMOV</channel>
+    <channel type="epics" name="epicsMotor_stop">SOL:S:m4.STOP</channel>
+    <channel type="epics" name="epicsMotor_velo">SOL:S:m4.VELO</channel>
+    <channel type="epics" name="epicsMotor_llm">SOL:S:m4.LLM</channel>
+    <channel type="epics" name="epicsMotor_hlm">SOL:S:m4.HLM</channel>
+    <channel type="epics" name="epicsMotor_egu">SOL:S:m4.EGU</channel>
+    <!-- Properties -->
     <username>PhiX</username>
     <motor_name>AlignmentX</motor_name>
     <GUIstep>0.1</GUIstep>

--- a/mxcubecore/configuration/lnls_sol/udiff_phiy.xml
+++ b/mxcubecore/configuration/lnls_sol/udiff_phiy.xml
@@ -5,8 +5,8 @@
     <channel type="epics" name="epicsMotor_dmov" polling="500">SOL:S:m5.DMOV</channel>
     <channel type="epics" name="epicsMotor_stop">SOL:S:m5.STOP</channel>
     <channel type="epics" name="epicsMotor_velo">SOL:S:m5.VELO</channel>
-    <channel type="epics" name="epicsMotor_dllm">SOL:S:m5.DLLM</channel>
-    <channel type="epics" name="epicsMotor_dhlm">SOL:S:m5.DHLM</channel>
+    <channel type="epics" name="epicsMotor_llm">SOL:S:m5.LLM</channel>
+    <channel type="epics" name="epicsMotor_hlm">SOL:S:m5.HLM</channel>
     <channel type="epics" name="epicsMotor_egu">SOL:S:m5.EGU</channel>
     <username>PhiY</username>
     <motor_name>AlignmentY</motor_name>

--- a/mxcubecore/configuration/lnls_sol/udiff_phiz.xml
+++ b/mxcubecore/configuration/lnls_sol/udiff_phiz.xml
@@ -5,8 +5,8 @@
     <channel type="epics" name="epicsMotor_dmov" polling="500">SOL:S:m6.DMOV</channel>
     <channel type="epics" name="epicsMotor_stop">SOL:S:m6.STOP</channel>
     <channel type="epics" name="epicsMotor_velo">SOL:S:m6.VELO</channel>
-    <channel type="epics" name="epicsMotor_dllm">SOL:S:m6.DLLM</channel>
-    <channel type="epics" name="epicsMotor_dhlm">SOL:S:m6.DHLM</channel>
+    <channel type="epics" name="epicsMotor_llm">SOL:S:m6.LLM</channel>
+    <channel type="epics" name="epicsMotor_hlm">SOL:S:m6.HLM</channel>
     <channel type="epics" name="epicsMotor_egu">SOL:S:m6.EGU</channel>
     <username>PhiZ</username>
     <motor_name>AlignmentZ</motor_name>

--- a/mxcubecore/configuration/lnls_sol/udiff_sampx.xml
+++ b/mxcubecore/configuration/lnls_sol/udiff_sampx.xml
@@ -5,8 +5,8 @@
     <channel type="epics" name="epicsMotor_dmov" polling="500">SOL:S:m7.DMOV</channel>
     <channel type="epics" name="epicsMotor_stop">SOL:S:m7.STOP</channel>
     <channel type="epics" name="epicsMotor_velo">SOL:S:m7.VELO</channel>
-    <channel type="epics" name="epicsMotor_dllm">SOL:S:m7.DLLM</channel>
-    <channel type="epics" name="epicsMotor_dhlm">SOL:S:m7.DHLM</channel>
+    <channel type="epics" name="epicsMotor_llm">SOL:S:m7.LLM</channel>
+    <channel type="epics" name="epicsMotor_hlm">SOL:S:m7.HLM</channel>
     <channel type="epics" name="epicsMotor_egu">SOL:S:m7.EGU</channel>
     <username>sampx</username>
     <motor_name>CentringX</motor_name>

--- a/mxcubecore/configuration/lnls_sol/udiff_sampy.xml
+++ b/mxcubecore/configuration/lnls_sol/udiff_sampy.xml
@@ -5,8 +5,8 @@
     <channel type="epics" name="epicsMotor_dmov" polling="500">SOL:S:m8.DMOV</channel>
     <channel type="epics" name="epicsMotor_stop">SOL:S:m8.STOP</channel>
     <channel type="epics" name="epicsMotor_velo">SOL:S:m8.VELO</channel>
-    <channel type="epics" name="epicsMotor_dllm">SOL:S:m8.DLLM</channel>
-    <channel type="epics" name="epicsMotor_dhlm">SOL:S:m8.DHLM</channel>
+    <channel type="epics" name="epicsMotor_llm">SOL:S:m8.LLM</channel>
+    <channel type="epics" name="epicsMotor_hlm">SOL:S:m8.HLM</channel>
     <channel type="epics" name="epicsMotor_egu">SOL:S:m8.EGU</channel>
     <username>sampy</username>
     <motor_name>CentringY</motor_name>


### PR DESCRIPTION
Hi,

This PR changes the EPICS PVs used by EPICSMotor.py to check limits.
HLM and LLM fields are more straight-forward parameters for this than DHLM and DLLM.

Thanks,
Laís