### PR TITLE
Exposing type hinted attributes for UI

### DIFF
--- a/mxcubecore/BaseHardwareObjects.py
+++ b/mxcubecore/BaseHardwareObjects.py
@@ -21,10 +21,13 @@
 
 from __future__ import absolute_import
 
+import typing
+import ast
 import enum
 from collections import OrderedDict
 import logging
 from gevent import event, Timeout
+import pydantic
 
 from mxcubecore.dispatcher import dispatcher
 from mxcubecore.CommandContainer import CommandContainer
@@ -680,6 +683,63 @@ class HardwareObject(HardwareObjectNode, HardwareObjectMixin):
         HardwareObjectMixin.__init__(self)
         self.log = logging.getLogger("HWR").getChild(self.__class__.__name__)
         self.user_log = logging.getLogger("user_log_level")
+        self.__exports = {}
+        self.__pydantic_models = {}
+        self._exported_attributes = {}
+        self._exports_config_list = []
+
+    def init(self):
+        self._exports_config_list.extend(
+            ast.literal_eval(self.get_property("exports", "[]").strip())
+        )
+
+        self.__exports = dict.fromkeys(self._exports_config_list, {})
+
+        if self.__exports:
+            self._get_type_annotations()
+
+    def _get_type_annotations(self):
+        _models = {}
+
+        for attr_name, _ in self.__exports.items():
+            self._exported_attributes[attr_name] = {}
+            self.__exports[attr_name] = []
+            self.__pydantic_models[attr_name] = {}
+            fdict = {}
+
+            for _n, _t in typing.get_type_hints(getattr(self, attr_name)).items():
+                # Skipp return typehint
+                if _n != "return":
+                    self.__exports[attr_name].append(_n)
+                    fdict[_n] = (_t, pydantic.Field(alias=_n))
+
+            _models[attr_name] = (
+                pydantic.create_model(attr_name, **fdict),
+                pydantic.Field(alias=attr_name)
+            )
+
+            self.__pydantic_models[attr_name] = _models[attr_name][0]
+            self._exported_attributes[attr_name]["signature"] = self.__exports[attr_name]
+            self._exported_attributes[attr_name]["schema"] = self.__pydantic_models[attr_name].schema_json()
+
+
+        model = pydantic.create_model(self.__class__.__name__, **_models)
+        self.__pydantic_models["all"] = model
+
+    def execute_exported_command(self, cmd_name, args):
+        if cmd_name in self.__exports.keys():
+            cmd = getattr(self, cmd_name)
+            cmd(**args)
+        else:
+            self.log.info(f"Command {cmd} not exported, check type hints and configuration file")
+
+    @property
+    def pydantic_model(self):
+        return self.__pydantic_models
+
+    @property
+    def exported_attributes(self):
+        return self._exported_attributes
 
     def __getstate__(self):
         return self.name()

--- a/mxcubecore/BaseHardwareObjects.py
+++ b/mxcubecore/BaseHardwareObjects.py
@@ -434,6 +434,24 @@ class HardwareObjectMixin(CommandContainer):
         # Internal object-specific state attribute, used to check for state changes
         self._specific_state = None
 
+        # Dictionary on the form:
+        # key: The exporterd member function name
+        # value: The arguments of the exported member
+        self._exports = {}
+
+        # Dictionary containing list Pydantic models for each of the exported member
+        # functions arguemnts. The key is the member name and the value a list of the
+        # pydantic models.
+        self._pydantic_models = {}
+
+        # Dictionary on the form:
+        # key: The exporterd member function name
+        # value: dictionary on the form {signautre: [<arguments>] schema:<JSONSchema>}
+        self._exported_attributes = {}
+
+        # List of member names (methods) to be exported (Set at configuration stage)
+        self._exports_config_list = []
+
     def __bool__(self):
         return True
 
