### PR TITLE
Bug fix and Py4J version handling

### DIFF
--- a/mxcubecore/HardwareObjects/Beamline.py
+++ b/mxcubecore/HardwareObjects/Beamline.py
@@ -798,17 +798,24 @@ class Beamline(ConfiguredObject):
             setattr(acq_parameters, tag, val)
 
         motor_positions = self.diffractometer.get_positions()
-        osc_start = (
-            None
-            if not params["osc_start"]
-            else motor_positions.get("phi", params["osc_start"])
-        )
-        acq_parameters.osc_start = osc_start
-        kappa = motor_positions.get("kappa", False)
-        kappa = kappa if kappa else None
-        acq_parameters.kappa = round(float(kappa), 2) if kappa else None
-        kappa_phi = motor_positions.get("kappa_phi", False)
-        acq_parameters.kappa_phi = round(float(kappa_phi), 2) if kappa_phi else None
+        osc_start = motor_positions.get("phi")
+        if osc_start is None:
+            acq_parameters.osc_start = params.get("osc_start")
+        else:
+            acq_parameters.osc_start = osc_start
+
+        kappa = motor_positions.get("kappa")
+        if kappa is None:
+            acq_parameters.kappa = None
+        else:
+            acq_parameters.kappa = round(float(kappa), 2)
+
+        kappa_phi = motor_positions.get("kappa_phi")
+        if kappa_phi is None:
+            acq_parameters.kappa_phi = None
+        else:
+            acq_parameters.kappa_phi = round(float(kappa_phi), 2)
+
         try:
             acq_parameters.resolution = self.resolution.get_value()
         except Exception:

--- a/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
+++ b/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
@@ -2265,7 +2265,7 @@ class GphlWorkflow(HardwareObjectYaml):
     Switch to maximum zoom before continuing"""
 
                 schema = {
-                    "title": "GΦL Tramslational calibration",
+                    "title": "GΦL Translational calibration",
                     "type": "object",
                     "properties": {},
                 }

--- a/mxcubecore/HardwareObjects/Gphl/GphlWorkflowConnection.py
+++ b/mxcubecore/HardwareObjects/Gphl/GphlWorkflowConnection.py
@@ -32,10 +32,10 @@ import time
 import sys
 
 from py4j import clientserver, java_gateway
+from py4j.protocol import Py4JJavaError
 
 from mxcubecore.utils import conversion
 from mxcubecore.HardwareObjects.Gphl import GphlMessages
-from mxcubecore.model import crystal_symmetry
 
 from mxcubecore.BaseHardwareObjects import HardwareObjectYaml
 from mxcubecore import HardwareRepository as HWR
@@ -87,6 +87,7 @@ class GphlWorkflowConnection(HardwareObjectYaml):
         super().__init__(name)
         # Py4J gateway to external workflow program
         self._gateway = None
+        self.msg_class_imported = False
 
         # ID for current workflow calculation
         self._enactment_id = None
@@ -220,6 +221,8 @@ class GphlWorkflowConnection(HardwareObjectYaml):
             # NB, for now workflow is started as the connection is made,
             # so we are never in state 'ON'/STANDBY
             raise RuntimeError("Workflow is already running, cannot be started")
+
+        self.msg_class_imported = False
 
         # Cannot be done in init, where the api.sessions link is not yet ready
         self.software_paths["GPHL_WDIR"] = os.path.join(
@@ -489,6 +492,19 @@ class GphlWorkflowConnection(HardwareObjectYaml):
         NB Callled freom external java) workflow"""
         if self.get_state() is self.STATES.OFF:
             return None
+
+        if not self.msg_class_imported:
+            try:
+                msg_class = self._gateway.jvm.py4j.reflection.ReflectionUtil.classForName("co.gphl.sdcp.astra.service.py4j.Py4jMessage")
+                java_gateway.java_import(self._gateway.jvm, "co.gphl.sdcp.astra.service.py4j.Py4jMessage")
+            except Py4JJavaError:
+                msg_class = self._gateway.jvm.py4j.reflection.ReflectionUtil.classForName("co.gphl.sdcp.py4j.Py4jMessage")
+                java_gateway.java_import(self._gateway.jvm, "co.gphl.sdcp.py4j.Py4jMessage")
+
+            logging.getLogger("HWR").debug(
+                "GΦL workflow Py4jMessage class is: %s" % msg_class
+            )
+        self.msg_class_imported = True
 
         xx0 = self._decode_py4j_message(py4j_message)
         message_type = xx0.message_type
@@ -945,7 +961,7 @@ class GphlWorkflowConnection(HardwareObjectYaml):
         py4j_payload = self._payload_to_java(payload)
 
         try:
-            response = self._gateway.jvm.co.gphl.sdcp.py4j.Py4jMessage(
+            response = self._gateway.jvm.Py4jMessage(
                 py4j_payload, enactment_id, correlation_id
             )
         except:


### PR DESCRIPTION
1) Fixed apparent bug in setting default values for osc_start, kappa, phi; configured values of 0.0 were set to None
This should solve the 'red box for osc_start' bug in the qt UI.

2) Changed code to work with both old and new py4j versions