### PR TITLE
Fix Error in keV-A conversion

### DIFF
--- a/mxcubecore/HardwareObjects/QtGraphicsLib.py
+++ b/mxcubecore/HardwareObjects/QtGraphicsLib.py
@@ -1890,7 +1890,7 @@ class GraphicsItemCentringLines(GraphicsItem):
         """
         painter.setPen(self.custom_pen)
         painter.drawLine(
-            self.start_coord[0], 0, self.start_coord[0], self.scene().height()
+            self.start_coord[0], 0, self.start_coord[0], int(self.scene().height())
         )
         painter.drawLine(
             0, self.start_coord[1], self.scene().width(), self.start_coord[1]

--- a/mxcubecore/HardwareObjects/QtGraphicsLib.py
+++ b/mxcubecore/HardwareObjects/QtGraphicsLib.py
@@ -124,8 +124,8 @@ class GraphicsItem(qt_import.QGraphicsItem):
         """Sets start position"""
 
         if position_x is not None and position_y is not None:
-            self.start_coord[0] = position_x
-            self.start_coord[1] = position_y
+            self.start_coord[0] = int(position_x)
+            self.start_coord[1] = int(position_y)
         self.scene().update()
 
     def get_start_position(self):
@@ -144,7 +144,7 @@ class GraphicsItem(qt_import.QGraphicsItem):
         :type position_y: int
         """
         if position_x is not None and position_y is not None:
-            self.end_coord = [position_x, position_y]
+            self.end_coord = [int(position_x), int(position_y)]
         self.scene().update()
 
     def get_display_name(self):

--- a/mxcubecore/configuration/mockup/gphl/session.xml
+++ b/mxcubecore/configuration/mockup/gphl/session.xml
@@ -5,9 +5,9 @@
   <file_info>
     <file_suffix>cbf</file_suffix>
     <precision>5</precision>
-    <base_directory>/home/rhfogh/calc/mxcube_data</base_directory>
+    <base_directory>/alt/rhfogh/calc/mxcube_data</base_directory>
     <raw_data_folder_name>RAW_DATA</raw_data_folder_name>
-    <processed_data_base_directory>/home/rhfogh/calc/mxcube_data</processed_data_base_directory>
+    <processed_data_base_directory>/alt/rhfogh/calc/mxcube_data</processed_data_base_directory>
     <processed_data_folder_name>PROCESSED_DATA</processed_data_folder_name>
     <archive_base_directory>/home/rhfogh/calc/mxcube_data</archive_base_directory>
     <archive_folder>ARCHIVE</archive_folder>

--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -2403,11 +2403,11 @@ class GphlWorkflow(TaskNode):
                     duration, energy, flux_density
                 )
         msg = (
-            "Dose could not be calculated from:\n"
+            "WARNING: Dose could not be calculated from:\n"
             " energy:%s keV, strategy_length:%s deg, exposure_time:%s s, "
             "image_width:%s deg, transmission: %s  flux_density:%s  photons/mm^2"
         )
-        raise ValueError(
+        print(
             msg % (
                 energy,
                 strategy_length,
@@ -2417,6 +2417,7 @@ class GphlWorkflow(TaskNode):
                 flux_density
             )
         )
+        return 0
 
     def recommended_dose_budget(self, resolution=None):
         """Get resolution-dependent dose budget using current configuration

--- a/mxcubecore/utils/conversion.py
+++ b/mxcubecore/utils/conversion.py
@@ -44,7 +44,8 @@ except Exception:
     binary_type = bytes
 
 # Conversion from kEv to A, wavelength = HC_OVER_E/energy
-HC_OVER_E = h * c / e * 10e6
+# NB This is * 10e7 (and NOT * 10e6), because the unit is A, not nm.
+HC_OVER_E = h * c / e * 10e7
 
 
 # Utility functions:


### PR DESCRIPTION
The main part of this PR is a bug fix - the HC_OVER_E conversion constant between A and keV was WRONG  by a factor of 10. It was calculated at h*c*10e6/e, missing the point that this point gives the conversion between *nm* and keV, whereas we want it in A.

I am very surprised that this problem has never been noticed - I can only assume that 1) mxcubecore is not yet heavily used, 2) conversion from A to energy and back again does not show the problem or 3) the conversion factor is often not used. Anyway, if someone could double check that the new value is correct and whether it gives errors somewhere it would be lovely.

The rest of the changes are WIP progress in refactoring teh GPhL user interface.

 