@@ -450,7 +468,68 @@ class HardwareObjectMixin(CommandContainer):
         """"'public' post-initialization method. Override as needed
 
         For ConfiguredObjects called after loading contained objects"""
-        pass
+        self._exports = dict.fromkeys(self._exports_config_list, {})
+
+        if self._exports:
+            self._get_type_annotations()
+
+    def _get_type_annotations(self):
+        """
+        Retrieve typehints and create pydantic models for each argument
+        """
+        _models = {}
+
+        for attr_name, _ in self._exports.items():
+            self._exported_attributes[attr_name] = {}
+            self._exports[attr_name] = []
+            self._pydantic_models[attr_name] = {}
+            fdict = {}
+
+            for _n, _t in typing.get_type_hints(getattr(self, attr_name)).items():
+                # Skipp return typehint
+                if _n != "return":
+                    self._exports[attr_name].append(_n)
+                    fdict[_n] = (_t, pydantic.Field(alias=_n))
+
+            _models[attr_name] = (
+                pydantic.create_model(attr_name, **fdict),
+                pydantic.Field(alias=attr_name)
+            )
+
+            self._pydantic_models[attr_name] = _models[attr_name][0]
+            self._exported_attributes[attr_name]["signature"] = self._exports[attr_name]
+            self._exported_attributes[attr_name]["schema"] = self._pydantic_models[attr_name].schema_json()
+
+        model = pydantic.create_model(self.__class__.__name__, **_models)
+        self._pydantic_models["all"] = model
+
+    def execute_exported_command(self, cmd_name, args):
+        if cmd_name in self._exports.keys():
+            cmd = getattr(self, cmd_name)
+            cmd(**args)
+        else:
+            self.log.info(f"Command {cmd} not exported, check type hints and configuration file")
+
+    @property
+    def pydantic_model(self):
+        """
+        Returns:
+          The pydantic model for method
+        """
+        return self._pydantic_models
+
+    @property
+    def exported_attributes(self):
+        """
+        Returns:
+           A dictionary containing the method signature and JSONSchema
+           on the format:
+            {
+                "schema": JSONSchema string
+                "signaure" list of argument names
+            }
+        """
+        return self._exported_attributes
 
     def abort(self):
         """Immediately terminate HardwareObject action
@@ -683,63 +762,12 @@ class HardwareObject(HardwareObjectNode, HardwareObjectMixin):
         HardwareObjectMixin.__init__(self)
         self.log = logging.getLogger("HWR").getChild(self.__class__.__name__)
         self.user_log = logging.getLogger("user_log_level")
-        self.__exports = {}
-        self.__pydantic_models = {}
-        self._exported_attributes = {}
-        self._exports_config_list = []
 
     def init(self):
         self._exports_config_list.extend(
             ast.literal_eval(self.get_property("exports", "[]").strip())
         )
-
-        self.__exports = dict.fromkeys(self._exports_config_list, {})
-
-        if self.__exports:
-            self._get_type_annotations()
-
-    def _get_type_annotations(self):
-        _models = {}
-
-        for attr_name, _ in self.__exports.items():
-            self._exported_attributes[attr_name] = {}
-            self.__exports[attr_name] = []
-            self.__pydantic_models[attr_name] = {}
-            fdict = {}
-
-            for _n, _t in typing.get_type_hints(getattr(self, attr_name)).items():
-                # Skipp return typehint
-                if _n != "return":
-                    self.__exports[attr_name].append(_n)
-                    fdict[_n] = (_t, pydantic.Field(alias=_n))
-
-            _models[attr_name] = (
-                pydantic.create_model(attr_name, **fdict),
-                pydantic.Field(alias=attr_name)
-            )
-
-            self.__pydantic_models[attr_name] = _models[attr_name][0]
-            self._exported_attributes[attr_name]["signature"] = self.__exports[attr_name]
-            self._exported_attributes[attr_name]["schema"] = self.__pydantic_models[attr_name].schema_json()
-
-
-        model = pydantic.create_model(self.__class__.__name__, **_models)
-        self.__pydantic_models["all"] = model
-
-    def execute_exported_command(self, cmd_name, args):
-        if cmd_name in self.__exports.keys():
-            cmd = getattr(self, cmd_name)
-            cmd(**args)
-        else:
-            self.log.info(f"Command {cmd} not exported, check type hints and configuration file")
-
-    @property
-    def pydantic_model(self):
-        return self.__pydantic_models
-
-    @property
-    def exported_attributes(self):
-        return self._exported_attributes
+        HardwareObjectMixin.init(self)
 
     def __getstate__(self):
         return self.name()

--- a/mxcubecore/HardwareObjects/Beamline.py
+++ b/mxcubecore/HardwareObjects/Beamline.py
@@ -423,6 +423,17 @@ class Beamline(ConfiguredObject):
     __content_roles.append("imaging")
 
     @property
+    def beamline_actions(self):
+        """Beamline Actions
+
+        Returns:
+            Optional[beamline_actions]:
+        """
+        return self._objects.get("beamline_actions")
+
+    __content_roles.append("beamline_actions")
+
+    @property
     def xml_rpc_server(self):
         """XMLRPCServer for RPC
 

