### PR TITLE
Moved logic from mxcube-web to mxcubcore

### DIFF
--- a/mxcubecore/HardwareObjects/BeamlineActions.py
+++ b/mxcubecore/HardwareObjects/BeamlineActions.py
@@ -1,5 +1,4 @@
 import sys
-import typing
 import ast
 import importlib
 import operator
@@ -8,12 +7,11 @@ from mxcubecore.BaseHardwareObjects import HardwareObject
 from mxcubecore.TaskUtils import task
 from mxcubecore.CommandContainer import CommandObject
 from mxcubecore.utils.conversion import camel_to_snake
+from mxcubecore import HardwareRepository as HWR
 
 from mxcubecore.CommandContainer import (
     CommandObject,
     TWO_STATE_COMMAND_T,
-    PROCEDURE_COMMAND_T,
-    ARGUMENT_TYPE_JSON_SCHEMA,
     ARGUMENT_TYPE_LIST,
 )
 
@@ -142,22 +140,25 @@ class HWObjActuatorCommand(CommandObject):
         return value
 
 
-class CommandDescription(typing.NamedTuple):
-    name: str
-    task: typing.Any
-    result: typing.Any
-    messages: list
-
-
 class AnnotatedCommand(CommandObject):
     def __init__(self, beamline_action_ho, name, cmd_name):
         self._beamline_action_ho = beamline_action_ho
         self._name = name
         self._cmd_name = cmd_name
         self._value = ""
+        self._last_result = None
+        self._messages = []
+        self.task = None
 
     def get_value(self):
         return self._value
+
+    def set_last_result(self, result):
+        self._last_result = result
+
+    @property
+    def cmd_name(self):
+        return self._cmd_name
 
 
 class BeamlineActions(HardwareObject):
@@ -166,8 +167,7 @@ class BeamlineActions(HardwareObject):
         self._annotated_commands = []
         self._annotated_command_dict = {}
         self._command_list = []
-        self._current_command = CommandDescription("", None, None, [])
-        self._command_log = []
+        self._current_command = None
 
     def _get_command_object_class(self, path_str):
         parts = path_str.split(".")
@@ -237,49 +237,91 @@ class BeamlineActions(HardwareObject):
     def get_annotated_commands(self):
         return list(self._annotated_command_dict.values())
 
+    def _execute_annotated_command(self, name, args):
+        cmd = getattr(self, name, None)
+        self._annotated_command_dict[name].emit("commandBeginWaitReply", name)
+
+        _model = self.pydantic_model[name](**args)
+        _all_child_models = []
+
+        for _key in _model.dict().keys():
+            _all_child_models.append(getattr(_model, _key))
+
+        _t = gevent.spawn(cmd, *_all_child_models)
+        _t.link(self._command_done)
+
+        self._current_command = cmd.__self__
+        self._current_command.task = _t
+
     def get_commands(self):
         return self._command_list
+
+    def _execute_command(self, name, args):
+        try:
+            cmds = self.get_commands()
+        except Exception:
+            cmds = []
+
+        for cmd in cmds:
+            if cmd.name() == name:
+                try:
+                    cmd.emit("commandBeginWaitReply", name)
+                    logging.getLogger("user_level_log").info(
+                        "Starting %s(%s)",
+                        cmd.name(),
+                        ", ".join(map(str, args)),
+                    )
+                    cmd(*args)
+                except Exception as ex:
+                    err = str(sys.exc_info()[1])
+                    raise Exception(str(err)) from ex
 
     def execute_command(self, name, args):
         cmd = getattr(self, name, None)
 
         if cmd:
-            self._annotated_command_dict[name].emit("commandBeginWaitReply", name)
-            _t = gevent.spawn(cmd, **args)
-            _t.link(self._command_done)
-
-            self._current_command = CommandDescription(name, _t, None, [])
-            self._command_log.append(self._current_command)
+            self._execute_annotated_command(name, args)
+        else:
+            self._execute_command(name, args)
 
     def _command_done(self, greenlet):
-        cmd_obj = self._annotated_command_dict[self._current_command.name]
+        cmd_obj = self._annotated_command_dict[self._current_command.cmd_name]
         result = ""
 
         try:
