### PR TITLE
tango attribute polling: fix issue with numpy array attributes

### DIFF
--- a/mxcubecore/Command/Tango.py
+++ b/mxcubecore/Command/Tango.py
@@ -325,12 +325,14 @@ class TangoChannel(ChannelObject):
 
     def update(self, value=Poller.NotInitializedValue):
 
-        if value == Poller.NotInitializedValue:
+        # start with checking if we have a numpy array, as comparing
+        # numpy.ndarray to Poller.NotInitializedValue raises a ValueError exception
+        if isinstance(value, numpy.ndarray):
+            value = value.tolist()
+        elif value == Poller.NotInitializedValue:
             value = self.get_value()
         elif isinstance(value, tuple):
             value = list(value)
-        elif isinstance(value, numpy.ndarray):
-            value = value.tolist()
 
         self.value = value
         self.emit("update", value)

--- a/mxcubecore/Command/Tango.py
+++ b/mxcubecore/Command/Tango.py
@@ -144,9 +144,6 @@ class TangoChannel(ChannelObject):
     _tangoEventsQueue = queue.Queue()
     _eventReceivers = {}
 
-    #if gevent_version < [1,3,0]:
-        #_tangoEventsProcessingTimer = gevent.get_hub().loop.async()
-    #else:
     _tangoEventsProcessingTimer = gevent.get_hub().loop.async_()
 
     # start Tango events processing timer
@@ -285,7 +282,6 @@ class TangoChannel(ChannelObject):
             value = self.raw_device.read_attribute(
                 self.attribute_name, PyTango.DeviceAttribute.ExtractAs.String
             ).value
-            # value = self.device.read_attribute_as_str(self.attribute_name).value
         else:
             value = self.raw_device.read_attribute(self.attribute_name).value
 
@@ -355,10 +351,6 @@ class TangoChannel(ChannelObject):
 
     def set_value(self, new_value):
         self.device.write_attribute(self.attribute_name, new_value)
-        # attr = PyTango.AttributeProxy(self.device_name + "/" + self.attribute_name)
-        # a = attr.read()
-        # a.value = newValue
-        # attr.write(a)
 
     def is_connected(self):
         return self.device is not None

--- a/mxcubecore/CommandContainer.py
+++ b/mxcubecore/CommandContainer.py
@@ -276,7 +276,7 @@ class ChannelObject:
                 if cmdobj is not None:
                     cmdobj(value)
 
-    def get_value(self, force: bool = False) -> None:
+    def get_value(self, force: bool = False):
         """Get channel value.
 
         Args:


### PR DESCRIPTION
In TangoChannel.update(), we'll get an exception if attribute value is of numpy.ndarray. 

Value of numpy.ndarray type can't be compared to Poller.NotInitializedValue, Comparison raised following exception:
    
      ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
    
Check _first_ if value is ndarray, and only if it's not, compare it with Poller.NotInitializedValue.
https://github.com/elmjag/mxcubecore/blob/tango_numpy/mxcubecore/Command/Tango.py#L325

Also, some minor clean-up.