--- a/mxcubecore/HardwareObjects/BeamlineActions.py
+++ b/mxcubecore/HardwareObjects/BeamlineActions.py
@@ -1,0 +1,262 @@
+import sys
+import typing
+import enum
+import ast
+import importlib
+import operator
+
+from mxcubecore.BaseHardwareObjects import HardwareObject
+from mxcubecore.TaskUtils import task
+from mxcubecore.CommandContainer import CommandObject
+from mxcubecore.utils.conversion import camel_to_snake
+
+import gevent
+import logging
+
+class ControllerCommand(CommandObject):
+    def __init__(self, name, cmd=None, username=None, klass=None):
+        CommandObject.__init__(self, name, username)
+
+        if not cmd:
+            self._cmd = klass()
+        else:
+            self._cmd=cmd
+
+        self._cmd_execution = None
+        self.type = "CONTROLLER"
+
+        if self.name() == "Anneal":
+            self.add_argument("Time [s]", "float")
+        if self.name() == "Test":
+            self.add_argument("combo test", "combo", [{"value1": 0, "value2": 1}])
+
+    def is_connected(self):
+        return True
+
+    @task
+    def __call__(self, *args, **kwargs):
+        self.emit("commandBeginWaitReply", (str(self.name()),))
+        self._cmd_execution = gevent.spawn(self._cmd, *args, **kwargs)
+        self._cmd_execution.link(self._cmd_done)
+
+    def _cmd_done(self, cmd_execution):
+        try:
+            try:
+                res = cmd_execution.get()
+                res = res if res else ""
+            except Exception:
+                logging.getLogger("HWR").exception(
+                    "%s: execution failed", str(self.name())
+                )
+                self.emit("commandFailed", (str(self.name()),))
+            else:
+                if isinstance(res, gevent.GreenletExit):
+                    # command aborted
+                    self.emit("commandFailed", (str(self.name()),))
+                else:
+                    self.emit("commandReplyArrived", (str(self.name()), res))
+        finally:
+            self.emit("commandReady",  (str(self.name()), ""))
+
+    def abort(self):
+        if self._cmd_execution and not self._cmd_execution.ready():
+            self._cmd_execution.kill()
+
+    def value(self):
+        return None
+
+class HWObjActuatorCommand(CommandObject):
+    """Class for two state hardware objects"""
+
+    def __init__(self, name, hwobj):
+        super().__init__(name)
+        self._hwobj = hwobj
+        self.type = TWO_STATE_COMMAND_T
+        self.argument_type = ARGUMENT_TYPE_LIST
+        self._hwobj.connect("valueChanged", self._cmd_done)
+
+    def _get_action(self):
+        """Return which action has to be executed.
+        Return:
+            (str): The name of the command
+        """
+        values = [v.name for v in self._hwobj.VALUES]
+        values.remove("UNKNOWN")
+        values.remove(self._hwobj.get_value().name)
+
+        return self._hwobj.VALUES[values[0]]
+
+    @task
+    def __call__(self, *args, **kwargs):
+        """Execute the action.
+        Args: None
+        Kwargs: None
+        """
+        self.emit("commandBeginWaitReply", (str(self.name()),))
+        value = self._get_action()
+        self._hwobj.set_value(value, timeout=60)
+
+    def _cmd_done(self, state):
+        """Handle the command execution.
+        Args:
+            (obj): Command execution greenlet.
+        """
+        gevent.sleep(1)
+        try:
+            res = self._hwobj.get_value().name
+        except Exception:
+            self.emit("commandFailed", (str(self.name()),))
+        else:
+            if isinstance(res, gevent.GreenletExit):
+                self.emit("commandFailed", (str(self.name()),))
+            else:
+                self.emit("commandReplyArrived", (str(self.name()), res))
+
+    def value(self):
+        """Return the current command vaue.
+        Return:
+            (str): The value as a string
+        """
+        value = "UNKNOWN"
+        if hasattr(self._hwobj, "get_value"):
+            value = self._hwobj.get_value()
+            try:
+                return value.name
+            except AttributeError:
+                return value
+        return value
+
+
+class CommandDescription(typing.NamedTuple):
+    name: str
+    task: typing.Any
+    result: typing.Any
+    messages: list
+
+class AnnotatedCommand(CommandObject):
+    def __init__(self, beamline_action_ho, name, cmd_name):
+        self._beamline_action_ho = beamline_action_ho
+        self._name = name
+        self._cmd_name = cmd_name
+        self._value = ""
+
+    def get_value(self):
+        return self._value
+
+class BeamlineActions(HardwareObject):
+    def __init__(self, *args):
+        HardwareObject.__init__(self, *args)
+        self._annotated_commands = []
+        self._annotated_command_dict = {}
+        self._command_list = []
+        self._current_command = CommandDescription("", None, None, [])
+        self._command_log = []
+
+    def _get_command_object_class(self, path_str):
+        parts = path_str.split(".")
+
+        _module_name = "mxcubecore."+".".join(parts[:-1])
+        _cls_name = parts[-1]
+        self._annotated_commands.append(_cls_name)
+        
+        # Assume import from current module if only class name givien (no module)
+        if len(parts) == 1:
+            _cls = getattr(sys.modules[__name__], _cls_name)
+        else:
+            _mod = importlib.import_module(_module_name)
+            _cls = getattr(_mod, _cls_name)
+        
+        return _cls
+
+    def init(self):
+        command_list = ast.literal_eval(
+            self.get_property("commands").strip().replace("\n", "")
+        )
+
+        for command in command_list:
+            attrname = camel_to_snake(command["command"].split(".")[-1])
+            
+            if hasattr(self, attrname):
+                msg = "Command with name %s already exists" % command["command"].split(".")[-1]
+                logging.getLogger("HWR").warning(msg)
+                continue
+
+            if command["type"] == "annotated":
+                _cls = self._get_command_object_class(command["command"])
+                fname = camel_to_snake(_cls.__name__)
+                _cls_inst = _cls(self, fname.replace("_", " ").title(), fname)
+
+                self._annotated_command_dict[fname] = _cls_inst
+                setattr(self, attrname, getattr(_cls_inst, fname))
+                self._exports_config_list.append(attrname)
+            elif command["type"] == "controller":
+                try:
+                    cmd = operator.attrgetter(command["command"])(self)
+                    _cmd_obj = ControllerCommand(command["name"], cmd, command["name"])
+                except AttributeError:
+                    _cls = self._get_command_object_class(command["command"])
+                    _cmd_obj = ControllerCommand(command["name"], None, command["name"], klass=_cls)
+
+                self._command_list.append(_cmd_obj)
+                setattr(self, attrname, _cmd_obj)
+            elif command["type"] == "actuator":
+                try:
+                    cmd = operator.attrgetter(command["command"])
+                    _cmd_obj = HWObjActuatorCommand(command["name"], cmd)
+                    self._command_list.append(_cmd_obj)
+                except AttributeError:
+                    pass
+
+        super().init()
+
+    def get_annotated_command(self, name):
+        return self._annotated_command_dict[name]
+    
+    def get_annotated_commands(self):
+        return list(self._annotated_command_dict.values())
+
+    def get_commands(self):
+        return self._command_list
+
+    def execute_command(self, name, args):
+        cmd = getattr(self, name, None)
+
+        if cmd:
+            self._annotated_command_dict[name].emit("commandBeginWaitReply", name)
+            _t = gevent.spawn(cmd, **args)
+            _t.link(self._command_done)
+            
+            self._current_command = CommandDescription(name, _t, None, [])
+            self._command_log.append(self._current_command)
+
+    def _command_done(self, greenlet):
+        cmd_obj = self._annotated_command_dict[self._current_command.name]
+        result = ""
+        
+        try:
+            try:
+                result = greenlet.get()
+            except Exception:
+                logging.getLogger("HWR").exception(
+                    "%s: execution failed", self._current_command.name
+                )
+                cmd_obj.emit("commandFailed", (self._current_command.name,))
+            else:
+                if isinstance(result, gevent.GreenletExit):
+                    # command aborted
+                    cmd_obj.emit("commandFailed", (self._current_command.name,))
+                else:
+                    self._current_command.result = result
+                    cmd_obj.emit("commandReplyArrived", (self._current_command.name, result))
+        finally:
+            cmd_obj.emit("commandReady", (
+                self._current_command.name,
+                self._current_command.result)
+            )
+
+            self._current_command = CommandDescription("", None, None, [])
+
+    def abort_command(self, name):
+        cmd_obj = self._annotated_command_dict[self._current_command.name]
+        self._current_command.task.kill()
+

