### PR TITLE
Fixed and simplified image_number precision configuration

### DIFF
--- a/mxcubecore/HardwareObjects/Beamline.py
+++ b/mxcubecore/HardwareObjects/Beamline.py
@@ -796,27 +796,11 @@ class Beamline(ConfiguredObject):
 
         path_template = queue_model_objects.PathTemplate()
 
-        # path_template.directory = str()
-        # path_template.process_directory = str()
-        # path_template.base_prefix = str()
-        # path_template.mad_prefix = ""
-        # path_template.reference_image_prefix = ""
-        # path_template.wedge_prefix = ""
-
         acq_params = self.get_default_acquisition_parameters()
         path_template.start_num = acq_params.first_image
         path_template.num_files = acq_params.num_images
 
         path_template.run_number = self.run_number
-
-        # file_info = self.session["file_info"]
-        # path_template.suffix = file_info.get_property("file_suffix")
-        # path_template.precision = "04"
-        # try:
-        #     if file_info.get_property("precision"):
-        #         path_template.precision = eval(file_info.get_property("precision"))
-        # except Exception:
-        #     pass
 
         return path_template
 

--- a/mxcubecore/HardwareObjects/Beamline.py
+++ b/mxcubecore/HardwareObjects/Beamline.py
@@ -796,12 +796,12 @@ class Beamline(ConfiguredObject):
 
         path_template = queue_model_objects.PathTemplate()
 
-        path_template.directory = str()
-        path_template.process_directory = str()
-        path_template.base_prefix = str()
-        path_template.mad_prefix = ""
-        path_template.reference_image_prefix = ""
-        path_template.wedge_prefix = ""
+        # path_template.directory = str()
+        # path_template.process_directory = str()
+        # path_template.base_prefix = str()
+        # path_template.mad_prefix = ""
+        # path_template.reference_image_prefix = ""
+        # path_template.wedge_prefix = ""
 
         acq_params = self.get_default_acquisition_parameters()
         path_template.start_num = acq_params.first_image
@@ -809,14 +809,14 @@ class Beamline(ConfiguredObject):
 
         path_template.run_number = self.run_number
 
-        file_info = self.session["file_info"]
-        path_template.suffix = file_info.get_property("file_suffix")
-        path_template.precision = "04"
-        try:
-            if file_info.get_property("precision"):
-                path_template.precision = eval(file_info.get_property("precision"))
-        except Exception:
-            pass
+        # file_info = self.session["file_info"]
+        # path_template.suffix = file_info.get_property("file_suffix")
+        # path_template.precision = "04"
+        # try:
+        #     if file_info.get_property("precision"):
+        #         path_template.precision = eval(file_info.get_property("precision"))
+        # except Exception:
+        #     pass
 
         return path_template
 

--- a/mxcubecore/HardwareObjects/EMBL/EMBLXrayImaging.py
+++ b/mxcubecore/HardwareObjects/EMBL/EMBLXrayImaging.py
@@ -473,7 +473,7 @@ class EMBLXrayImaging(QtGraphicsManager, AbstractCollect):
         acq_params = data_model.acquisitions[0].acquisition_parameters
         path_template = data_model.acquisitions[0].path_template
 
