### PR TITLE
Replaced the global_role with "dotted/attribute path"

### DIFF
--- a/mxcubecore/BaseHardwareObjects.py
+++ b/mxcubecore/BaseHardwareObjects.py
@@ -173,7 +173,6 @@ class HardwareObjectNode(object):
         self.__name = node_name
         self.__references = []
         self._xml_path = None
-        self._global_role = None
 
     @staticmethod
     def set_user_file_directory(user_file_directory):
@@ -195,19 +194,6 @@ class HardwareObjectNode(object):
         Args :
           path (str): String representing the path of the Hardware Object in its file"""
         self._path = path
-
-    def set_global_role(self, role):
-        """
-        Set the "global role" of the HardwareObject
-
-        Args:
-          role (str): Role
-        """
-        self._global_role = role
-
-    @property
-    def global_role(self):
-        return self._global_role
 
     def get_xml_path(self):
         return self._xml_path

--- a/mxcubecore/HardwareObjectFileParser.py
+++ b/mxcubecore/HardwareObjectFileParser.py
@@ -175,15 +175,6 @@ class HardwareObjectHandler(ContentHandler):
         elif len(self.objects) == 1:
             return self.objects[0]
 
-    def add_global_role(self, attrs, obj):
-        if "global_role" in attrs:
-            obj.set_global_role(attrs["global_role"])
-        else:
-            logging.getLogger("HWR").warning(
-                f"No global role defined for {self.name}, using filename as global role"
-            )
-            obj.set_global_role(self.name[1:])
-
     def startElement(self, name, attrs):
         """[summary]
 
@@ -290,8 +281,6 @@ class HardwareObjectHandler(ContentHandler):
                 else:
                     new_object.set_path(self.path)
                     self.objects.append(new_object)
-
-                self.add_global_role(attrs, new_object)
             else:
                 new_object_class = new_objects_classes[name]
                 new_object = new_object_class(object_name)
@@ -319,8 +308,6 @@ class HardwareObjectHandler(ContentHandler):
                     if new_object is None:
                         self.class_error = True
                         return
-
-                    self.add_global_role(attrs, new_object)
                 else:
                     new_object = BaseHardwareObjects.HardwareObject(object_name)
 

--- a/mxcubecore/HardwareObjects/Beamline.py
+++ b/mxcubecore/HardwareObjects/Beamline.py
@@ -33,7 +33,7 @@ __author__ = "Rasmus H Fogh"
 
 import logging
 
-from mxcubecore.BaseHardwareObjects import ConfiguredObject
+from mxcubecore.BaseHardwareObjects import ConfiguredObject, HardwareObject
 
 # NBNB The acq parameter names match the attributes of AcquisitionParameters
 # Whereas the limit parmeter values use more udnerstandable names
@@ -122,9 +122,13 @@ class Beamline(ConfiguredObject):
         # List of undulators
         self.undulators = []
 
+        # Dictionary with the python id of hardwareobject as key 
+        # and the "dotted/attribute path" to hardwareobject from the 
+        # Beamline object
+        self._hardware_object_id_dict = {}
+
     def init(self):
         """Object initialisation - executed *after* loading contents"""
-
         # Validate acquisition parameters
         for acquisition_type, params in self.default_acquisition_parameters.items():
             unrecognised = [x for x in params if x not in self.SUPPORTED_ACQ_PARAMETERS]
@@ -143,6 +147,64 @@ class Beamline(ConfiguredObject):
             logging.getLogger("HWR").warning(
                 "Unrecognised parameter limits for: %s" % unrecognised
             )
+
+    def _hwr_init_done(self):
+        """
+        Method called after the initialization of HardwareRepository is done
+        (when all HardwreObjects have been created and initialized)
+        """
+        self._hardware_object_id_dict = self._get_id_dict()
+
+    def get_id(self, ho: HardwareObject) -> str:
+        """
+        Returns "dotted path/attribute" which is unique within the context of
+        HardwareRepository
+
+        Args:
+            ho (HardwareObject): The hardware object for which to get the id
+
+        Returns:
+            (str): Returns "dotted path/attribute"
+        """
+        return self._hardware_object_id_dict.get(id(ho))
+
+    def _get_id_dict(self) -> dict:
+        """
+        Wrapper function used to call the recursive method used to find all 
+        HardwareObjects accessible from the Beamline object.
+        """
+        result = {}
+
+        for ho_name in self.all_roles:
+            ho = self._objects.get(ho_name)
+
+            if ho:
+                result[id(ho)] = ho_name
+                self._get_id_dict_rec(ho, ho_name, result)
+
+        return result
+
+    def _get_id_dict_rec(self, ho: HardwareObject, _path: str="", result: dict = {}) -> str:
+        """
+        Recurses through all the roles of ho and constructs its corresponding 
+        "dotted path/attribute"
+
+        Args:
+            ho (HardwreObject): The HardwareObject to get the id for
+            _path (str): Current path (used in recursion)
+            result: A dictionary where the key is the id of the HardwareObject
+                    and the value its dotted path.
+
+        Returns:
+            (str): Dotted path for the given HardwareObject
+        """
+        if hasattr(ho, "get_roles"):
+            for role in ho.get_roles():
+                child_ho = ho.get_object_by_role(role)
+                if id(child_ho) not in result:
+                    result[id(child_ho)] = self._get_id_dict_rec(child_ho, f"{_path}.{role}", result)
+
+        return _path
 
     # NB this function must be re-implemented in nested subclasses
     @property

