### PR TITLE
take_snapshot instead of get_snapshot

### DIFF
--- a/mxcubecore/HardwareObjects/abstract/AbstractVideoDevice.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractVideoDevice.py
@@ -292,6 +292,13 @@ class AbstractVideoDevice(HardwareObject):
             open(filename, "w").write(jpgstr)
 
     def take_snapshot(self, bw=None, return_as_array=True):
+        """Take the snapshot.
+        Args:
+            bs(bool): Return grayscale image (True)
+            return_as_array(bool): Return the image as array. Default is True.
+        Returns:
+            (): Snapshot image.
+        """
         self.get_snapshot(bw, return_as_array)
     
     def get_snapshot(self, bw=None, return_as_array=True):

--- a/mxcubecore/HardwareObjects/abstract/AbstractVideoDevice.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractVideoDevice.py
@@ -290,7 +290,7 @@ class AbstractVideoDevice(HardwareObject):
             jpgstr = self.get_jpg_image()
             open(filename, "w").write(jpgstr)
 
-    def get_snapshot(self, bw=None, return_as_array=True):
+    def take_snapshot(self, bw=None, return_as_array=True):
         """Get the snapshot.
         Args:
             bs(bool): Return grayscale image (True)

--- a/mxcubecore/HardwareObjects/abstract/AbstractVideoDevice.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractVideoDevice.py
@@ -36,6 +36,7 @@ import logging
 from io import BytesIO
 import gevent
 import numpy as np
+import warnings
 
 try:
     import cv2
@@ -291,6 +292,9 @@ class AbstractVideoDevice(HardwareObject):
             open(filename, "w").write(jpgstr)
 
     def take_snapshot(self, bw=None, return_as_array=True):
+        self.get_snapshot(bw, return_as_array)
+    
+    def get_snapshot(self, bw=None, return_as_array=True):
         """Get the snapshot.
         Args:
             bs(bool): Return grayscale image (True)
@@ -298,6 +302,9 @@ class AbstractVideoDevice(HardwareObject):
         Returns:
             (): Snapshot image.
         """
+        warnings.warn(
+            "Deprecated method, call take_snapshot instead", DeprecationWarning
+        )
         if not USEQT:
             print("get snapshot not implemented yet for non-qt mode")
             return None


### PR DESCRIPTION
I think to be consistent with [sampleView hardwareObject](https://github.com/mxcube/mxcubecore/blob/develop/mxcubecore/HardwareObjects/SampleView.py#L140), we should define take_snapshot instead of get_snapshot.