### PR TITLE
FlexHCD - Don't change to transfer phase in unload

### DIFF
--- a/mxcubecore/HardwareObjects/EMBLFlexHCD.py
+++ b/mxcubecore/HardwareObjects/EMBLFlexHCD.py
@@ -587,8 +587,6 @@ class EMBLFlexHCD(SampleChanger):
         return self._set_loaded_sample_and_prepare(loaded_sample, previous_sample)
 
     def _do_unload(self, sample=None):
-        HWR.beamline.diffractometer.set_phase("Transfer")
-
         self._execute_cmd_exporter(
             "unloadSample",
             sample.get_cell_no(),

--- a/mxcubecore/HardwareObjects/FlexHCDMaintenance.py
+++ b/mxcubecore/HardwareObjects/FlexHCDMaintenance.py
@@ -1,6 +1,7 @@
 """
 FLEX HCD maintenance mockup.
 """
+
 from mxcubecore.BaseHardwareObjects import Equipment
 import ast
 
@@ -91,6 +92,7 @@ class FlexHCDMaintenance(Equipment):
         :rtype: None
         """
         self._sc.change_gripper(gripper=args)
+        self.emit("gripperChanged")
 
     def _do_reset_sample_number(self):
         """


### PR DESCRIPTION
 - Don't change to transfer phase in unload (to be done earlier by prepare unload in control system)
 - Emitting gripper changed