### PR TITLE
CI: drop lint step from tests action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,11 +27,6 @@ jobs:
           python -m pip install poetry --user
           python -m poetry install
 
-      - name: Linting and code quality checks
-        run: |
-          # Disabled for now
-          # python -m poetry run pre-commit run --all-files
-
       - name: Test with pytest
         run: |
           python -m poetry run pytest --no-cov


### PR DESCRIPTION
Remove the (disabled) step for running pre-commit checks from the 'Pytest' action.

Running pre-commit checks have been moved to it's own 'Linting & Code Quality' action, that is the pre-commit.yml file.