--- a/mxcubecore/HardwareObjects/GenericDiffractometer.py
+++ b/mxcubecore/HardwareObjects/GenericDiffractometer.py
@@ -230,6 +230,7 @@ class GenericDiffractometer(HardwareObject):
         self.get_motor_positions = self.get_positions
 
     def init(self):
+        super().init()
         # Internal values -----------------------------------------------------
         self.ready_event = gevent.event.Event()
         self.user_clicked_event = gevent.event.AsyncResult()

--- a/mxcubecore/HardwareObjects/abstract/AbstractDetector.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractDetector.py
@@ -84,6 +84,7 @@ class AbstractDetector(HardwareObject):
 
     def init(self):
         """Initialise some common paramerters"""
+        super().init()
 
         try:
             self._metadata = dict(self["beam"].get_properties())

--- a/mxcubecore/HardwareObjects/mockup/BeamlineActionsMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/BeamlineActionsMockup.py
@@ -1,8 +1,23 @@
-from mxcubecore.BaseHardwareObjects import HardwareObject
+import sys
+import typing
+import enum
+
+
 from mxcubecore.TaskUtils import task
 from mxcubecore.CommandContainer import CommandObject
+from mxcubecore.HardwareObjects.BeamlineActions import BeamlineActions, ControllerCommand, AnnotatedCommand
+from mxcubecore.utils.conversion import camel_to_snake
+
 import gevent
 import logging
