### PR TITLE
Handle light

### DIFF
--- a/mxcubecore/HardwareObjects/BlissNState.py
+++ b/mxcubecore/HardwareObjects/BlissNState.py
@@ -88,7 +88,10 @@ class BlissNState(AbstractNState):
             if self._prefix:
                 _attr = self._prefix + "_is_in"
                 _cmd = getattr(self._bliss_obj, _attr)
-                _val = _cmd()
+                if isinstance(_cmd, bool):
+                    _val = _cmd
+                else:
+                    _val = _cmd()
             else:
                 _val = self._bliss_obj.state
         # print(f"get_value:  {self.value_to_enum(_val)}, {_val}")

--- a/mxcubecore/HardwareObjects/Microdiff.py
+++ b/mxcubecore/HardwareObjects/Microdiff.py
@@ -292,21 +292,22 @@ class Microdiff(MiniDiff.MiniDiff):
                 logging.getLogger("HWR").exception("Cannot prepare centring")
 
     def set_light_in(self):
+        """Set the backlight in - used by the XMLRPC calls"""
         logging.getLogger("HWR").info("Moving backlight in")
-        venum = self.get_object_by_role("BackLightSwitch").VALUES
-        self.get_object_by_role("BackLightSwitch").handle_beamstop(venum.IN)
-        self.wait_ready()
+        light_hwobj = self.getObjectByRole("BackLightSwitch")
+        light_hwobj.set_value(light_hwobj.VALUES.IN)
+        self.wait_ready(20)
 
     def set_light_out(self):
+        """Set the backlight out - used by the XMLRPC calls"""
         logging.getLogger("HWR").info("Moving backlight out")
-        venum = self.get_object_by_role("BackLightSwitch").VALUES
-        self.get_object_by_role("BackLightSwitch").handle_beamstop(venum.OUT)
-        self.wait_ready()
+        light_hwobj = self.getObjectByRole("BackLightSwitch")
+        light_hwobj.set_value(light_hwobj.VALUES.OUT)
+        self.wait_ready(20)
 
     def set_phase(self, phase, wait=False, timeout=None):
         if self._ready():
             if phase in self.phases:
-
                 if phase in ["BeamLocation", "Transfer", "Centring"]:
                     self.close_detector_cover()
                     self.phase_prepare(phase)

--- a/mxcubecore/HardwareObjects/MiniDiff.py
+++ b/mxcubecore/HardwareObjects/MiniDiff.py
@@ -422,7 +422,7 @@ class MiniDiff(Equipment):
     def is_ready(self):
         return self.is_valid() and not any(
             [
-                m.motorIsMoving()
+                m.is_ready()
                 for m in (
                     self.sampleXMotor,
                     self.sampleYMotor,

--- a/mxcubecore/HardwareObjects/XMLRPCServer.py
+++ b/mxcubecore/HardwareObjects/XMLRPCServer.py
@@ -440,6 +440,8 @@ class XMLRPCServer(HardwareObject):
         try:
             for angle, path in path_list:
                 HWR.beamline.diffractometer.phiMotor.set_value(angle)
+                # give some time to get the snapshot
+                time.sleep(1)
                 HWR.beamline.diffractometer.wait_ready()
                 self.save_snapshot(path, show_scale, handle_light=False)
         except Exception as ex:
@@ -454,6 +456,8 @@ class XMLRPCServer(HardwareObject):
 
         if handle_light:
             HWR.beamline.diffractometer.set_light_in()
+            # give some time to get the snapshot
+            time.sleep(1)
 
         try:
             if showScale:


### PR DESCRIPTION
Fix set_light_in/out, used by XMLRPC.
Change obsolete call in MiniDiff
Handle property coming from bliss actuator.