### PR TITLE
SardanaMotor states are redefined

### DIFF
--- a/mxcubecore/HardwareObjects/SardanaMotor.py
+++ b/mxcubecore/HardwareObjects/SardanaMotor.py
@@ -252,7 +252,7 @@ class SardanaMotor(AbstractMotor, HardwareObject):
         """
         Descript. : True if the motor is currently moving
         """
-        return self.is_ready() and self.get_state() == SardanaMotorState.MOVING
+        return self.is_ready() and self.get_state() == HardwareObjectState.BUSY
 
     motorIsMoving = is_moving
 


### PR DESCRIPTION
States for motors defined in [AbstractMotor](https://github.com/mxcube/mxcubecore/blob/develop/mxcubecore/HardwareObjects/abstract/AbstractMotor.py#L40) is a little bit weird to me
like `<MotorStates.HOME: (<HardwareObjectState.READY: 3>, 5)>`
that `type(MotorStates.HOME.value)` is a tuple and makes it a little bit verbose to work with it. Maybe a better definition for States can be fine in [ExporterStaes](https://github.com/mxcube/mxcubecore/blob/develop/mxcubecore/Command/exporter/ExporterStates.py#L31).
On the other hand `class MotorStates(Enum)` seems suffering from lack of states.

Is there any reason to define these sates like that? Can we make it like one in `class ExporterStates(Enum)`