+
+
+class EnumArg(str, enum.Enum):
+    centring = "Centring"
+    data_collection = 'DataCollection'
+    beam_location = 'BeamLocation'
+    transfer = "Transfer"
+    unknown = "Unknown"
 
 
 class SimulatedAction:
@@ -25,64 +40,38 @@ class LongSimulatedAction:
         return args
 
 
-class ControllerCommand(CommandObject):
-    def __init__(self, name, cmd, username=None, klass=SimulatedAction):
-        CommandObject.__init__(self, name, username)
-        self._cmd = klass()
-        self._cmd_execution = None
-        self.type = "CONTROLLER"
-
-        if self.name() == "Anneal":
-            self.add_argument("Time [s]", "float")
-        if self.name() == "Test":
-            self.add_argument("combo test", "combo", [{"value1": 0, "value2": 1}])
-
-    def is_connected(self):
-        return True
-
-    @task
-    def __call__(self, *args, **kwargs):
-        self.emit("commandBeginWaitReply", (str(self.name()),))
-        self._cmd_execution = gevent.spawn(self._cmd, *args, **kwargs)
-        self._cmd_execution.link(self._cmd_done)
-
-    def _cmd_done(self, cmd_execution):
-        try:
-            try:
-                res = cmd_execution.get()
-            except Exception:
-                logging.getLogger("HWR").exception(
-                    "%s: execution failed", str(self.username)
-                )
-                self.emit("commandFailed", (str(self.name()),))
-            else:
-                if isinstance(res, gevent.GreenletExit):
-                    # command aborted
-                    self.emit("commandFailed", (str(self.name()),))
-                else:
-                    self.emit("commandReplyArrived", (str(self.name()), res))
-        finally:
-            self.emit("commandReady")
-
-    def abort(self):
-        if self._cmd_execution and not self._cmd_execution.ready():
-            self._cmd_execution.kill()
-
-    def value(self):
-        return None
+class Arg(typing.NamedTuple):
+    name: str
+    unit: str
+    alias: str
 
 
-class BeamlineActionsMockup(HardwareObject):
+class Anneal2(AnnotatedCommand):
     def __init__(self, *args):