--- a/mxcubecore/HardwareObjects/Beamline.py
+++ b/mxcubecore/HardwareObjects/Beamline.py
@@ -220,8 +220,8 @@ class Beamline(ConfiguredObject):
         if hasattr(ho, "get_roles"):
             for role in ho.get_roles():
                 child_ho = ho.get_object_by_role(role)
-                if id(child_ho) not in result:
-                    result[id(child_ho)] = self._get_id_dict_rec(child_ho, f"{_path}.{role}", result)
+                if child_ho not in result:
+                    result[child_ho] = self._get_id_dict_rec(child_ho, f"{_path}.{role}", result)
 
         return _path
 

--- a/mxcubecore/HardwareObjects/Beamline.py
+++ b/mxcubecore/HardwareObjects/Beamline.py
@@ -170,7 +170,7 @@ class Beamline(ConfiguredObject):
         """
         return self._hardware_object_id_dict.get(ho)
 
-    def get_ho(self, _id: str) -> Union[HardwareObject, None]:
+    def get_hardware_object(self, _id: str) -> Union[HardwareObject, None]:
         """
         Returns the HardwareObject with the given id
 

--- a/mxcubecore/HardwareObjects/Beamline.py
+++ b/mxcubecore/HardwareObjects/Beamline.py
@@ -27,6 +27,8 @@ All HardwareObjects
 from __future__ import division, absolute_import
 from __future__ import print_function, unicode_literals
 
+from typing import Union
+
 __copyright__ = """ Copyright © 2019 by the MXCuBE collaboration """
 __license__ = "LGPLv3+"
 __author__ = "Rasmus H Fogh"
@@ -161,12 +163,29 @@ class Beamline(ConfiguredObject):
         HardwareRepository
 
         Args:
-            ho (HardwareObject): The hardware object for which to get the id
+            ho: The hardware object for which to get the id
 
         Returns:
-            (str): Returns "dotted path/attribute"
+            "dotted path/attribute"
         """
-        return self._hardware_object_id_dict.get(id(ho))
+        return self._hardware_object_id_dict.get(ho)
+
+    def get_ho(self, _id: str) -> Union[HardwareObject, None]:
+        """
+        Returns the HardwareObject with the given id
+
+        Args:
+            _id: "attribute path" / id of HardwareObject
+        Returns:
+            HardwareObject with the given id
+        """
+        found_ho = None
+
+        for current_ho, current_id in self._hardware_object_id_dict.items():
+            if current_id == _id:
+                found_ho = current_ho
+
+        return found_ho
 
     def _get_id_dict(self) -> dict:
         """
@@ -179,7 +198,7 @@ class Beamline(ConfiguredObject):
             ho = self._objects.get(ho_name)
 
             if ho:
-                result[id(ho)] = ho_name
+                result[ho] = ho_name
                 self._get_id_dict_rec(ho, ho_name, result)
 
         return result

--- a/mxcubecore/HardwareObjects/SampleView.py
+++ b/mxcubecore/HardwareObjects/SampleView.py
@@ -41,11 +41,7 @@ class SampleView(AbstractSampleView):
         super(SampleView, self).init()
 
         self._camera = self.get_object_by_role("camera")
-        self._focus = self.get_object_by_role("focus")
-        self._zoom = self.get_object_by_role("zoom")
-        self._frontlight = self.get_object_by_role("frontlight")
-        self._backlight = self.get_object_by_role("backlight")
-        self._diffractometer = self.get_object_by_role("diffractometer")
+        self._diffractometer =  HWR.beamline.diffractometer
 
         self._ui_snapshot_cb = None
 

