### PR TITLE
DOCS: starting with the Command Package and its modules

### DIFF
--- a/mxcubecore/Command/Epics.py
+++ b/mxcubecore/Command/Epics.py
@@ -37,6 +37,8 @@ __license__ = "LGPLv3+"
 
 
 class EpicsCommand(CommandObject):
+    """ Epics Command """
+    
     def __init__(self, name, pv_name, username=None, args=None, **kwargs):
         CommandObject.__init__(self, name, username, **kwargs)
 
@@ -154,7 +156,7 @@ class EpicsCommand(CommandObject):
                 pass
 
     def get_pv_value(self):
-        # wrapper function to pv.get() in order to supply additional named parameter
+        """wrapper function to pv.get() in order to supply additional named parameter"""
         return self.pv.get(as_string=self.read_as_str)
 
     def poll(
@@ -201,7 +203,7 @@ class EpicsCommand(CommandObject):
 
 
 class EpicsChannel(ChannelObject):
-    """Emulation of a 'Epics channel' = an Epics command + polling"""
+    """Emulates an *Epics channel* with an EpicsCommand +polling"""
 
     def __init__(self, name, command, username=None, polling=None, args=None, **kwargs):
         ChannelObject.__init__(self, name, username, **kwargs)

--- a/mxcubecore/Command/Epics.py
+++ b/mxcubecore/Command/Epics.py
@@ -37,7 +37,7 @@ __license__ = "LGPLv3+"
 
 
 class EpicsCommand(CommandObject):
-    """ Epics Command """
+    """Epics Command"""
 
     def __init__(self, name, pv_name, username=None, args=None, **kwargs):
         CommandObject.__init__(self, name, username, **kwargs)

--- a/mxcubecore/Command/Epics.py
+++ b/mxcubecore/Command/Epics.py
@@ -38,7 +38,7 @@ __license__ = "LGPLv3+"
 
 class EpicsCommand(CommandObject):
     """ Epics Command """
-    
+
     def __init__(self, name, pv_name, username=None, args=None, **kwargs):
         CommandObject.__init__(self, name, username, **kwargs)
 

--- a/mxcubecore/Command/Sardana.py
+++ b/mxcubecore/Command/Sardana.py
@@ -252,8 +252,8 @@ class SardanaMacro(CommandObject, SardanaObject, ChannelObject):
         return
 
     def update(self, event):
-        """update the macro command status: ``commandCanExecute``, ``commandReady``, ``commandNotReady``, ``commandReplyArrive``, ``commandReplyAbort`` and ``commandFailed`` """
-        
+        """update the macro command status: ``commandCanExecute``, ``commandReady``, ``commandNotReady``, ``commandReplyArrive``, ``commandReplyAbort`` and ``commandFailed``"""
+
         data = event.event[2]
 
         try:
@@ -389,13 +389,13 @@ class SardanaCommand(CommandObject):
 
 
 class SardanaChannel(ChannelObject, SardanaObject):
-    """ Creates a Sardana Channel """
+    """Creates a Sardana Channel"""
 
     def __init__(
         self, name, attribute_name, username=None, uribase=None, polling=None, **kwargs
     ):
         super(SardanaChannel, self).__init__(name, username, **kwargs)
-        
+
         class ChannelInfo(object):
             def __init__(self):
                 super(ChannelInfo, self).__init__()

--- a/mxcubecore/Command/Sardana.py
+++ b/mxcubecore/Command/Sardana.py
@@ -18,6 +18,9 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 
+
+""" Sardana Control System """
+
 from __future__ import absolute_import
 
 import logging
@@ -101,6 +104,8 @@ class AttributeEvent:
 
 
 class SardanaObject(object):
+    """Sardana Object"""
+    
     _eventsQueue = queue.Queue()
     _eventReceivers = {}
 
@@ -121,6 +126,7 @@ class SardanaObject(object):
 
 
 class SardanaMacro(CommandObject, SardanaObject, ChannelObject):
+    """Sardana macro"""
 
     macroStatusAttr = None
     INIT, STARTED, RUNNING, DONE = range(4)
@@ -319,6 +325,8 @@ class SardanaMacro(CommandObject, SardanaObject, ChannelObject):
 
 
 class SardanaCommand(CommandObject):
+    """SardanaCommand"""
+    
     def __init__(self, name, command, taurusname=None, username=None, **kwargs):
         CommandObject.__init__(self, name, username, **kwargs)
 

--- a/mxcubecore/Command/Sardana.py
+++ b/mxcubecore/Command/Sardana.py
@@ -19,7 +19,7 @@
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 
 
-""" Sardana Control System """
+"""Sardana Control System  """
 
 from __future__ import absolute_import
 
@@ -47,13 +47,15 @@ from mxcubecore.CommandContainer import (
     ConnectionError,
 )
 
+# This is a site specific module where some of the dependencies might not be capture by the ``pyproject.toml`` during installation
+
 try:
     from PyTango import DevFailed, ConnectionFailed
     import PyTango
 except Exception:
     logging.getLogger("HWR").warning("Pytango is not available in this computer.")
 
-# from mxcubecore.TaskUtils import task
+#
 
 try:
     from sardana.taurus.core.tango.sardana import registerExtensions

--- a/mxcubecore/Command/Sardana.py
+++ b/mxcubecore/Command/Sardana.py
@@ -51,7 +51,7 @@ try:
     from PyTango import DevFailed, ConnectionFailed
     import PyTango
 except Exception:
-    logging.getLogger("HWR").warning("Pytango is not available in this computer.")    
+    logging.getLogger("HWR").warning("Pytango is not available in this computer.")
 
 # from mxcubecore.TaskUtils import task
 
@@ -108,7 +108,7 @@ class AttributeEvent:
 
 class SardanaObject(object):
     """Sardana Object"""
-    
+
     _eventsQueue = queue.Queue()
     _eventReceivers = {}
 
@@ -331,7 +331,7 @@ class SardanaMacro(CommandObject, SardanaObject, ChannelObject):
 
 class SardanaCommand(CommandObject):
     """SardanaCommand"""
-    
+
     def __init__(self, name, command, taurusname=None, username=None, **kwargs):
         CommandObject.__init__(self, name, username, **kwargs)
 
@@ -390,7 +390,7 @@ class SardanaCommand(CommandObject):
 
 class SardanaChannel(ChannelObject, SardanaObject):
     """ Creates a Sardana Channel """
-    
+
     def __init__(
         self, name, attribute_name, username=None, uribase=None, polling=None, **kwargs
     ):

--- a/mxcubecore/Command/Sardana.py
+++ b/mxcubecore/Command/Sardana.py
@@ -47,8 +47,11 @@ from mxcubecore.CommandContainer import (
     ConnectionError,
 )
 
-from PyTango import DevFailed, ConnectionFailed
-import PyTango
+try:
+    from PyTango import DevFailed, ConnectionFailed
+    import PyTango
+except Exception:
+    logging.getLogger("HWR").warning("Pytango is not available in this computer.")    
 
 # from mxcubecore.TaskUtils import task
 
@@ -249,6 +252,8 @@ class SardanaMacro(CommandObject, SardanaObject, ChannelObject):
         return
 
     def update(self, event):
+        """update the macro command status: ``commandCanExecute``, ``commandReady``, ``commandNotReady``, ``commandReplyArrive``, ``commandReplyAbort`` and ``commandFailed`` """
+        
         data = event.event[2]
 
         try:
@@ -384,12 +389,13 @@ class SardanaCommand(CommandObject):
 
 
 class SardanaChannel(ChannelObject, SardanaObject):
+    """ Creates a Sardana Channel """
+    
     def __init__(
         self, name, attribute_name, username=None, uribase=None, polling=None, **kwargs
     ):
-
         super(SardanaChannel, self).__init__(name, username, **kwargs)
-
+        
         class ChannelInfo(object):
             def __init__(self):
                 super(ChannelInfo, self).__init__()

--- a/mxcubecore/Command/__init__.py
+++ b/mxcubecore/Command/__init__.py
@@ -1,40 +1,37 @@
 """Command package.
 
-The Command package is the place to put command launchers
-and channel readers/writers modules.
+The Command package is the place to put Command launchers
+and Channel readers/writers modules.
 
-The modules should be organised by control software, i.e.
-in the 'Spec' module you will find the SpecCommand and
-SpecChannel classes.
+The modules are organised by Control System Software used at different facility or specific to the hardware targeted.
 
 Command launchers and channels should derive from the
 CObject class of the HardwareRepository.CommandContainer module.
 They should emit the following Qt signals :
-    - connected, when connected to the control software
-    - disconnected, when disconnected from control software and implement the
-      is_connected() method.
-
+    - ``connected``, when connected to the control software
+    - ``disconnected``, when disconnected from control software and implement the
+      ``is_connected()`` method.
 Every command launcher class in the module should emit
-the following Qt signals :
-    - commandBeginWaitReply, when the command has been sent
+the following signals :
+    - ``commandBeginWaitReply``, when the command has been sent
       and we are waiting for the reply. The only argument
       is the command 'user' name. Useful for setting up a
       message to the user. *SHOULD NOT BLOCK EXECUTION*
-    - commandReplyArrived, when the reply for the command
+    - ``commandReplyArrived``, when the reply for the command
       is arrived. The arguments are: reply value and command
       'user' name.
-    - commandFailed, when the command failed to execute.
+    - ``commandFailed``, when the command failed to execute.
 The arguments are: ``error message`` and command 'user' name.
-    - commandAborted, when the command has been aborted.
+    - ``commandAborted``, when the command has been aborted.
 The arguments are: command 'user' name.
 
-Every command launcher should be a callable object ; the
-arguments provided are those for the remote command to
+Every command launcher should be a callable object ;
+the arguments provided are those for the remote command to
 be executed.
 
 A Channel object should emit the following signals :
-    - 'update', when the value of the channel changes
+    - ``update``, when the value of the channel changes
 
-A channel object should have a 'get_value' method at least,
-and an optional 'set_value'
+A channel object should have a ``get_value`` method at least,
+and an optional ``set_value``
 """

--- a/mxcubecore/Command/__init__.py
+++ b/mxcubecore/Command/__init__.py
@@ -3,7 +3,7 @@
 The Command package is the place to put Command launchers
 and Channel readers/writers modules.
 
-The modules are organised by Control System Software used at different facilities 
+The modules are organised by Control System Software used at different facilities
 or specific to the hardware targeted.
 Not all the facilities or even different beamlines from a facility have the same dependencies installed.
 **One should modify the** ``pyproject.toml`` **to address their needs.**

--- a/mxcubecore/Command/__init__.py
+++ b/mxcubecore/Command/__init__.py
@@ -1,4 +1,4 @@
-"""Command package
+"""Command package.
 
 The Command package is the place to put command launchers
 and channel readers/writers modules.
@@ -10,22 +10,22 @@ SpecChannel classes.
 Command launchers and channels should derive from the
 CObject class of the HardwareRepository.CommandContainer module.
 They should emit the following Qt signals :
-- connected, when connected to the control software
-- disconnected, when disconnected from control software
-and implement the is_connected() method.
+    - connected, when connected to the control software
+    - disconnected, when disconnected from control software and implement the
+      is_connected() method.
 
 Every command launcher class in the module should emit
 the following Qt signals :
-- commandBeginWaitReply, when the command has been sent
-and we are waiting for the reply. The only argument
-is the command 'user' name. Useful for setting up a
-message to the user. *SHOULD NOT BLOCK EXECUTION*
-- commandReplyArrived, when the reply for the command
-is arrived. The arguments are: reply value and command
-'user' name.
-- commandFailed, when the command failed to execute.
-The arguments are: error message and command 'user' name.
-- commandAborted, when the command has been aborted.
+    - commandBeginWaitReply, when the command has been sent
+      and we are waiting for the reply. The only argument
+      is the command 'user' name. Useful for setting up a
+      message to the user. *SHOULD NOT BLOCK EXECUTION*
+    - commandReplyArrived, when the reply for the command
+      is arrived. The arguments are: reply value and command
+      'user' name.
+    - commandFailed, when the command failed to execute.
+The arguments are: ``error message`` and command 'user' name.
+    - commandAborted, when the command has been aborted.
 The arguments are: command 'user' name.
 
 Every command launcher should be a callable object ; the
@@ -33,7 +33,7 @@ arguments provided are those for the remote command to
 be executed.
 
 A Channel object should emit the following signals :
-- 'update', when the value of the channel changes
+    - 'update', when the value of the channel changes
 
 A channel object should have a 'get_value' method at least,
 and an optional 'set_value'

--- a/mxcubecore/Command/__init__.py
+++ b/mxcubecore/Command/__init__.py
@@ -16,13 +16,13 @@ They should both implement the ``is_connected()`` method.
 
     - Command launcher class in the module should emit the following signals :
         - ``commandBeginWaitReply``, when the command has been sent and we are waiting for the reply.
-     
+
         - ``commandReplyArrived``, when the reply for the commandis arrived.
 
         - ``commandFailed``, when the command failed to execute.
 
         - ``commandAborted``, when the command has been aborted.
- 
+
 Every Command launcher should be a callable object ;
 the arguments provided are those for the remote command to
 be executed.

--- a/mxcubecore/Command/__init__.py
+++ b/mxcubecore/Command/__init__.py
@@ -3,35 +3,32 @@
 The Command package is the place to put Command launchers
 and Channel readers/writers modules.
 
-The modules are organised by Control System Software used at different facility or specific to the hardware targeted.
+The modules are organised by Control System Software used at different facilities 
+or specific to the hardware targeted.
+Not all the facilities or even different beamlines from a facility have the same dependencies installed.
+**One should modify the** ``pyproject.toml`` **to address their needs.**
 
-Command launchers and channels should derive from the
-CObject class of the HardwareRepository.CommandContainer module.
-They should emit the following Qt signals :
+CommandObject class and ChannelObject class derive from the mxcubecore.CommandContainer module.
+They should both emit the following signals :
     - ``connected``, when connected to the control software
-    - ``disconnected``, when disconnected from control software and implement the
-      ``is_connected()`` method.
-Every command launcher class in the module should emit
-the following signals :
-    - ``commandBeginWaitReply``, when the command has been sent
-      and we are waiting for the reply. The only argument
-      is the command 'user' name. Useful for setting up a
-      message to the user. *SHOULD NOT BLOCK EXECUTION*
-    - ``commandReplyArrived``, when the reply for the command
-      is arrived. The arguments are: reply value and command
-      'user' name.
-    - ``commandFailed``, when the command failed to execute.
-The arguments are: ``error message`` and command 'user' name.
-    - ``commandAborted``, when the command has been aborted.
-The arguments are: command 'user' name.
+    - ``disconnected``, when disconnected from control software
+They should both implement the ``is_connected()`` method.
 
-Every command launcher should be a callable object ;
+    - Command launcher class in the module should emit the following signals :
+        - ``commandBeginWaitReply``, when the command has been sent and we are waiting for the reply.
+     
+        - ``commandReplyArrived``, when the reply for the commandis arrived.
+
+        - ``commandFailed``, when the command failed to execute.
+
+        - ``commandAborted``, when the command has been aborted.
+ 
+Every Command launcher should be a callable object ;
 the arguments provided are those for the remote command to
 be executed.
 
-A Channel object should emit the following signals :
-    - ``update``, when the value of the channel changes
-
-A channel object should have a ``get_value`` method at least,
-and an optional ``set_value``
+    - A Channel object should:
+        - have a ``get_value`` method
+        - have a ``set_value`` method (optional)
+        - emit an ``update`` signal when the value of the channel changes
 """


### PR DESCRIPTION
Some failure during import prevented some of the modules to be rendered in the docs. WIP since I have not looks through every module. To address the issue just added a try/except around the import.

Not sure if all the methods in the classes need to have docstring. It is misleading to only have some documentation for the get_value() and is_connected() (inherited?)