### PR TITLE
Workflow, queue_model_objects - Fixing imports, making sure we can import queue_model_objects standalone

### DIFF
--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -29,6 +29,12 @@ import logging
 
 from mxcubecore.model import queue_model_enumerables
 
+try:
+    from mxcubecore.model import crystal_symmetry
+    import ruamel.yaml as yaml
+except Exception:
+    logging.getLogger("HWR").warning("Cannot import dependenices needed for GPHL workflows - GPhL workflows might not work")
+
 # This module is used as a self contained entity by the BES
 # workflows, so we need to make sure that this module can be
 # imported eventhough HardwareRepository is not avilable.


### PR DESCRIPTION
It was decided long ago that the queue_model_objects should be importable as it is and not contain or contain as little logic as possible, and contain classes only carrying data. We have deviated from the later but the module still needs to be importable without the rest of mxcubecore or non standard library dependencies.