### PR TITLE
Removed name override

### DIFF
--- a/mxcubecore/HardwareObjects/BlissMotor.py
+++ b/mxcubecore/HardwareObjects/BlissMotor.py
@@ -195,6 +195,3 @@ class BlissMotor(AbstractMotor):
         """Stop the motor movement"""
         self.motor_obj.stop(wait=False)
 
-    def name(self):
-        """Get the motor name. Should be removed when GUI ready"""
-        return self.actuator_name

--- a/mxcubecore/HardwareObjects/ExporterMotor.py
+++ b/mxcubecore/HardwareObjects/ExporterMotor.py
@@ -248,7 +248,3 @@ class ExporterMotor(AbstractMotor):
             (float): the maximim speed [unit/s].
         """
         return self._exporter.execute("getMotorMaxSpeed", (self.actuator_name,))
-
-    def name(self):
-        """Get the motor name. Should be removed when GUI ready"""
-        return self.actuator_name


### PR DESCRIPTION
 - Overriding name method gives unexpected names for exporter motors