### PR TITLE
link to developer docs from README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ Installation of the mxubecore module is commonly done as a depdency of either [M
 Standalone installation of the moudle can be done via poetry `poetry install` or for development purpouses (creating a symlink to the current folder) by using pip: `pip install -e .`. Don't forget the trailing "." (period).
 
 mxcubecore depends on python-ldap that in turn depends on the openldap system library. It can be installed through conda by installing the openldap depdency: `conda install openldap` or on systems using apt-get: `sudo apt-get install -y libldap2-dev libsasl2-dev slapd ldap-utils tox lcov valgrind`. See [python-ldap](https://www.python-ldap.org/en/python-ldap-3.4.3/installing.html#debian) for more information.
+
+See [Developer documentation](https://mxcubecore.readthedocs.io/) for more information on working with mxcubecore.


### PR DESCRIPTION
Link to the generated developer docs from the readme file. This way these docs will get some visibility. Right now I suspect most are not aware of the dev docs existance.