### PR TITLE
add documentation URL to pyproject specifications

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
 readme = "README.md"
 homepage = "http://github.com/mxcube/mxcubecore"
 repository = "http://github.com/mxcube/mxcubecore"
-documentation = ""
+documentation = "https://mxcubecore.readthedocs.io/"
 keywords = ["mxcube", "mxcube3", "mxcubecore"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
It seems that poetry started to insist that 'documentation' field must contain a valid URL. Poetry will refuse to install package with an empty 'documentation' field.

Let's point to our generated docs at readthedocs.io site.