-        filename_template = "%s_%d_%" + str(path_template.precision) + "d"
+        filename_template = "%s_%d_%0" + str(path_template.precision) + "d"
         config_filename = (
             filename_template
             % (

--- a/mxcubecore/HardwareObjects/MAXIV/MaxIVSession.py
+++ b/mxcubecore/HardwareObjects/MAXIV/MaxIVSession.py
@@ -24,7 +24,7 @@ class MaxIVSession(Session):
     # Framework-2 method, inherited from HardwareObject and called
     # by the framework after the object has been initialized.
     def init(self):
-        self.default_precision = "04"
+        self.default_precision = 4
         self.login = ""
         self.is_commissioning = False
         self.synchrotron_name = self.get_property("synchrotron_name")

--- a/mxcubecore/HardwareObjects/Session.py
+++ b/mxcubecore/HardwareObjects/Session.py
@@ -34,7 +34,7 @@ class Session(HardwareObject):
         self.email_extension = None
         self.template = None
 
-        self.default_precision = "05"
+        self.default_precision = 5
         self.suffix = None
 
         self.base_directory = None

--- a/mxcubecore/configuration/alba_xaloc13/session.xml
+++ b/mxcubecore/configuration/alba_xaloc13/session.xml
@@ -9,7 +9,7 @@
 
   <file_info>
      <file_suffix>cbf</file_suffix>
-     <precision>'04'</precision>    
+     <precision>4</precision>
      <!-- base_directory>/beamlines/bl13/projects/cycle2017-I</base_directory -->
 
      <!-- ATTENTION - base directory is obtained from ldap user home directory. Following lines are ignored -->

--- a/mxcubecore/configuration/desy_p11/session.xml
+++ b/mxcubecore/configuration/desy_p11/session.xml
@@ -4,7 +4,7 @@
   <beamline_name>P11</beamline_name>
   <file_info>
     <file_suffix>cbf</file_suffix>
-    <precision>'05'</precision>
+    <precision>5</precision>
     <base_directory>/tmp/mxcube_base_dir</base_directory>
     <raw_data_folder_name>RAW_DATA</raw_data_folder_name>
     <processed_data_base_directory>/tmp/mxcube_base_dir</processed_data_base_directory>

--- a/mxcubecore/configuration/embl_hh_p13/session.xml
+++ b/mxcubecore/configuration/embl_hh_p13/session.xml
@@ -4,7 +4,7 @@
   <beamline_name>P13</beamline_name>
   <file_info>
     <file_suffix>cbf</file_suffix>
-    <precision>"05"</precision>
+    <precision>5</precision>
     <base_directory>/mnt/beegfs/P13/2021</base_directory>
     <raw_data_folder_name>RAW_DATA</raw_data_folder_name>
     <processed_data_base_directory>/data/users/</processed_data_base_directory>

--- a/mxcubecore/configuration/embl_hh_p14/session.xml
+++ b/mxcubecore/configuration/embl_hh_p14/session.xml
@@ -4,7 +4,7 @@
   <beamline_name>P14</beamline_name>
   <file_info>
     <file_suffix>cbf</file_suffix>
-    <precision>'05'</precision>    
+    <precision>5</precision>
     <base_directory>/mnt/beegfs/P14/2021</base_directory>
     <raw_data_folder_name>RAW_DATA</raw_data_folder_name>
     <processed_data_base_directory>/data/users/</processed_data_base_directory>

--- a/mxcubecore/configuration/embl_hh_pe2/session.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/session.xml
@@ -4,7 +4,7 @@
   <beamline_name>PE2</beamline_name>
   <file_info>
     <file_suffix>cbf</file_suffix>
-    <precision>'07'</precision>
+    <precision>7</precision>
     <base_directory>/mnt/beegfs/PE2/2019/</base_directory>
     <raw_data_folder_name>RAW_DATA</raw_data_folder_name>
     <processed_data_base_directory>/dataInt/</processed_data_base_directory>

--- a/mxcubecore/configuration/mockup/gphl/alba_session.xml
+++ b/mxcubecore/configuration/mockup/gphl/alba_session.xml
@@ -9,7 +9,7 @@
 
   <file_info>
      <file_suffix>cbf</file_suffix>
-     <precision>'04'</precision>    
+     <precision>4</precision>
      <!-- base_directory>/beamlines/bl13/projects/cycle2017-I</base_directory -->
 
      <!-- ATTENTION - base directory is obtained from ldap user home directory. Following lines are ignored -->

--- a/mxcubecore/configuration/mockup/gphl/session.xml
+++ b/mxcubecore/configuration/mockup/gphl/session.xml
@@ -4,7 +4,7 @@
   <beamline_name>test</beamline_name>
   <file_info>
     <file_suffix>cbf</file_suffix>
-    <precision>'05'</precision>
+    <precision>5</precision>
     <base_directory>/home/rhfogh/calc/mxcube_data</base_directory>
     <raw_data_folder_name>RAW_DATA</raw_data_folder_name>
     <processed_data_base_directory>/home/rhfogh/calc/mxcube_data</processed_data_base_directory>

--- a/mxcubecore/configuration/mockup/session.xml
+++ b/mxcubecore/configuration/mockup/session.xml
@@ -4,7 +4,7 @@
   <beamline_name>test</beamline_name>
   <file_info>
     <file_suffix>cbf</file_suffix>
-    <precision>'05'</precision>
+    <precision>5</precision>
     <base_directory>/tmp/mxcube_test_data</base_directory>
     <raw_data_folder_name>RAW_DATA</raw_data_folder_name>
     <processed_data_base_directory>/tmp/mxcube_test_data</processed_data_base_directory>

--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -1348,9 +1348,6 @@ class XrayCentring2(TaskNode):
                 sample_model
             )
         self.path_template.num_files = 0
-        # self.path_template.precision = "0" + str(
-        #     HWR.beamline.session["file_info"].get_property("precision", 4)
-        # )
         self.path_template.directory = os.path.join(
             HWR.beamline.session.get_base_image_directory(), params.get("subdir", "")
         )
@@ -2270,9 +2267,6 @@ class GphlWorkflow(TaskNode):
         )
 
         self.path_template.num_files = 0
