### PR TITLE
Changing limits for zoom mockups

### DIFF
--- a/mxcubecore/HardwareObjects/mockup/MicrodiffZoomMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/MicrodiffZoomMockup.py
@@ -30,11 +30,11 @@ class MicrodiffZoomMockup(AbstractNState):
         if _len > 0:
             # we can only assume that the values are consecutive integers
             # so the limits correspond to the keys
-            limits = (1, _len)
+            limits = (0, _len-1)
             self.set_limits(limits)
         else:
             # Normally we get the limits from the hardware
-            limits = (1, 10)
+            limits = (0, 9)
             self.set_limits(limits)
             # there is nothing in the xml file, create ValueEnum from the limits
             self._initialise_values()
@@ -79,7 +79,7 @@ class MicrodiffZoomMockup(AbstractNState):
         """Initialise the ValueEnum """
         low, high = self.get_limits()
 
-        values = {"LEVEL%s" % str(v): v for v in range(low, high + 1)}
+        values = {"LEVEL%s" % str(v): v for v in range(low + 1, high + 2)}
         self.VALUES = Enum(
             "ValueEnum",
             dict(values, **{item.name: item.value for item in BaseValueEnum}),


### PR DESCRIPTION
In ui with mockups, zoom slider doesn’t get the maximum. There should be a shift for limit interval. If you have the same problem here is solution for that