### PR TITLE
Added missing method get_first_and_last_file

### DIFF
--- a/mxcubecore/HardwareObjects/LimaEigerDetector.py
+++ b/mxcubecore/HardwareObjects/LimaEigerDetector.py
@@ -7,6 +7,7 @@ import os
 import math
 import logging
 
+from mxcubecore.model.queue_model_objects import PathTemplate
 from mxcubecore.TaskUtils import task
 from mxcubecore import HardwareRepository as HWR
 from mxcubecore.HardwareObjects.abstract.AbstractDetector import AbstractDetector
@@ -272,9 +273,16 @@ class LimaEigerDetector(AbstractDetector):
 
         return file_name
 
-    def get_first_and_last_file(self, pt):
-        file_name_template = self.get_image_file_name(pt)
+    def get_first_and_last_file(self, pt: PathTemplate):
+        """
+        Get complete path to first and last image
 
+        Args:
+          pt (PathTempalte): Path template parameter
+
+        Returns:
+        (Tuple): Tuple containing first and last image path (first, last)
+        """
         start_num = int(math.ceil(pt.start_num / 100))
         end_num = int(math.ceil((pt.start_num + pt.num_files - 1) / 100))
 

--- a/mxcubecore/HardwareObjects/abstract/AbstractDetector.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractDetector.py
@@ -54,6 +54,7 @@ import ast
 
 from mxcubecore import HardwareRepository as HWR
 from mxcubecore.BaseHardwareObjects import HardwareObject
+from mxcubecore.model.queue_model_objects import PathTemplate
 
 __copyright__ = """ Copyright © 2019 by the MXCuBE collaboration """
 __license__ = "LGPLv3+"
@@ -326,3 +327,18 @@ class AbstractDetector(HardwareObject):
             (float): Detector threshold energy [eV]
         """
         return self._threshold_energy
+
+    def get_first_and_last_file(self, pt: PathTemplate):
+        """
+        Get complete path to first and last image
+
+        Args:
+          pt (PathTempalte): Path template parameter
+
+        Returns:
+        (Tuple): Tuple containing first and last image path (first, last)
+        """
+        start_num = pt.start_num
+        end_num = pt.start_num + pt.num_files - 1
+
+        return (pt.get_image_path() % start_num, pt.get_image_path() % end_num)


### PR DESCRIPTION
Added a method that was missing in the previous PR #760, the method was present for `EigerDetector` but not in the `AbstractDetector` .