-        # self.path_template.precision = "0" + str(
-        #     HWR.beamline.session["file_info"].get_property("precision", 4)
-        # )
 
         self.path_template.directory = os.path.join(
             HWR.beamline.session.get_base_image_directory(), params.get("subdir", "")

--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -1339,14 +1339,6 @@ class XrayCentring2(TaskNode):
         params is a dictionary with structure determined by mxcube3 usage
         """
 
-        # Set configured settings
-        # # NB settings is an internal attribute DO NOT MODIFY
-        # settings = HWR.beamline.gphl_workflow.settings
-        # self.auto_char_params = copy.deepcopy(settings.get("auto_char_params", {}))
-        # self.auto_char_params.update(params.pop("auto_char_params", {}))
-        # self.auto_acq_params = copy.deepcopy(settings.get("auto_acq_params", {}))
-        # self.auto_acq_params.update(params.pop("auto_acq_params", {}))
-
         # Set path template
         self.path_template.set_from_dict(params)
         if params["prefix"]:
@@ -1356,9 +1348,9 @@ class XrayCentring2(TaskNode):
                 sample_model
             )
         self.path_template.num_files = 0
-        self.path_template.precision = "0" + str(
-            HWR.beamline.session["file_info"].get_property("precision", 4)
-        )
+        # self.path_template.precision = "0" + str(
+        #     HWR.beamline.session["file_info"].get_property("precision", 4)
+        # )
         self.path_template.directory = os.path.join(
             HWR.beamline.session.get_base_image_directory(), params.get("subdir", "")
         )
@@ -1366,33 +1358,6 @@ class XrayCentring2(TaskNode):
             HWR.beamline.session.get_base_process_directory(),
             params.get("subdir", ""),
         )
-
-        # # First set some parameters from defaults
-        # default_parameters = HWR.beamline.get_default_acquisition_parameters()
-        # self.aimed_resolution = default_parameters.resolution
-        # self.exposure_time = default_parameters.exp_time
-        # self.image_width = default_parameters.osc_range
-        #
-        # # Set parameters from diffraction plan
-        # diffraction_plan = sample_model.diffraction_plan
-        # if diffraction_plan:
-        #     # It is not clear if diffraction_plan is a dict or an object,
-        #     # and if so which kind
-        #     if hasattr(diffraction_plan, "radiationSensitivity"):
-        #         radiation_sensitivity = diffraction_plan.radiationSensitivity
-        #     else:
-        #         radiation_sensitivity = diffraction_plan.get("radiationSensitivity")
-        #
-        #     if radiation_sensitivity:
-        #         self.relative_rad_sensitivity = radiation_sensitivity
-        #
-        #     if hasattr(diffraction_plan, "aimedResolution"):
-        #         resolution = diffraction_plan.aimedResolution
-        #     else:
-        #         resolution = diffraction_plan.get("aimedResolution")
-        #
-        #     if resolution:
-        #         self.aimed_resolution = resolution
 
         # Set paramaters from params dict
         if "name" in params:
@@ -1619,7 +1584,7 @@ class PathTemplate(object):
         return prefix
 
     def get_image_file_name(self, suffix=None):
-        template = "%s_%s_%%" + str(self.precision) + "d.%s"
+        template = "%s_%s_%%0" + str(self.precision) + "d.%s"
 
         if suffix:
             file_name = template % (self.get_prefix(), self.run_number, suffix)
@@ -2305,9 +2270,9 @@ class GphlWorkflow(TaskNode):
         )
 
         self.path_template.num_files = 0
-        self.path_template.precision = "0" + str(
-            HWR.beamline.session["file_info"].get_property("precision", 4)
-        )
+        # self.path_template.precision = "0" + str(
+        #     HWR.beamline.session["file_info"].get_property("precision", 4)
+        # )
 
         self.path_template.directory = os.path.join(
             HWR.beamline.session.get_base_image_directory(), params.get("subdir", "")


### PR DESCRIPTION
This removes duplicates setting of image number ndigits, and refactors to specify the precision as a digit rather than as previously
<precision>'05'</precision>

It seems to work in qt (for a very quick test), but could not be tested in the web version, where it requires the pending PR  mxcube3 #942 