### PR TITLE
Resolution - Added keyword argument `wavelength` to `get_limits` 

### DIFF
--- a/mxcubecore/HardwareObjects/Resolution.py
+++ b/mxcubecore/HardwareObjects/Resolution.py
@@ -47,7 +47,7 @@ class Resolution(AbstractResolution):
             timeout(float): optional - timeout [s],
                              if timeout is None: wait forever (default).
         """
-        # The precision depoends on the difference between the current
+        # The precision depends on the difference between the current
         # resolution and the target value - the smaller the difference,
         # the better the precision.
         # We move twice to get the closet possible to the requested resolution.

--- a/mxcubecore/HardwareObjects/abstract/AbstractResolution.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractResolution.py
@@ -84,11 +84,37 @@ class AbstractResolution(AbstractMotor):
 
     def get_limits(self):
         """Return resolution low and high limits.
+
+        Args:
+            wavelength: Returns the limits for given wavelength if
+                        passed, current wavelength is otherwised used
+
         Returns:
             (tuple): two floats tuple (low limit, high limit).
         """
         _low, _high = self._hwr_detector.distance.get_limits()
-        return (self.distance_to_resolution(_low), self.distance_to_resolution(_high))
+
+        return (
+            self.distance_to_resolution(_low),
+            self.distance_to_resolution(_high),
+        )
+
+    def get_limits_for_wavelength(self, wavelength: float):
+        """Return resolution low and high limits.
+
+        Args:
+            wavelength: Returns the limits for given wavelength if
+                        passed, current wavelength is otherwised used
+
+        Returns:
+            (tuple): two floats tuple (low limit, high limit).
+        """
+        _low, _high = self._hwr_detector.distance.get_limits()
+
+        return (
+            self.distance_to_resolution(_low, wavelength=wavelength),
+            self.distance_to_resolution(_high, wavelength=wavelength),
+        )
 
     def set_limits(self, limits):
         """Resolution limits are not settable.


### PR DESCRIPTION
Added keyword argument wavelength to get_limits to be able to retrieve the limits for an arbitrary wavelength.