### PR TITLE
Allow open/close methods to have timeout

### DIFF
--- a/mxcubecore/HardwareObjects/abstract/AbstractShutter.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractShutter.py
@@ -18,14 +18,15 @@
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 
 """ AbstractShutter class - interface for shutter type devices.
-Defines BaseValueEnum and ShutterStates Enums.
+Define open/close methods and is_open property.
+Overload BaseValueEnum
 """
 
 import abc
 from enum import Enum, unique
 from mxcubecore.HardwareObjects.abstract.AbstractNState import AbstractNState
 
-__copyright__ = """ Copyright 2016-2022 by the MXCuBE collaboration """
+__copyright__ = """ Copyright 2016-2023 by the MXCuBE collaboration """
 __license__ = "LGPLv3+"
 
 
@@ -42,20 +43,29 @@ class AbstractShutter(AbstractNState):
     """Abstract base class for shutter type objects."""
 
     __metaclass__ = abc.ABCMeta
-    VALUES = BaseValueEnum
 
     @property
     def is_open(self):
-        """Check the state of the shutter.
+        """Check if the shutter is open.
         Returns:
             (bool): True if open, False otherwise.
         """
         return self.get_value() == self.VALUES.OPEN
 
-    def open(self):
-        """Open the shutter."""
-        self.set_value(self.VALUES.OPEN)
+    def open(self, timeout=None):
+        """Open the shutter.
+        Args:
+            timeout(float): optional - timeout [s],
+                            If timeout == 0: return at once and do not wait
+                            if timeout is None: wait forever.
+        """
+        self.set_value(self.VALUES.OPEN, timeout=timeout)
 
-    def close(self):
-        """Close the shutter"""
-        self.set_value(self.VALUES.CLOSED)
+    def close(self, timeout=None):
+        """Close the shutter.
+        Args:
+            timeout(float): optional - timeout [s],
+                            If timeout == 0: return at once and do not wait
+                            if timeout is None: wait forever.
+        """
+        self.set_value(self.VALUES.CLOSED, timeout=timeout)

--- a/mxcubecore/HardwareObjects/mockup/ShutterMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/ShutterMockup.py
@@ -19,6 +19,7 @@
 
 """ Mockup shutter implementation"""
 
+from warnings import warn
 from enum import Enum, unique
 from mxcubecore.HardwareObjects.abstract.AbstractShutter import AbstractShutter
 from mxcubecore.BaseHardwareObjects import HardwareObjectState
@@ -36,7 +37,7 @@ class ShutterStates(Enum):
     AUTOMATIC = HardwareObjectState.READY, 10
 
 
-class ShutterMockup(ActuatorMockup, AbstractShutter):
+class ShutterMockup(AbstractShutter, ActuatorMockup):
     """
     ShutterMockup for simulating a simple open/close shutter.
     """
@@ -45,18 +46,11 @@ class ShutterMockup(ActuatorMockup, AbstractShutter):
 
     def init(self):
         """Initialisation"""
-        super(ShutterMockup, self).init()
+        super().init()
         self.update_value(self.VALUES.CLOSED)
         self.update_state(self.STATES.READY)
 
-    def is_open(self):
-        return self.get_value() is self.VALUES.OPEN
-
     def is_closed(self):
+        """This is deprecated"""
+        warn("is_closed is deprecated. Use is_open instead", DeprecationWarning)
         return self.get_value() is self.VALUES.CLOSED
-
-    def open(self):
-        self.set_value(self.VALUES.OPEN, timeout=None)
-
-    def close(self):
-        self.set_value(self.VALUES.CLOSED, timeout=None)

--- a/mxcubecore/configuration/mockup/safety-shutter-mockup.xml
+++ b/mxcubecore/configuration/mockup/safety-shutter-mockup.xml
@@ -1,5 +1,5 @@
-<device class = "ShutterMockup">
+<object class = "ShutterMockup">
     <actuator_name>safety_shutter</actuator_name>
     <user_name>SafetyShutter</user_name>
     <values>{"OPEN": "OPEN", "CLOSED": "CLOSED"}</values>
-</device>
+</object>

--- a/test/pytest/test_shutter.py
+++ b/test/pytest/test_shutter.py
@@ -42,31 +42,16 @@ class TestShutter(TestAbstractNStateBase.TestAbstractNStateBase):
         ), "Shutter hardware objects is None (not initialized)"
 
         # The methods are defined with abc.abstractmethod which will raise
-        # an exception if the method is not defined. So there is no need to test for
-        # the presence of each method
+        # an exception if the method is not defined. So there is no need to
+        # test for the presence of each method
+        print(f"state is {test_object.get_state()}")
         assert test_object.get_state() == HardwareObjectState.READY
 
     def test_shutter_open_close(self, test_object):
-        test_object.open()
-        assert test_object.is_open() is True
-        assert test_object.is_closed() is False
+        test_object.open(timeout=None)
+        assert test_object.is_open is True
 
         assert test_object.get_state() == HardwareObjectState.READY
 
-        test_object.close()
-        assert test_object.is_open() is False
-        assert test_object.is_closed() is True
-
-    """
-    def test_shutter_is_valid(self, test_object):
-        test_object.close()
-        assert test_object.is_valid()
-
-        try:
-            test_object.current_state = None
-        except Exception:
-            assert True
-
-        test_object.open()
-        assert test_object.is_valid()
-    """
+        test_object.close(timeout=None)
+        assert test_object.is_open is False


### PR DESCRIPTION
Allow the AbstractShutter to use the  AbstractNState class timeout mechanism.
Cleanup the test and the Mockup class