### PR TITLE
Update Python version for the `pre-commit` hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,11 @@
 default_language_version:
-  python: python3.8
+  python: python3.10
 repos:
   - repo: https://github.com/python-poetry/poetry
     rev: 1.5.0
     hooks:
       - id: poetry-check
-        language_version: python3.8
 #      - id: poetry-lock
-#        language_version: python3.8
   - repo: https://github.com/myint/autoflake
     rev: v1.6.0
     hooks:
@@ -24,7 +22,6 @@ repos:
     hooks:
     - id: black
       name: Black
-      language_version: python3.8
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:


### PR DESCRIPTION
Since the Python range is `>=3.8,<3.11` in `conda-environment.yml` (and in the Poetry config in `pyproject.toml` as well), the version installed by default will be Python 3.10.

It makes sense to use the same version in the pre-commit hooks.

GitHub: fix https://github.com/mxcube/mxcubecore/issues/836