-            try:
-                result = greenlet.get()
-            except Exception:
-                logging.getLogger("HWR").exception(
-                    "%s: execution failed", self._current_command.name
-                )
-                cmd_obj.emit("commandFailed", (self._current_command.name,))
+            result = greenlet.get()
+        except Exception:
+            logging.getLogger("HWR").exception(
+                "%s: execution failed", self._current_command.cmd_name
+            )
+            cmd_obj.emit("commandFailed", (self._current_command.cmd_name,))
+        else:
+            self._current_command.set_last_result(result)
+            if isinstance(result, gevent.GreenletExit):
+                # command aborted
+                cmd_obj.emit("commandFailed", (self._current_command.cmd_name,))
+                result = ""
             else:
-                if isinstance(result, gevent.GreenletExit):
-                    # command aborted
-                    cmd_obj.emit("commandFailed", (self._current_command.name,))
-                else:
-                    self._current_command.result = result
-                    cmd_obj.emit(
-                        "commandReplyArrived", (self._current_command.name, result)
-                    )
+                cmd_obj.emit(
+                    "commandReplyArrived", (self._current_command.cmd_name, result)
+                )
         finally:
             cmd_obj.emit(
                 "commandReady",
-                (self._current_command.name, self._current_command.result),
+                (self._current_command.cmd_name, result),
             )
 
-            self._current_command = CommandDescription("", None, None, [])
+            self._current_command = None
 
     def abort_command(self, name):
-        cmd_obj = self._annotated_command_dict[self._current_command.name]
-        self._current_command.task.kill()
+        if (
+            self._current_command
+            and self._current_command.cmd_name in self._annotated_command_dict
+        ):
+            self._annotated_command_dict[self._current_command.cmd_name]
+            self._current_command.task.kill()
+        else:
+            for cmd in self.get_commands():
+                if cmd.name() == name:
+                    cmd.abort()
+                    break

--- a/mxcubecore/HardwareObjects/mockup/BeamlineActionsMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/BeamlineActionsMockup.py
@@ -1,7 +1,6 @@
-import typing
-import enum
+from typing_extensions import Literal
 
-
+from pydantic import BaseModel, Field
 from mxcubecore.TaskUtils import task
 from mxcubecore.CommandContainer import CommandObject
 from mxcubecore.HardwareObjects.BeamlineActions import (
@@ -15,12 +14,12 @@ import gevent
 import logging
 
 
-class EnumArg(str, enum.Enum):
-    centring = "Centring"
-    data_collection = "DataCollection"
-    beam_location = "BeamLocation"
-    transfer = "Transfer"
-    unknown = "Unknown"
+class SimpleFloat(BaseModel):
+    exp_time: float = Field(100e-6, gt=0, lt=10, description="(s)")
+
+
+class StringLiteral(BaseModel):
+    phase: Literal["Centring", "DataCollection", "BeamLocation", "Transfer"] = Field(1)
 
 
 class SimulatedAction:
@@ -43,20 +42,15 @@ class LongSimulatedAction:
         return args
 
 
-class Arg(typing.NamedTuple):
-    name: str
-    unit: str
-    alias: str
-
-
 class Anneal2(AnnotatedCommand):
     def __init__(self, *args):
         super().__init__(*args)
 
-    # @argument(ArgMeta("time", "s", "time"))
-    def anneal2(self, time: float) -> None:
-        print("ANNEAL")
-        gevent.sleep(float(time))
+    def anneal2(self, data: SimpleFloat) -> None:
+        logging.getLogger("user_level_log").info(
+            f"Annealing for {data.exp_time} seconds"
+        )
+        gevent.sleep(data.exp_time)
 
 
 class QuickRealign2(AnnotatedCommand):
@@ -64,15 +58,17 @@ class QuickRealign2(AnnotatedCommand):
         super().__init__(*args)
 
     def quick_realign2(self) -> None:
-        print("REALIGN")
+        for i in range(10):
+            gevent.sleep(1)
+            logging.getLogger("user_level_log").info("%d, sleeping for 1 second", i + 1)
 
 
 class ComboTest2(AnnotatedCommand):
     def __init__(self, *args):
         super().__init__(*args)
 
-    def combo_test2(self, combo_arg: EnumArg) -> None:
-        print("COMBO")
+    def combo_test2(self, data: StringLiteral) -> None:
+        logging.getLogger("user_level_log").info(f"Selected {data.phase}")
 
 
 class BeamlineActionsMockup(BeamlineActions):


### PR DESCRIPTION
Moved logic that was previously in `mxcubeweb` down to mxcubecore and "unified" the interface for calling `execute` and `abort` between "annotated" and "standard" `BeamlineActions`.

Improved the AnnotatedBamlineAction mockups