### PR TITLE
MPEG Video - made restarting of video stream more robust

### DIFF
--- a/mxcubecore/HardwareObjects/TangoLimaMpegVideo.py
+++ b/mxcubecore/HardwareObjects/TangoLimaMpegVideo.py
@@ -78,7 +78,7 @@ class TangoLimaMpegVideo(TangoLimaVideo):
                     "-hs",
                     "localhost",
                     "-p",
-                    port,
+                    str(port),
                     "-q",
                     str(self._quality),
                     "-s",

--- a/mxcubecore/HardwareObjects/mockup/MDCameraMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/MDCameraMockup.py
@@ -120,7 +120,7 @@ class MDCameraMockup(BaseHardwareObjects.Device):
                     "-hs",
                     "localhost",
                     "-p",
-                    self._port,
+                    str(self._port),
                     "-of",
                     self._format,
                     "-q",


### PR DESCRIPTION
Made restarting of video stream more robust. 

WIP for now as the option `-tu` changed to `-uri` this is a change that will break the video stream until `mxcube-video-streamer` and `mxcubeweb` is updated. 