### PR TITLE
Linting and minor fixes

### DIFF
--- a/mxcubecore/HardwareObjects/BlissEnergy.py
+++ b/mxcubecore/HardwareObjects/BlissEnergy.py
@@ -119,12 +119,12 @@ class BlissEnergy(AbstractEnergy):
 
             _delta = math.fabs(current_value - value)
             if _delta < 0.001:
-                logging.getLogger("user_level_log").debug(
+                logging.getLogger("user_level_log").info(
                     "Energy: already at %g, not moving", value
                 )
                 return
 
-            logging.getLogger("user_level_log").debug(
+            logging.getLogger("user_level_log").info(
                 "Energy: moving energy to %g", value
             )
 

--- a/mxcubecore/HardwareObjects/EMBLFlexHCD.py
+++ b/mxcubecore/HardwareObjects/EMBLFlexHCD.py
@@ -35,6 +35,8 @@ import pickle
 import logging
 import gevent
 
+from mxcubecore import HardwareRepository as HWR
+
 from mxcubecore.TaskUtils import task
 from mxcubecore.HardwareObjects.abstract.AbstractSampleChanger import (
     SampleChanger,
@@ -585,6 +587,8 @@ class EMBLFlexHCD(SampleChanger):
         return self._set_loaded_sample_and_prepare(loaded_sample, previous_sample)
 
     def _do_unload(self, sample=None):
+        HWR.beamline.diffractometer.set_phase("Transfer")
+
         self._execute_cmd_exporter(
             "unloadSample",
             sample.get_cell_no(),

--- a/mxcubecore/HardwareObjects/EMBLFlexHCD.py
+++ b/mxcubecore/HardwareObjects/EMBLFlexHCD.py
@@ -136,7 +136,7 @@ class Cell(Container):
 
 
 class EMBLFlexHCD(SampleChanger):
-    __TYPE__ = "HCD"
+    __TYPE__ = "Flex Sample Changer"
 
     def __init__(self, *args, **kwargs):
         super(EMBLFlexHCD, self).__init__(self.__TYPE__, True, *args, **kwargs)

--- a/mxcubecore/HardwareObjects/ESRF/ESRFSession.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFSession.py
@@ -32,7 +32,6 @@ class ESRFSession(Session.Session):
         Returns:
            Sub-directory path string
         """
-
         subdir = ""
 
         if isinstance(sample_data, dict):
@@ -42,10 +41,10 @@ class ESRFSession(Session.Session):
             sample_name = sample_data.name
             protein_acronym = sample_data.crystals[0].protein_acronym
 
-        # if protein_acronym:
-        #    subdir = "%s/%s-%s/" % (protein_acronym, protein_acronym, sample_name)
-        # else:
-        subdir = "%s/" % sample_name
+        if protein_acronym:
+            subdir = "%s/%s-%s/" % (protein_acronym, protein_acronym, sample_name)
+        else:
+            subdir = "%s/" % sample_name
 
         return subdir.replace(":", "-")
 

--- a/mxcubecore/HardwareObjects/Energy.py
+++ b/mxcubecore/HardwareObjects/Energy.py
@@ -172,11 +172,11 @@ class Energy(Equipment):
         current_en = self.get_value()
         pos = math.fabs(current_en - energy)
         if pos < 0.001:
-            logging.getLogger("user_level_log").debug(
+            logging.getLogger("user_level_log").info(
                 "Energy: already at %g, not moving", energy
             )
         else:
-            logging.getLogger("user_level_log").debug(
+            logging.getLogger("user_level_log").info(
                 "Energy: moving energy to %g", energy
             )
             if pos > 0.02:

--- a/mxcubecore/HardwareObjects/MachCurrent.py
+++ b/mxcubecore/HardwareObjects/MachCurrent.py
@@ -48,7 +48,7 @@ class MachCurrent(AbstractMachineInfo):
             logging.getLogger("user_level_log").info(self.opmsg)
         self.emit("valueChanged", (mach, opmsg, fillmode, refill))
 
-    def get_current(self):
+    def get_current(self) -> float:
         try:
             value = self.get_channel_object("Current").get_value()
         except Exception as e:
@@ -57,7 +57,7 @@ class MachCurrent(AbstractMachineInfo):
 
         return value
 
-    def get_message(self):
+    def get_message(self) -> str:
         try:
             msg = self.get_channel_object("OperatorMsg").get_value()
         except Exception as e:
@@ -66,7 +66,7 @@ class MachCurrent(AbstractMachineInfo):
 
         return msg
 
-    def get_fill_mode(self):
+    def get_fill_mode(self) -> str:
         try:
             fmode = self.get_channel_object("FillingMode").get_value()
         except Exception as e:

--- a/mxcubecore/HardwareObjects/Microdiff.py
+++ b/mxcubecore/HardwareObjects/Microdiff.py
@@ -75,7 +75,7 @@ class Microdiff(MiniDiff.MiniDiff):
             "DataCollection": 3,
             "Transfer": 4,
         }
-        self.movePhase = self.add_command(
+        self.move_phase = self.add_command(
             {
                 "type": "exporter",
                 "exporter_address": self.exporter_addr,
@@ -419,7 +419,7 @@ class Microdiff(MiniDiff.MiniDiff):
                     # self.close_detector_cover()
                     self.phase_prepare(phase)
 
-                self.movePhase(phase)
+                self.move_phase(phase)
                 if wait:
                     if not timeout:
                         timeout = 40

--- a/mxcubecore/HardwareObjects/Resolution.py
+++ b/mxcubecore/HardwareObjects/Resolution.py
@@ -40,15 +40,6 @@ __license__ = "LGPLv3+"
 class Resolution(AbstractResolution):
     """Resolution as motor"""
 
-    unit = "Å"
-
-    def __init__(self, name):
-        super(Resolution, self).__init__(name)
-
-    def init(self):
-        """Initialisation"""
-        super(Resolution, self).init()
-
     def set_value(self, value, timeout=None):
         """Set the resolution.
         Args:

--- a/mxcubecore/HardwareObjects/XMLRPCServer.py
+++ b/mxcubecore/HardwareObjects/XMLRPCServer.py
@@ -451,7 +451,7 @@ class XMLRPCServer(HardwareObject):
         # Wait a couple of seconds for the files to appear
 
         time.sleep(2)
-        HWR.beamline.diffractometer.wait_ready()
+        HWR.beamline.diffractometer.wait_ready(300)
         tmp_path = HWR.beamline.diffractometer.get_property(
             "custom_snapshot_script_dir", "/tmp"
         )
@@ -579,14 +579,14 @@ class XMLRPCServer(HardwareObject):
         """
         Sets the zoom to a pre-defined level.
         """
-        zoom = HWR.beamline.sample_view.zoom
+        zoom = HWR.beamline.diffractometer.zoomMotor
         zoom.set_value(zoom.value_to_enum(pos))
 
     def get_zoom_level(self):
         """
         Returns the zoom level.
         """
-        zoom = HWR.beamline.sample_view.zoom
+        zoom = HWR.beamline.diffractometer.zoomMotor
         pos = zoom.get_value().value
         return pos
 

--- a/mxcubecore/HardwareObjects/abstract/AbstractMachineInfo.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractMachineInfo.py
@@ -41,37 +41,44 @@ class AbstractMachineInfo(HardwareObject):
         self._mach_info_dict = {}
 
     @abc.abstractmethod
-    def get_current(self):
+    def get_current(self) -> float:
         """Read current.
         Returns:
-            value: Current.
+            Current.
         """
-        return None
+        return 0
 
-    def get_message(self):
-        """Read message.
-        Returns:
-            value: Message.
+    def get_message(self) -> str:
         """
-        return None
-
-    def get_lifetime(self):
-        """Read life time.
         Returns:
-            value: Life time [s].
+            Message.
         """
-        return None
+        return ""
 
-    def get_topup_remaining(self):
-        """Read top up remaining.
-        Returns:
-            value: Top up remaining.
+    def get_lifetime(self) -> float:
         """
-        return None
-
-    def get_mach_info_dict(self):
-        """Read machine info dictionary.
         Returns:
-            (dict): Copy of mach_info_dict.
+            Life time [s].
+        """
+        return 0
+
+    def get_topup_remaining(self) -> float:
+        """
+        Returns:
+            Top up remaining.
+        """
+        return 0
+
+    def get_fill_mode(self) -> str:
+        """
+        Returns:
+            Machine fille mode
+        """
+        return ""
+
+    def get_mach_info_dict(self) -> dict:
+        """
+        Returns:
+            Copy of mach_info_dict.
         """
         return self._mach_info_dict.copy()

--- a/mxcubecore/HardwareObjects/mockup/MDCameraMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/MDCameraMockup.py
@@ -107,7 +107,7 @@ class MDCameraMockup(BaseHardwareObjects.Device):
     def get_stream_size(self):
         return self.get_width(), self.get_height(), 1
 
-    def start_video_stream_process(self, fmt, size, port):
+    def start_video_stream_process(self, size):
         if (
             not self._video_stream_process
             or self._video_stream_process.poll() is not None
@@ -120,9 +120,9 @@ class MDCameraMockup(BaseHardwareObjects.Device):
                     "-hs",
                     "localhost",
                     "-p",
-                    port,
+                    self._port,
                     "-of",
-                    fmt,
+                    self._format,
                     "-q",
                     "4",
                     "-s",
@@ -135,10 +135,9 @@ class MDCameraMockup(BaseHardwareObjects.Device):
 
     def stop_streaming(self):
         if self._video_stream_process:
-            ps = psutil.Process(self._video_stream_process.pid).children() + [
-                self._video_stream_process
-            ]
-
+            ps = [self._video_stream_process] + psutil.Process(
+                self._video_stream_process.pid
+            ).children()
             for p in ps:
                 p.kill()
 
@@ -146,14 +145,15 @@ class MDCameraMockup(BaseHardwareObjects.Device):
 
     def start_streaming(self, _format="MPEG1", size=(0, 0), port="4042"):
         self._format = _format
+        self._port = port
 
         if not size[0]:
             _s = int(self.get_width()), int(self.get_height())
         else:
             _s = size
 
-        self.start_video_stream_process(self._format, _s, port)
+        self.start_video_stream_process(_s)
 
     def restart_streaming(self, size):
         self.stop_streaming()
-        self.start_streaming(self._format, size)
+        self.start_streaming(size)

--- a/mxcubecore/HardwareObjects/mockup/MachineInfoMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/MachineInfoMockup.py
@@ -77,32 +77,34 @@ class MachineInfoMockup(AbstractMachineInfo):
             else:
                 self._message = self.default_message
                 self.attention = False
-            self._current = "%3.2f mA" % (
+
+            self._current = (
                 self.default_current - (3 - self._topup_remaining / 100.0) * 5
             )
+
             values = dict()
             values["current"] = self._current
             values["message"] = self._message
-            values["lifetime"] = "%3.2f hours" % self._lifetime
-            values["topup_remaining"] = "%3.0f secs" % self._topup_remaining
+            values["lifetime"] = self._lifetime
+            values["topup_remaining"] = self._topup_remaining
             values["attention"] = self.attention
             self._mach_info_dict = values
 
             self.emit("machInfoChanged", values)
 
-    def get_current(self):
+    def get_current(self) -> float:
         """Override method."""
         return self._current
 
-    def get_lifetime(self):
+    def get_lifetime(self) -> float:
         """Override method."""
         return self._lifetime
 
-    def get_topup_remaining(self):
+    def get_topup_remaining(self) -> float:
         """Override method."""
         return self._topup_remaining
 
-    def get_message(self):
+    def get_message(self) -> str:
         """Override method."""
         return self._message
 

--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -1567,15 +1567,7 @@ class PathTemplate(object):
         return prefix
 
     def get_image_file_name(self, suffix=None):
-        template = "%s_%s_%%0" + str(self.precision) + "d.%s"
-
-        if suffix:
-            file_name = template % (self.get_prefix(), self.run_number, suffix)
-        else:
-            file_name = template % (self.get_prefix(), self.run_number, self.suffix)
-        if self.compression:
-            file_name = "%s.gz" % file_name
-
+        file_name = HWR.beamline.detector.get_image_file_name(self)
         return file_name
 
     def get_image_path(self):


### PR DESCRIPTION
While testing I discovered a few things that needed to be fixed.

- Delegating the retrieval of the image filename to the detector `HardwareObject` previously in the `PathTemplate`. However the later knows nothing about HDF5 file structure such as number of images per file or how the images are stored, so its more appropriate to have this method  on the detector.

- Some linting and camel to snake case issues fixed 

- Added function `adxv_notify` on AbstractMultiCollect that can be used for following images
 