### PR TITLE
Fixed bug in recent commit

### DIFF
--- a/mxcubecore/HardwareObjects/mockup/ShutterMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/ShutterMockup.py
@@ -19,7 +19,6 @@
 
 """ Mockup shutter implementation"""
 
-from warnings import warn
 from enum import Enum, unique
 from mxcubecore.HardwareObjects.abstract.AbstractShutter import AbstractShutter
 from mxcubecore.BaseHardwareObjects import HardwareObjectState

--- a/mxcubecore/HardwareObjects/mockup/ShutterMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/ShutterMockup.py
@@ -63,7 +63,3 @@ class ShutterMockup(AbstractShutter, ActuatorMockup):
         )
         self.VALUES = Enum("ValueEnum", values_dict)
 
-    def _set_value(self, value):
-        """Simulate setting different values"""
-        self._nominal_value = value
-        self.update_state(self.STATES.READY)

--- a/mxcubecore/configuration/mockup/gphl/gphl-setup.yml
+++ b/mxcubecore/configuration/mockup/gphl/gphl-setup.yml
@@ -4,7 +4,8 @@ _initialise_class:
 
 directory_locations:
     # Directory locations. Can also be used with ${} syntax in this file
-    GPHL_INSTALLATION: /alt/rhfogh/Software/GPhL/gphl_release
+#    GPHL_INSTALLATION: /alt/rhfogh/Software/GPhL/gphl_release
+    GPHL_INSTALLATION: /alt/rhfogh/Software/GPhL/nightly_20230724/Files_workflow_TRUNK_alpha-bdg
 #    GPHL_INSTALLATION: /alt/rhfogh/Software/GPhL/nightly_20230602/Files_workflow_BETA_beta-academic
 
 
@@ -86,8 +87,8 @@ software_properties:
     # co.gphl.wf.recen.bdg_licence_dir/fill/me/in
 
     # OPTIONAL. simcal *binary* For Mock collection emulation only. Not used by ASTRA workflow
-#    co.gphl.wf.simcal.bin: /alt/rhfogh/Software/GPhL/nightly_20230602/Files_workflow_TRUNK_alpha-bdg/autoPROC/bin/linux64/simcal
-#    co.gphl.wf.simcal.bdg_licence_dir: /alt/rhfogh/Software/GPhL/nightly_20230602/Files_workflow_TRUNK_alpha-bdg
-    co.gphl.wf.simcal.bin: /alt/rhfogh/Software/GPhL/gphl_release/autoPROC/bin/linux64/simcal
-    co.gphl.wf.simcal.bdg_licence_dir: /alt/rhfogh/Software/GPhL/gphl_release
+    co.gphl.wf.simcal.bin: /alt/rhfogh/Software/GPhL/nightly_20230724/Files_workflow_TRUNK_alpha-bdg/autoPROC/bin/linux64/simcal
+    co.gphl.wf.simcal.bdg_licence_dir: /alt/rhfogh/Software/GPhL/nightly_20230724/Files_workflow_TRUNK_alpha-bdg
+#    co.gphl.wf.simcal.bin: /alt/rhfogh/Software/GPhL/gphl_release/autoPROC/bin/linux64/simcal
+#    co.gphl.wf.simcal.bdg_licence_dir: /alt/rhfogh/Software/GPhL/gphl_release
 #    co.gphl.wf.simcal.bin: "{GPHL_INSTALLATION}/autoPROC/bin/linux64/simcal"/alt/rhfogh/Software/GPhL/gphl_release


### PR DESCRIPTION
The 'Open' button did not work in the Qt mock version; removing ShutterMockup._set_value restored previous function