### PR TITLE
sardana motors: handle limit 0.0 correctly

### DIFF
--- a/mxcubecore/Command/Sardana.py
+++ b/mxcubecore/Command/Sardana.py
@@ -429,9 +429,11 @@ class SardanaChannel(ChannelObject, SardanaObject):
                     self.info.maxval = float(ranges[-1])
             elif int(taurus.Release.version[0]) > 3:  # taurus 4 and beyond
                 minval, maxval = self.attribute.getRange()
-                if minval:
+                if minval is not None:
                     self.info.minval = minval.magnitude
+                if maxval is not None:
                     self.info.maxval = maxval.magnitude
+
         except Exception:
             import traceback
 


### PR DESCRIPTION
The taurus Quantity(0.0) value evaluates to false. Thus when motor's limit is set to exactly 0.0 the code:

    if minval:
       <save limit>

will not run the if-body. Check explicitly for None values of minval and maxval variables to avoid this problem.