### PR TITLE
Introduced AbstractAuthenticator

### DIFF
--- a/mxcubecore/HardwareObjects/ISPyBClient.py
+++ b/mxcubecore/HardwareObjects/ISPyBClient.py
@@ -670,7 +670,8 @@ class ISPyBClient(HardwareObject):
         # Authentication
         if self.authServerType == "ldap":
             logging.getLogger("HWR").debug("LDAP login")
-            ok, msg = self.ldap_login(login_name, psd, ldap_connection)
+            ok = self.ldap_login(login_name, psd, ldap_connection)
+            msg = loginID
             logging.getLogger("HWR").debug("searching for user %s" % login_name)
         elif self.authServerType == "ispyb":
             logging.getLogger("HWR").debug("ISPyB login")
@@ -749,7 +750,7 @@ class ISPyBClient(HardwareObject):
         if ldap_connection is None:
             ldap_connection = self.ldapConnection
 
-        return ldap_connection.login(login_name, psd)
+        return ldap_connection.authenticate(login_name, psd)
 
     def get_todays_session(self, prop, create_session=True):
         logging.getLogger("HWR").debug("getting proposal for todays session")

--- a/mxcubecore/HardwareObjects/ISPyBClient.py
+++ b/mxcubecore/HardwareObjects/ISPyBClient.py
@@ -5,6 +5,7 @@ import time
 import itertools
 import os
 import traceback
+import warnings
 from pprint import pformat
 from collections import namedtuple
 from datetime import datetime
@@ -739,11 +740,16 @@ class ISPyBClient(HardwareObject):
         }
 
     def ldap_login(self, login_name, psd, ldap_connection):
+        warnings.warn(
+            ("Using Authenticatior from ISPyBClient is deprecated,"
+            "use Authenticator to authenticate spereatly and then login to ISPyB"),
+            DeprecationWarning
+        )
+
         if ldap_connection is None:
             ldap_connection = self.ldapConnection
 
-        ok, msg = ldap_connection.login(login_name, psd)
-        return ok, msg
+        return ldap_connection.login(login_name, psd)
 
     def get_todays_session(self, prop, create_session=True):
         logging.getLogger("HWR").debug("getting proposal for todays session")


### PR DESCRIPTION
**Greetings from the MXCuBE meeting :)**

Introduced `AbstractAuthenticator` and made necessary updates to `LdapLogin`

This also means that we should move the `authenticate` call from `ISPyBclient` to the the authenticate/login
logic. 

All `*LdapLogin` classes have been updated so that they care now call `*Authenticator` 

