### PR TITLE
Bug fix when parsing reference objects

### DIFF
--- a/mxcubecore/HardwareObjectFileParser.py
+++ b/mxcubecore/HardwareObjectFileParser.py
@@ -350,7 +350,7 @@ class HardwareObjectHandler(ContentHandler):
 
         if self.element_is_a_reference:
             if len(self.objects) > 0:
-                self.objects[0].add_reference(
+                self.objects[-1].add_reference(
                     name, self.reference, role=self.element_role
                 )
         else:


### PR DESCRIPTION
Bug has been introduced (when?), so it was only possible to do self.get_roles(). This PR sets back the lost functionality self["xxx"].get_roless(), when reference objects are defined as:

```
<object class=MyObject>
   <xxx>
        <object role=aaa href=/my_reference_object1 />
        <object role=bbb href=/my_reference_object2 />
   </xxx>
</object>
```