### PR TITLE
Refactor lima cameras

### DIFF
--- a/mxcubecore/HardwareObjects/TangoLimaVideoDevice.py
+++ b/mxcubecore/HardwareObjects/TangoLimaVideoDevice.py
@@ -115,6 +115,18 @@ class TangoLimaVideoDevice(AbstractVideoDevice):
         return [self.device.image_width, self.device.image_height]
 
     def get_image(self):
+        """
+        Reads image from `video_last_image` attribute of lima device proxy,
+        which is type of `bytes` and converts it into np.array of int.
+
+        Returns
+            raw_buffer : 1d np.array of np.uint16
+                Image
+            width : int
+                Image width
+            height : int
+                Image height
+        """
         img_data = self.device.video_last_image
 
         if img_data[0] == "VIDEO_IMAGE":

--- a/mxcubecore/HardwareObjects/abstract/AbstractVideoDevice.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractVideoDevice.py
@@ -214,9 +214,15 @@ class AbstractVideoDevice(Device):
             return qimage.copy()
 
     def get_jpg_image(self):
-        """ for now this function allows to deal with prosilica or any RGB encoded video data"""
         """
-           the signal imageReceived is as expected by mxcube3
+        Reads`raw_data` image `[1D numpy array of np.uint16]` from `self.get_image()`
+        and converts it to .jpg image. 
+        For now this function allows to deal with prosilica or any RGB encoded video data
+
+        Returns
+        -------
+        jpg_img : bytes
+            Coverted image, emited as signal imageReceived expected by mxcube3.
         """
         raw_buffer, width, height = self.get_image()
 

--- a/mxcubecore/HardwareObjects/abstract/AbstractVideoDevice.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractVideoDevice.py
@@ -46,6 +46,8 @@ except Exception:
 
 from mxcubecore.BaseHardwareObjects import Device
 
+from io import BytesIO
+
 
 module_names = ["qt", "PyQt5", "PyQt4"]
 
@@ -228,14 +230,12 @@ class AbstractVideoDevice(Device):
 
         if raw_buffer is not None and raw_buffer.any():
             image = Image.frombytes("RGB", (width, height), raw_buffer)
-            from cStringIO import StringIO
-
-            strbuf = StringIO()
-            image.save(strbuf, "JPEG")
-            jpgimg_str = strbuf.getvalue()
-            if jpgimg_str is not None:
-                self.emit("imageReceived", jpgimg_str, width, height)
-            return jpgimg_str
+            buffer = BytesIO()
+            image.save(buffer, "JPEG")
+            jpg_img = buffer.getvalue()
+            if jpg_img is not None:
+                self.emit("imageReceived", jpg_img, width, height)
+            return jpg_img
         else:
             return None
 

--- a/mxcubecore/HardwareObjects/abstract/AbstractVideoDevice.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractVideoDevice.py
@@ -54,9 +54,9 @@ module_names = ["qt", "PyQt5", "PyQt4"]
 if any(mod in sys.modules for mod in module_names):
     USEQT = True
     try:
-        from PyQt5.QtGui import QImage, QPixmap
+        from PyQt5.QtGui import QImage, QPixmap, QSize
     except ImportError:
-        from PyQt4.QtGui import QImage, QPixmap
+        from PyQt4.QtGui import QImage, QPixmap, QSize
 else:
     USEQT = False
     from PIL import Image


### PR DESCRIPTION
After moving to python 3, Lima camera was causing problems, because `AbstractVideoDevice.get_jpg_image` was using `cStringIO` which was deprecated in py3.

I'm creating this MR on behalf of MAX-IV. @meghdadyazdi is a reviewer