### PR TITLE
Simplify dependencies

### DIFF
--- a/conda-environment-dev.yml
+++ b/conda-environment-dev.yml
@@ -9,11 +9,3 @@ dependencies:
   # Dev
   - pip
   - poetry
-  # Format, lint
-  - black
-  - flake8
-  # Test
-  - coverage
-  - pytest
-  - pytest-cov
-  - pytest-mock

--- a/mxcubecore/__version__.py
+++ b/mxcubecore/__version__.py
@@ -1,15 +1,7 @@
-try:
-    # Python3.8+ standard library
-    from importlib.metadata import (  # pyright: ignore[reportMissingImports]
-        PackageNotFoundError,
-        version,
-    )
-except ImportError:
-    # Python3.7 module backport
-    from importlib_metadata import (
-        PackageNotFoundError,
-        version,  # pyright: ignore[reportMissingImports]
-    )
+from importlib.metadata import (  # pyright: ignore[reportMissingImports]
+    PackageNotFoundError,
+    version,
+)
 
 __version__: str
 try:

--- a/poetry.lock
+++ b/poetry.lock
@@ -758,22 +758,22 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "6.6.0"
+version = "7.0.1"
 description = "Read metadata from Python packages"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-6.6.0-py3-none-any.whl", hash = "sha256:43dd286a2cd8995d5eaef7fee2066340423b818ed3fd70adf0bad5f1fac53fed"},
-    {file = "importlib_metadata-6.6.0.tar.gz", hash = "sha256:92501cdf9cc66ebd3e612f1b4f0c0765dfa42f0fa38ffb319b6bd84dd675d705"},
+    {file = "importlib_metadata-7.0.1-py3-none-any.whl", hash = "sha256:4805911c3a4ec7c3966410053e9ec6a1fecd629117df5adee56dfc9432a1081e"},
+    {file = "importlib_metadata-7.0.1.tar.gz", hash = "sha256:f238736bb06590ae52ac1fab06a3a9ef1d8dce2b7a35b5ab329371d6c8f5d2cc"},
 ]
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
-testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
 
 [[package]]
 name = "importlib-resources"
@@ -2547,4 +2547,4 @@ tango = ["PyTango"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"
-content-hash = "991fd99809aea19370db000a1e2179e4afb01ca08470272488d7befef4d1efcd"
+content-hash = "32153909850af238b4a54263fc6be10c05e73fa25c3129cb264468100bce86f9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,17 +32,16 @@ greenlet = "^1.1.3"
 jsonpickle = "^2.2.0"
 jsonschema = "^4.17.1"
 lxml = "^4.9.1"
-matplotlib = [ { version = "3.5.3", python = "3.7" }, { version = "^3.6.2", python = ">=3.8" } ]
-numpy = [ { version = "1.21.6", python = "3.7" }, { version = "^1.23.5", python = ">=3.8" } ]
+matplotlib = "^3.6.2"
+numpy = "^1.23.5"
 Pillow = "^9.3.0"
 pydantic = "^1.10.2"
 PyDispatcher = "^2.0.6"
 "ruamel.yaml" = "^0.17.21"
-scipy = [ { version = "1.7.3", python = "3.7" }, { version = "^1.9.3", python = ">=3.8" } ]
+scipy = "^1.9.3"
 suds-py3 = "1.4.5.0"
 psutil = "^5.9.4"
 gipc = "^1.4.0"
-importlib_metadata = { version = ">=4.12.0", python = "3.7" }
 py4j = "0.10.9.7"
 f90nml = "1.4.3"
 lucid3 = "^3.0.0"
@@ -52,7 +51,7 @@ requests = "^2.31.0"
 colorama = "^0.4.6"
 
 [tool.poetry.dev-dependencies]
-pylint = [ { version = "==2.13.9", python = "<=3.7.1" }, { version = "^2.15.6", python = ">=3.8" } ]
+pylint = "^2.15.6"
 pre-commit = "^2.20.0"
 pytest = "^7.2.0"
 pytest-cov = "^4.0.0"
@@ -248,5 +247,5 @@ force-exclude = '''
 '''
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "setuptools>=45", "setuptools_scm[toml]>=6.2"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Remove formatting and linting dependencies from the conda environment since they are in pre-commit already.

Remove test dependencies from the conda environment since they are in the Poetry dev dependencies already.

Remove code related to `importlib_metadata` on Python "<3.8".

Remove dependency version constraints for Python "<3.8" since we only support Python ">=3.8,<3.11".

Remove setuptools and setuptools-scm from build dependencies since they are superfluous.