--- a/mxcubecore/HardwareObjects/SampleView.py
+++ b/mxcubecore/HardwareObjects/SampleView.py
@@ -39,14 +39,11 @@ class SampleView(AbstractSampleView):
 
     def init(self):
         super(SampleView, self).init()
-
         self._camera = self.get_object_by_role("camera")
-        self._diffractometer =  HWR.beamline.diffractometer
-
         self._ui_snapshot_cb = None
 
         self.hide_grid_threshold = self.get_property("hide_grid_threshold", 5)
-        for motor_name, motor_ho in self._diffractometer.get_motors().items():
+        for motor_name, motor_ho in HWR.beamline.diffractometer.get_motors().items():
             if motor_ho:
                 motor_ho.connect("stateChanged", self._update_shape_positions)
 
@@ -68,7 +65,7 @@ class SampleView(AbstractSampleView):
         if shapes_updated:
             self.emit("shapesChanged")
 
-        for motor_name, motor_ho in self._diffractometer.get_motors().items():
+        for motor_name, motor_ho in HWR.beamline.diffractometer.get_motors().items():
             motor_ho.connect("stateChanged", self._update_shape_positions)
 
     def _update_shape_positions(self, *args, **kwargs):

--- a/mxcubecore/HardwareRepository.py
+++ b/mxcubecore/HardwareRepository.py
@@ -299,6 +299,7 @@ def init_hardware_repository(configuration_path):
     _instance = __HardwareRepositoryClient(configuration_path)
     _instance.connect()
     beamline = load_from_yaml(BEAMLINE_CONFIG_FILE, role="beamline")
+    beamline._hwr_init_done()
 
 
 def uninit_hardware_repository():
@@ -442,6 +443,7 @@ class __HardwareRepositoryClient:
             else:
                 if hwobj_instance is not None:
                     self.xml_source[hwobj_name] = xml_data
+
                     dispatcher.send("hardwareObjectLoaded", hwobj_name, self)
 
                     def hardwareObjectDeleted(name=hwobj_instance.name()):

--- a/mxcubecore/utils/pyispyb_client/test.py
+++ b/mxcubecore/utils/pyispyb_client/test.py
@@ -24,8 +24,6 @@ configuration = pyispyb_client.Configuration(
 
 TOKEN = None
 
-import pdb
-pdb.set_trace()
 
 # Enter a context with an instance of the API client
 with pyispyb_client.ApiClient(configuration) as api_client:
@@ -94,8 +92,7 @@ with pyispyb_client.ApiClient(configuration) as api_client:
             ],
         ),
     ) # SSXDataCollectionGroupCreate | 
-    import pdb
-    pdb.set_trace()
+
     # example passing only required values which don't have defaults set
     try:
         # Create Datacollectiongroup

--- a/test/pytest/test_beamline_ho_id.py
+++ b/test/pytest/test_beamline_ho_id.py
@@ -33,6 +33,15 @@ def test_object(beamline):
 
 class TestBeamlineHoId():
     def test_beamline_id(self, test_object):
-        ho = test_object.get_ho("diffractometer")
+        
+        # Test if we can retrive a object located directly on 
+        # the beamline object
+        ho = test_object.get_hardware_object("diffractometer")
         ho_id = test_object.get_id(ho)
         assert("diffractometer" == ho_id)
+
+        # Test if we can get an object further down the strucutre
+        ho = test_object.get_hardware_object("diffractometer.sampx")
+        ho_id = test_object.get_id(ho)
+        assert("diffractometer.sampx" == ho_id)
+

--- a/test/pytest/test_beamline_ho_id.py
+++ b/test/pytest/test_beamline_ho_id.py
@@ -1,0 +1,38 @@
+#! /usr/bin/env python
+# encoding: utf-8
+#
+# This file is part of MXCuBE.
+#
+# MXCuBE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# MXCuBE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with MXCuBE. If not, see <https://www.gnu.org/licenses/>.
+"""
+"""
+
+from __future__ import division, absolute_import
+from __future__ import print_function, unicode_literals
+
+import pytest
+
+__copyright__ = """ Copyright © 2016 - 2020 by MXCuBE Collaboration """
+__license__ = "LGPLv3+"
+
+@pytest.fixture
+def test_object(beamline):
+    result = beamline
+    yield result
+
+class TestBeamlineHoId():
+    def test_beamline_id(self, test_object):
+        ho = test_object.get_ho("diffractometer")
+        ho_id = test_object.get_id(ho)
+        assert("diffractometer" == ho_id)


### PR DESCRIPTION
The "dotted/attribute path" of a HardwareObject within the Beamline hierarchy can be retrieved through `beamline.get_id`.