### PR TITLE
Patch for issue #895

### DIFF
--- a/mxcubecore/HardwareObjects/QueueManager.py
+++ b/mxcubecore/HardwareObjects/QueueManager.py
@@ -365,7 +365,7 @@ class QueueManager(HardwareObject, QueueEntryContainer):
                 if result:
                     return result
 
-    def execute_entry(self, entry, _async=False):
+    def execute_entry(self, entry, use_async=False):
         """
         Executes the queue entry <entry>.
 
@@ -379,7 +379,7 @@ class QueueManager(HardwareObject, QueueEntryContainer):
         self._is_stopped = False
         self._set_in_queue_flag()
 
-        if _async:
+        if use_async:
             task = gevent.spawn(self.__execute_entry, entry)
             task.link((lambda _t: self._queue_end()))
         else:


### PR DESCRIPTION
The problem described in #895 is due to a retry mechanism in the client that re-sends a request if there are no response after a certain amount of time. The call to `execute_entry` is in the case of #895 blocking so a retry is made after n minutes, effectively calling the entry twice (or even more depending on the duration of the call)

A parameter `_async` to make the call non-blocking was added, the task is executed in a greenlet if `_async` is passed `True`. The default behavior is to still that `execute_entry ` is blocking, so all logic that need a non blocking behavior need to set  `_async` to `True`