### PR TITLE
Fix login issues in ISPyB clients (and mockups)

### DIFF
--- a/mxcubecore/HardwareObjects/ISPyBClient.py
+++ b/mxcubecore/HardwareObjects/ISPyBClient.py
@@ -40,6 +40,9 @@ if sys.version_info > (3, 0):
 logging.getLogger("suds").setLevel(logging.INFO)
 
 
+LOGIN_TYPE_FALLBACK = "proposal"
+
+
 # Production web-services:    http://160.103.210.1:8080/ispyb-ejb3/ispybWS/
 # Test web-services:          http://160.103.210.4:8080/ispyb-ejb3/ispybWS/
 
@@ -167,7 +170,6 @@ class ISPyBClient(HardwareObject):
         self._disabled = False
 
         self.authServerType = None
-        self.loginType = None
         self.loginTranslate = None
 
         self.ws_root = None
@@ -194,7 +196,6 @@ class ISPyBClient(HardwareObject):
             if self.ldapConnection is None:
                 logging.getLogger("HWR").debug("LDAP Server is not available")
 
-        self.loginType = self.get_property("loginType") or "proposal"
         self.loginTranslate = self.get_property("loginTranslate") or True
         self.beamline_name = HWR.beamline.session.beamline_name
 
@@ -326,7 +327,15 @@ class ISPyBClient(HardwareObject):
                 except AttributeError:
                     pass
 
+    @property
+    def loginType(self):
+        return self.get_property("loginType", LOGIN_TYPE_FALLBACK)
+
     def get_login_type(self):
+        warnings.warn(
+            "Deprecated method `get_login_type`. Use `loginType` property instead.",
+            DeprecationWarning,
+        )
         return self.loginType
 
     def translate(self, code, what):

--- a/mxcubecore/HardwareObjects/ISPyBRestClient.py
+++ b/mxcubecore/HardwareObjects/ISPyBRestClient.py
@@ -56,9 +56,6 @@ class ISPyBRestClient(HardwareObject):
 
         self.__update_rest_token()
 
-    def get_login_type(self):
-        return "user"
-
     def __update_rest_token(self):
         """
         Updates REST token if necessary by default token expires in 3h so we

--- a/mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
@@ -20,6 +20,9 @@ except Exception:
 # to simulate no session scheduled, use "nosession" for password
 
 
+LOGIN_TYPE_FALLBACK = "proposal"
+
+
 class ISPyBClientMockup(HardwareObject):
     """
     Web-service client for ISPyB.
@@ -30,7 +33,6 @@ class ISPyBClientMockup(HardwareObject):
         self.__translations = {}
         self.__disabled = False
         self.__test_proposal = None
-        self.loginType = None
         self.base_result_url = None
         self.lims_rest = None
         self.login_ok = True
@@ -47,7 +49,6 @@ class ISPyBClientMockup(HardwareObject):
             if self.ldapConnection is None:
                 logging.getLogger("HWR").debug("LDAP Server is not available")
 
-        self.loginType = self.get_property("loginType") or "proposal"
         self.beamline_name = HWR.beamline.session.beamline_name
 
         try:
@@ -87,8 +88,15 @@ class ISPyBClientMockup(HardwareObject):
             "Laboratory": {"laboratoryId": 1, "name": "TEST eh1"},
         }
 
+    @property
+    def loginType(self):
+        return self.get_property("loginType", LOGIN_TYPE_FALLBACK)
+
     def get_login_type(self):
-        self.loginType = self.get_property("loginType") or "proposal"
+        warnings.warn(
+            "Deprecated method `get_login_type`. Use `loginType` property instead.",
+            DeprecationWarning,
+        )
         return self.loginType
 
     def login(self, loginID, psd, ldap_connection=None, create_session=True):

--- a/mxcubecore/HardwareObjects/mockup/ISPyBRestClientMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/ISPyBRestClientMockup.py
@@ -105,6 +105,8 @@ class ISPyBRestClientMockup(HardwareObject):
         :returns: None
 
         """
+        if password == "wrong":
+            raise Exception("Wrong credentials")
         self.__rest_token = "#MOCKTOKEN123"
         self.__rest_token_timestamp = datetime.now()
         self.__rest_username = user


### PR DESCRIPTION
For test purposes `ISPyBRestClientMockup` should fail authentication when the password is `wrong`.
Also there were multiple ways to access the "login type" value, that were not always in sync.
The one true way should be to go through `get_property("loginType")`.

GitHub: relates to https://github.com/mxcube/mxcubeweb/issues/1045
GitHub: relates to https://github.com/mxcube/mxcubeweb/pull/1049