### PR TITLE
ISPyB mock: drop ldap server code

### DIFF
--- a/mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
@@ -43,13 +43,6 @@ class ISPyBClientMockup(HardwareObject):
         Init method declared by HardwareObject.
         """
         self.lims_rest = self.get_object_by_role("lims_rest")
-        self.authServerType = self.get_property("authServerType") or "ldap"
-        if self.authServerType == "ldap":
-            # Initialize ldap
-            self.ldap_connection = self.get_object_by_role("ldapServer")
-            if self.ldap_connection is None:
-                logging.getLogger("HWR").debug("LDAP Server is not available")
-
         self.beamline_name = HWR.beamline.session.beamline_name
 
         try:


### PR DESCRIPTION
Remove the code that 'deals' with authServerType and ldapServer ISPyBClientMockup properties.

The LDAP mode is not really used in the code. The object does not change behaviour when authServerType is changed. Let's drop LDAP bits, as it creates unnecessary complication when using MxCube with mock hwobjs.