### PR TITLE
Clean `conda-environment-dev.yml`

### DIFF
--- a/conda-environment-dev.yml
+++ b/conda-environment-dev.yml
@@ -2,10 +2,21 @@ name: mxcubecore
 channels:
   - conda-forge
 dependencies:
+
+  ### Runtime dependencies
+
   - python >=3.8,<3.11
-  # Run-time
-  - openldap
-  - python-ldap=3.4.0
-  # Dev
-  - pip
+
+  # We install `python-ldap` from conda because it is "hard" to install.
+  # On PyPI it is not available as *wheel*, only as *sdist* which requires to be built
+  # with compilation steps that require a compiler and some header files.
+  # Installing with conda is much "easier".
+  #
+  # IMPORTANT:
+  # Always make sure that `python-ldap` here is pinned to the same version
+  # as in the Poetry lockfile `poetry.lock` (not the other way around).
+  - python-ldap=3.4.3
+
+  ### Development dependencies
+
   - poetry


### PR DESCRIPTION
Fix the pinned version for `python-ldap`.

Add some explanatory comments.

Remove `pip` since it is already a dependency of `python`.

Remove `openldap` since it is already a dependency of `python-ldap`.