### PR TITLE
Added missing .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,18 @@
 default_language_version:
-  python: python3.7
+  python: python3.8
 repos:
   - repo: https://github.com/python-poetry/poetry
     rev: 1.5.0
     hooks:
       - id: poetry-check
-        language_version: python3.7
-      - id: poetry-lock
-        language_version: python3.7
+        language_version: python3.8
+#      - id: poetry-lock
+#        language_version: python3.8
   - repo: https://github.com/myint/autoflake
     rev: v1.6.0
     hooks:
       - id: autoflake
         name: Autoflake
-        exclude: (utils/pyispyb_client/|deprecated/|mxcubecore/HardwareObjects/(ALBA|ASLS|DESY|EMBL|ESRF|LNLS|MAXIV|SOLEIL|ANSTO|Gphl|Arinax))
         args:
           - --expand-star-imports
           - --ignore-init-module-imports
@@ -25,14 +24,12 @@ repos:
     hooks:
     - id: black
       name: Black
-      language_version: python3.7
-      exclude: (utils/pyispyb_client/|deprecated/|mxcubecore/HardwareObjects/(ALBA|ASLS|DESY|EMBL|ESRF|LNLS|MAXIV|SOLEIL|ANSTO|Gphl|Arinax))
+      language_version: python3.8
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
-      # - id: trailing-whitespace
-      # - id: end-of-file-fixer
-      #   exclude: (deprecated/|mxcubecore/HardwareObjects/(ALBA|ASLS|DESY|EMBL|ESRF|LNLS|MAXIV|SOLEIL|ANSTO|Gphl|Arinax))
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
       - id: check-case-conflict
       - id: check-merge-conflict
         # exclude files where underlines are not distinguishable from merge conflicts


### PR DESCRIPTION
This is a basic `.pre-commit-config.yaml`, the configuration in `pyproject.toml` was not sufficient to run `pre-commit`. I guess its been broken somewhere along the road since we have not tested it for some time.

We can now start to use and build on this.

I've disabled flake8 and some other checks for the moment the first because there are simply quite alot to deal with at the moment but we can eventually enable it.

To install and run this locally so that is automatically executed on commit:
```
# Install the tool
pip install pre-commit

# Install the hook in your .git folder
pre-commit install

#run it manual once
pre-commit run
```
There are some more instructions on how to run/setup this locally here: 
   
    https://pre-commit.com/#install

This builds on what @oldfielj-ansto (thanks by the way :) ) started, anyone feel free to elaborate :)