-        HardwareObject.__init__(self, *args)
+        super().__init__(*args)
 
-    def init(self):
-        self.centrebeam = ControllerCommand("centrebeam", None, "Centre beam")
-        self.quick_realign = ControllerCommand(
-            "realign", None, "Quick realign", klass=LongSimulatedAction
-        )
-        self.anneal = ControllerCommand("Anneal", None, klass=SimulatedActionError)
-        self.combotest = ControllerCommand("Test", None, "Test with combo box")
+    #@argument(ArgMeta("time", "s", "time"))
+    def anneal2(self, time: float) -> None:
+        print("ANNEAL")
+        gevent.sleep(float(time))
 
-    def get_commands(self):
-        return [self.centrebeam, self.quick_realign, self.anneal, self.combotest]
+
+class QuickRealign2(AnnotatedCommand):
+    def __init__(self, *args):
+        super().__init__(*args)
+
+    def quick_realign2(self) -> None:
+        print("REALIGN")
+
+
+class ComboTest2(AnnotatedCommand):
+    def __init__(self, *args):
+        super().__init__(*args)
+
+    def combo_test2(self, combo_arg: EnumArg) -> None:
+        print("COMBO")
+
+
+class BeamlineActionsMockup(BeamlineActions):
+    def __init__(self, *args):
+        super().__init__(*args)

--- a/mxcubecore/HardwareObjects/mockup/DetectorMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/DetectorMockup.py
@@ -64,3 +64,6 @@ class DetectorMockup(AbstractDetector):
         Starts acquisition
         """
         return
+
+    def restart(self) -> None:
+        pass

--- a/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
@@ -17,16 +17,31 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 
+import enum
 import time
 import logging
 import random
 import warnings
+
+from pydantic import BaseModel, ValidationError
 
 from mxcubecore.HardwareObjects.GenericDiffractometer import (
     GenericDiffractometer,
 )
 from mxcubecore import HardwareRepository as HWR
 from gevent.event import AsyncResult
+
+
+class PhaseEnum(str, enum.Enum):
+    centring = "Centring"
+    data_collection = 'DataCollection'
+    beam_location = 'BeamLocation'
+    transfer = "Transfer"
+    unknown = "Unknown"
+
+
+class PhaseModel(BaseModel):
+    value: PhaseEnum = PhaseEnum.unknown
 
 
 class DiffractometerMockup(GenericDiffractometer):
@@ -40,7 +55,7 @@ class DiffractometerMockup(GenericDiffractometer):
         """
         GenericDiffractometer.__init__(self, *args)
 
-    def init(self):
+    def init(self) -> bool:
         """
         Descript. :
         """
@@ -170,7 +185,7 @@ class DiffractometerMockup(GenericDiffractometer):
         #
         return result
 
-    def is_ready(self):
+    def is_ready(self) -> bool:
         """
         Descript. :
         """
@@ -386,3 +401,15 @@ class DiffractometerMockup(GenericDiffractometer):
 
     def get_point_from_line(self, point_one, point_two, index, images_num):
         return point_one.as_dict()
+
+    def abort(self) -> None:
+        return None
+
+    def status(self) -> str:
+        return "READY"
+    
+    def my_fancy_function(self, speed: float, num_images:int, exp_time:float, phase:PhaseEnum) -> bool:
+        return True
+    
+    def my_other_funny_function(self) -> None:
+        pass

--- a/mxcubecore/configuration/mockup/detector-mockup.xml
+++ b/mxcubecore/configuration/mockup/detector-mockup.xml
@@ -12,4 +12,5 @@
   <hasShutterless>True</hasShutterless>
   <fileSuffix>h5</fileSuffix>
   <object hwrid="/detector-distance-mockup" role="detector_distance"/>
+  <exports>["reset"]</exports>
 </object>

--- a/mxcubecore/configuration/mockup/diffractometer-mockup.xml
+++ b/mxcubecore/configuration/mockup/diffractometer-mockup.xml
@@ -18,4 +18,5 @@
   <sample_mount_mode>sample_changer</sample_mount_mode>
   <!-- MD3 -->
   <grid_direction>{"fast": (0, 1), "slow": (1, 0), "omega_ref": 0}</grid_direction>
+  <exports>["abort", "status", "my_fancy_function", "my_other_funny_function"]</exports>
 </equipment>

--- a/mxcubecore/utils/conversion.py
+++ b/mxcubecore/utils/conversion.py
@@ -20,9 +20,10 @@
 
 """General data and functions, that can be shared between different HardwareObjects
 """
-
 from __future__ import division, absolute_import
 from __future__ import print_function, unicode_literals
+
+import re
 
 from scipy.constants import h, c, e
 
@@ -157,3 +158,6 @@ def make_table(column_names, rows):
     #
     return "\n".join(lines)
 
+def camel_to_snake(name):
+    pattern = re.compile(r'(?<!^)(?=[A-Z])')
+    return pattern.sub('_', name).lower()


### PR DESCRIPTION
Adds a feature that allows any type hinted member of a HardwareObject to be exported to the UI. 

A function written with type hints for instance;

`    
def my_fancy_function(self, speed: float, num_images:int, exp_time:float, phase:PhaseEnum) -> bool:
        return True
`

can now be exported so that a default UI can be displayed to the user, once validated the data entered
are passed to member in question.

Example of UI for the example below, illustrating the feature.
![md_th](https://user-images.githubusercontent.com/4331447/159678182-35d5a3c8-2f2f-4889-ad9d-fcb33401519b.png)

This feature is currently used in two places, it replaces the current beamline actions in MXCuBE 3
sot that they can be expressed as objects with type hinted members. It further makes it possible to
create simple maintenance UIs like the example above.

The type annotated beamline actions currently handles return data and errors like the previous
beamline actions. Error handling and return data for the the pure HardwareObject version still needs
to be implemented.

The feature itself is UI agnostic, its up the the UI-Application to display the exported information and
ultimately call ` execute_exported_command` once the input is validated.
