### PR TITLE
 to address the issue #894. Most of the fix is just adding a new line…

### DIFF
--- a/mxcubecore/HardwareObjects/BlissActuator.py
+++ b/mxcubecore/HardwareObjects/BlissActuator.py
@@ -1,12 +1,17 @@
 """
 Use bliss to set different actuators in/out.
-If private_state not specified, True will be send to set in and False for out.
-Example xml file:
-<device class="BlissActuator">
+
+If private_state not specified, ``True`` will be send to set in and ``False`` for out.
+
+Example of a configuration via xml file::
+
+  <device class="BlissActuator">
   <username>Detector Cover</username>
   <object href="/bliss" role="controller"/>
-</device>
+  </device>
+
 """
+
 import logging
 from warnings import warn
 

--- a/mxcubecore/HardwareObjects/BlissEnergy.py
+++ b/mxcubecore/HardwareObjects/BlissEnergy.py
@@ -17,23 +17,27 @@
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 """
 Energy and Wavelength with bliss.
-Example xml file:
-  - for tunable wavelength beamline:
-<object class="Energy">
-  <object href="/energy" role="energy_motor"/>
-  <object href="/bliss" role="bliss"/>
-</object>
-The energy should have methods get_value, get_limits, get_state and move.
-If used, the controller should have method moveEnergy.
 
-  - for fixed wavelength beamline:
-<object class="Energy">
-  <read_only>True</read_only>
-  <energy>12.8123</energy>
-  or
-  <object href="/energy" role="energy_motor"/>
-The energy should have methods get_value and get_state
-</object>
+Example xml file for tunable wavelength beamline::
+
+    <object class="Energy">
+    <object href="/energy" role="energy_motor"/>
+    <object href="/bliss" role="bliss"/>
+    </object>
+
+The energy should have methods ``get_value``, ``get_limits``, ``get_state`` and ``move``.
+If used, the controller should have the ``moveEnergy`` method.
+
+Example xml file for fixed wavelength beamline::
+
+    <object class="Energy">
+    <read_only>True</read_only>
+    <energy>12.8123</energy> or
+    <object href="/energy" role="energy_motor"/>
+    </object>
+
+The energy should have ``get_value`` and ``get_state`` methods
+
 """
 import logging
 import math
@@ -71,6 +75,7 @@ class BlissEnergy(AbstractEnergy):
 
     def get_value(self):
         """Read the energy.
+
         Returns:
             (float): Energy [keV]
         """
@@ -80,6 +85,7 @@ class BlissEnergy(AbstractEnergy):
 
     def get_limits(self):
         """Return energy low and high limits.
+
         Returns:
             (tuple): two floats tuple (low limit, high limit) [keV].
         """
@@ -92,7 +98,8 @@ class BlissEnergy(AbstractEnergy):
         self._energy_motor.stop()
 
     def _set_value(self, value):
-        """Execute the sequence to move to an energy
+        """Execute the sequence to move to an energy.
+
         Args:
             value (float): target energy
         """
@@ -102,7 +109,8 @@ class BlissEnergy(AbstractEnergy):
             self._energy_motor.set_value(value)
 
     def set_value(self, value, timeout=0):
-        """Move energy to absolute position. Wait the move to finish.
+        """Move energy to absolute position and wait ``move`` to finish.
+
         Args:
             value (float): target value.
             timeout (float): optional - timeout [s],

--- a/mxcubecore/HardwareObjects/BlissNState.py
+++ b/mxcubecore/HardwareObjects/BlissNState.py
@@ -19,14 +19,16 @@
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 
 """
-bliss implementation of AbstartNState
-Example xml file:
-<device class="BlissNState">
-  <username>Detector Cover</username>
-  <actuator_name>detcover</>
-  <object href="/bliss" role="controller"/>
-  <values>{"IN": "IN", "OUT": "OUT"}</values>
-</device>
+bliss implementation of AbstractNState.
+
+Example of a configuartion xml file::
+
+    <device class="BlissNState">
+    <username>Detector Cover</username>
+    <actuator_name>detcover</>
+    <object href="/bliss" role="controller"/>
+    <values>{"IN": "IN", "OUT": "OUT"}</values>
+    </device>
 """
 from enum import Enum
 from mxcubecore.HardwareObjects.abstract.AbstractMotor import MotorStates
@@ -40,7 +42,7 @@ __license__ = "LGPLv3+"
 
 
 class BlissNState(AbstractNState):
-    """bliss implementation of AbstartNState"""
+    """bliss implementation of AbstractNState"""
 
     SPECIFIC_STATES = MotorStates
 
@@ -79,9 +81,10 @@ class BlissNState(AbstractNState):
         self.update_state(self.STATES.READY)
 
     def get_value(self):
-        """Get the device value
+        """Get the device value.
+
         Returns:
-            (Enum): Enum member, corresponding to the value or UNKNOWN.
+            (Enum): Enum member, corresponding to the value or ``UNKNOWN``.
         """
         if self.device_type == "motor":
             _val = self._bliss_obj.position
@@ -100,6 +103,7 @@ class BlissNState(AbstractNState):
 
     def _set_value(self, value):
         """Set device to value.
+
         Args:
             value (str or enum): target value
         """
@@ -125,6 +129,7 @@ class BlissNState(AbstractNState):
 
     def get_state(self):
         """Get the device state.
+
         Returns:
             (enum 'HardwareObjectState'): Device state.
         """
@@ -153,7 +158,8 @@ class BlissNState(AbstractNState):
         return self.update_state(state)
 
     def initialise_values(self):
-        """Get the predefined valies. Create the VALUES Enum
+        """Get the predefined values and create the ``VALUES Enum``.
+
         Returns:
             (Enum): "ValueEnum" with predefined values.
         """

--- a/mxcubecore/HardwareObjects/BlissShutter.py
+++ b/mxcubecore/HardwareObjects/BlissShutter.py
@@ -19,16 +19,18 @@
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 
 """ BlissShutter class - interface for shutter controlled by BLISS
-Implements _set_value, get_value methods
-Bliss states are: UNKNOWN, OPEN, CLOSED, FAULT
-"MOVING", "DISABLE", "STANDBY", "RUNNING"
-Example xml file:
-<devic class="BlissShutter">
-  <username>Safety Shutter</username>
-  <name>safshut</name>
-  <type>tango</type>
-  <object href="/bliss" role="controller"/>
-</device>
+
+Implements ``_set_value``, ``get_value`` methods
+
+Example xml file::
+
+    <device class="BlissShutter">
+    <username>Safety Shutter</username>
+    <name>safshut</name> 
+    <type>tango</type>
+    <object href="/bliss" role="controller"/>
+    </device>
+
 """
 from enum import Enum, unique
 import gevent
@@ -42,7 +44,11 @@ __license__ = "LGPLv3+"
 
 @unique
 class BlissShutterStates(Enum):
-    """Shutter states definitions."""
+    """Shutter states definitions corresponding to the HardwareObjectState.
+
+    States are:
+    ``OPEN``, ``CLOSED``, ``FAULT``, ``MOVING``, ``DISABLE``, ``UNKNOWN``, ``AUTOMATIC``
+    """
 
     OPEN = HardwareObjectState.READY, "OPEN"
     CLOSED = HardwareObjectState.READY, "CLOSED"
@@ -103,6 +109,7 @@ class BlissShutter(AbstractShutter):
 
     def get_state(self):
         """Get the device state.
+
         Returns:
             (enum 'HardwareObjectState'): Device state.
         """
@@ -113,9 +120,10 @@ class BlissShutter(AbstractShutter):
         return self.SPECIFIC_STATES[_state].value[0]
 
     def get_value(self):
-        """Get the device value
+        """Get the device value.
+
         Returns:
-            (Enum): Enum member, corresponding to the value or UNKNOWN.
+            (Enum): Enum member, corresponding to the value or ``UNKNOWN``.
         """
         # the return from BLISS value is an Enum
         _val = self._bliss_obj.state.name
@@ -128,9 +136,11 @@ class BlissShutter(AbstractShutter):
             self._bliss_obj.close()
 
     def set_mode(self, value):
-        """Set automatic or manual mode for a Frontend shutter
+        """Set automatic or manual mode for a Frontend shutter.
+
         Args:
             value (str): MANUAL or AUTOMATIC
+
         Raises: NotImplementedError: Not a Fronend shutter.
         """
         self._bliss_obj.mode = value

--- a/mxcubecore/HardwareObjects/BlissShutter.py
+++ b/mxcubecore/HardwareObjects/BlissShutter.py
@@ -26,7 +26,7 @@ Example xml file::
 
     <device class="BlissShutter">
     <username>Safety Shutter</username>
-    <name>safshut</name> 
+    <name>safshut</name>
     <type>tango</type>
     <object href="/bliss" role="controller"/>
     </device>

--- a/mxcubecore/HardwareObjects/Camera.py
+++ b/mxcubecore/HardwareObjects/Camera.py
@@ -1,20 +1,22 @@
-"""Class for cameras connected to framegrabbers run by Taco Device Servers
+"""Class for cameras connected to framegrabbers run by Taco Device Servers.
 
-template:
+Example of a configuration using a xml file::
+
   <device class = "Camera">
-    <username>user label</username>
-    <!-- <taconame>device server name (//host/.../.../...)</taconame> -->
-    <interval>polling interval (in ms.)</interval>
-    <!-- <calibration>
-      <zoomMotor>Zoom motor Hardware Object reference</zoomMotor>
-      <calibrationData>
-        <offset>Zoom motor position (user units)</offset>
-        <pixelsPerMmY>pixels per mm (Y axis)</pixelsPerMmY>
-        <pixelsPerMmZ>pixels per mm (Z axis)</pixelsPerMmZ>
-      </calibrationData>
-    </calibration> -->
+  <username>user label</username>
+  <!-- <taconame>device server name (//host/.../.../...)</taconame> -->
+  <interval>polling interval (in ms.)</interval>
+  <!-- <calibration>
+  <zoomMotor>Zoom motor Hardware Object reference</zoomMotor>
+  <calibrationData>
+  <offset>Zoom motor position (user units)</offset>
+  <pixelsPerMmY>pixels per mm (Y axis)</pixelsPerMmY>
+  <pixelsPerMmZ>pixels per mm (Z axis)</pixelsPerMmZ>
+  </calibrationData>
+  </calibration> -->
   </device>
 """
+
 from mxcubecore import BaseHardwareObjects
 from mxcubecore import CommandContainer
 import gevent

--- a/mxcubecore/HardwareObjects/EMBLFlexHCD.py
+++ b/mxcubecore/HardwareObjects/EMBLFlexHCD.py
@@ -19,13 +19,21 @@
 #  along with MXCuBE.  If not, see <http://www.gnu.org/licenses/>.
 
 """FlexHCD Linux Java implementation of sample changer.
+
 Example xml file:
+
 <object class = "EMBLFlexHCD">
+
   <username>Sample Changer</username>
+
   <exporter_address>lid231flex1:9001</exporter_address>
+
   <object role="controller" href="/bliss"/>
-  <puck_configuration>["SC3", "UNI", "SC3", "UNI", "UNI", "UNI", "UNI", "UNI"]<
+
+  <puck_configuration>["SC3", "UNI", "SC3", "UNI", "UNI", "UNI", "UNI", "UNI"]>
+
 /puck_configuration>
+
 </object>
 """
 import time
@@ -324,7 +332,7 @@ class EMBLFlexHCD(SampleChanger):
         return self._execute_cmd_exporter("getState", attribute=True) != "Ready"
 
     def _wait_ready(self, timeout=None):
-        # None means wait forever timeout <=0 use default timeout
+        """None means wait forever timeout <=0 use default timeout"""
         if timeout is not None and timeout <= 0:
             timeout = self.timeout
 

--- a/mxcubecore/HardwareObjects/ESRF/ESRFBeam.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFBeam.py
@@ -19,11 +19,10 @@
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 
 """
-BeamDefiner ESRF implementation class - methods to define the size and shape of
-the beam.
+Define the size and shape of the beam taking into account apertures and/or slits.
 """
 
-__copyright__ = """ Copyright © 2023 by the MXCuBE collaboration """
+__copyright__ = """ Copyright  © 2023 by the MXCuBE collaboration """
 __license__ = "LGPLv3+"
 
 
@@ -87,6 +86,7 @@ class ESRFBeam(AbstractBeam):
 
     def _get_aperture_size(self):
         """Get the size and the label of the aperture in place.
+
         Returns:
             (float, str): Size [mm], label.
         """
@@ -101,6 +101,7 @@ class ESRFBeam(AbstractBeam):
 
     def _get_complex_size(self):
         """Get the size and the name of the definer in place.
+
         Returns:
             (float, str): Size [mm], label.
         """
@@ -113,6 +114,7 @@ class ESRFBeam(AbstractBeam):
 
     def _get_complex_size_old(self):
         """Get the size and the name of the definer in place.
+
         Returns:
             (float, str): Size [mm], label.
         """
@@ -129,6 +131,7 @@ class ESRFBeam(AbstractBeam):
 
     def _get_slits_size(self):
         """Get the size of the slits in place.
+
         Returns:
             (dict): {"width": float, "heigth": float}.
         """
@@ -140,7 +143,8 @@ class ESRFBeam(AbstractBeam):
     def get_value(self):
         """Get the size (width and heigth) of the beam and its shape.
             The size is in mm.
-        Retunrs:
+
+        Returns:
             (tuple): Dictionary (width, heigth, shape, name), with types
                                (float, float, Enum, str)
         """
@@ -186,6 +190,7 @@ class ESRFBeam(AbstractBeam):
 
     def get_available_size(self):
         """Get the available predefined beam definer configuration.
+
         Returns:
             (dict): apertures {name: dimension} or
                     slits {"width": motor object, "heigth", motor object} or
@@ -217,6 +222,7 @@ class ESRFBeam(AbstractBeam):
 
     def _set_slits_size(self, size=None):
         """Move the slits to the desired position.
+
         Args:
             size (list): Width, heigth [mm].
         Raises:
@@ -237,6 +243,7 @@ class ESRFBeam(AbstractBeam):
 
     def _set_aperture_size(self, size=None):
         """Move the aperture to the desired size.
+
         Args:
             size (str): The position name.
         """
@@ -249,6 +256,7 @@ class ESRFBeam(AbstractBeam):
 
     def _set_complex_size(self, size=None):
         """Move the complex definer to the desired size.
+
         Args:
             size (str): The position name.
         """
@@ -256,6 +264,7 @@ class ESRFBeam(AbstractBeam):
 
     def set_value(self, size=None):
         """Set the beam size
+
         Args:
             size (list): Width, heigth or
                   (str): Aperture or complex definer name.

--- a/mxcubecore/HardwareObjects/ESRF/ESRFBeamlineActions.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFBeamlineActions.py
@@ -15,9 +15,12 @@
 #
 #  You should have received a copy of the GNU General Lesser Public License
 #  along with MXCuBE.  If not, see <http://www.gnu.org/licenses/>.
+
 """ Execute commands and toggle two state actions
-Example xml file:
-<object class = "ESRF.ESRFBeamlineActions">
+
+Example xml file::
+
+  <object class = "ESRF.ESRFBeamlineActions">
   <object role="controller" href="/bliss"/>
   <object role="hutchtrigger"  href="/hutchtrigger"/>
   <object role="scintillator" href="/udiff_scint"/>
@@ -25,14 +28,15 @@ Example xml file:
   <object role="aperture" href="/udiff_apertureinout"/>
   <object role="cryostream" href="/udiff_cryo"/>
   <controller_commands>
-    <centrebeam>Centre beam</centrebeam>
-    <quick_realign>Quick realign</quick_realign>
-    <anneal_procedure>Anneal</anneal_procedure>
+  <centrebeam>Centre beam</centrebeam>
+  <quick_realign>Quick realign</quick_realign>
+  <anneal_procedure>Anneal</anneal_procedure>
   </controller_commands>
   <hwobj_commands>
-    ["hutchtrigger", "scintillator", "detector_cover", "aperture", "cryostream"]
+  ["hutchtrigger", "scintillator", "detector_cover", "aperture", "cryostream"]
   </hwobj_commands>
-</object>
+  </object>
+
 """
 import ast
 import gevent
@@ -91,6 +95,7 @@ class ESRFBeamlineActions(BeamlineActions):
 
     def get_commands(self):
         """Get which objects to be used in the GUI
+
         Returns:
             (list): List of object
         """

--- a/mxcubecore/HardwareObjects/ESRF/ESRFPhotonFlux.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFPhotonFlux.py
@@ -18,15 +18,18 @@
 #  You should have received a copy of the GNU General Lesser Public License
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 
-""" Photon fluc calculations
-Example xml file:
+""" Photon flux calculations.
+
+Example xml file::
+
 <object class="ESRF.ESRFPhotonFlux">
-  <username>Photon flux</username>
-  <object role="controller" href="/bliss"/>
-  <object role="aperture" href="/udiff_aperture"/>
-  <counter_name>i0</counter_name>
-  <beam_check_name>checkbeam</beam_check_name>
+<username>Photon flux</username>
+<object role="controller" href="/bliss"/>
+<object role="aperture" href="/udiff_aperture"/>
+<counter_name>i0</counter_name>
+<beam_check_name>checkbeam</beam_check_name>
 </object>
+
 """
 import logging
 import gevent
@@ -48,6 +51,7 @@ class ESRFPhotonFlux(AbstractFlux):
 
     def init(self):
         """Initialisation"""
+
         super().init()
         controller = self.get_object_by_role("controller")
 
@@ -82,6 +86,7 @@ class ESRFPhotonFlux(AbstractFlux):
 
     def _poll_flux(self):
         """Poll the flux every 2 seconds"""
+
         while True:
             self.re_emit_values()
             gevent.sleep(3)
@@ -123,6 +128,7 @@ class ESRFPhotonFlux(AbstractFlux):
 
     def check_beam(self):
         """Check if there is beam
+
         Returns:
             (bool): True if beam present, False otherwise
         """
@@ -130,6 +136,7 @@ class ESRFPhotonFlux(AbstractFlux):
 
     def wait_for_beam(self, timeout=None):
         """Wait until beam present
+
         Args:
             timeout (float): optional - timeout [s],
                              If timeout == 0: return at once and do not wait

--- a/mxcubecore/HardwareObjects/EdnaWorkflow.py
+++ b/mxcubecore/HardwareObjects/EdnaWorkflow.py
@@ -54,16 +54,27 @@ class EdnaWorkflow(HardwareObject):
     Example of a corresponding XML file (currently called "ednaparams.xml"):
 
     <object class = "EdnaWorkflow" role = "workflow">
+
     <bes_host>mxhpc2-1705</bes_host>
+
     <bes_port>8090</bes_port>
+
     <object href="/session" role="session"/>
+
     <workflow>
+
         <title>MXPressA</title>
+
         <path>MXPressA</path>
+
     </workflow>
+
     <workflow>
+
         <title>...</title>
+
         <path>...</path>
+
     </workflow>
     """
 

--- a/mxcubecore/HardwareObjects/Energy.py
+++ b/mxcubecore/HardwareObjects/Energy.py
@@ -4,20 +4,23 @@ import gevent
 from mxcubecore.BaseHardwareObjects import Equipment
 
 """
-Example xml file:
-  - for tunable wavelength beamline:
-<object class="Energy">
+
+Example xml file for tunable wavelength beamline::
+
+  <object class="Energy">
   <object href="/energy" role="energy"/>
   <object href="/bliss" role="controller"/>
   <tunable_energy>True</tunable_energy>
-</object>
-The energy should have methods get_value, get_limits and move.
-If used, the controller should have method moveEnergy.
+  </object>
 
-  - for fixed wavelength beamline:
-<object class="Energy">
+The energy should have ``get_value``, ``get_limits`` and ``move`` methods.
+If used, the controller should have method ``moveEnergy``.
+
+Example xml file for fixed wavelength beamline::
+
+  <object class="Energy">
   <default_energy>12.8123</tunable_energy>
-</object>
+  </object>
 """
 
 

--- a/mxcubecore/HardwareObjects/ExporterNState.py
+++ b/mxcubecore/HardwareObjects/ExporterNState.py
@@ -18,17 +18,20 @@
 #  You should have received a copy of the GNU General Lesser Public License
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 """
-Microdiff with Exporter implementation of AbstartNState
-Example xml file:
-<device class="ExporterNState">
+Microdiff with Exporter implementation of AbstractNState
+
+Example configuration using an xml file::
+
+  <device class="ExporterNState">
   <username>Fluorescence Detector</username>
   <exporter_address>wid30bmd2s:9001</exporter_address>
   <value_channel_name>FluoDetectorIsBack</value_channel_name>
   <state_channel_name>State</state_channel_name>
   <values>{"IN": False, "OUT": True}</values>
   <value_state>True</value_state>
-</device>
+  </device>
 """
+
 from enum import Enum
 from gevent import Timeout, sleep
 from mxcubecore.HardwareObjects.abstract.AbstractNState import AbstractNState
@@ -40,7 +43,7 @@ __license__ = "LGPLv3+"
 
 
 class ExporterNState(AbstractNState):
-    """Microdiff with Exporter implementation of AbstartNState"""
+    """Microdiff with Exporter implementation of AbstractNState"""
 
     SPECIFIC_STATES = ExporterStates
 
@@ -53,6 +56,7 @@ class ExporterNState(AbstractNState):
 
     def init(self):
         """Initialise the device"""
+
         super().init()
         value_channel = self.get_property("value_channel_name")
         # use the value to check if action finished.
@@ -87,19 +91,23 @@ class ExporterNState(AbstractNState):
 
     def _wait_hardware(self, value, timeout=None):
         """Wait timeout seconds till hardware in place.
+
         Args:
             value (str, int): value to be tested.
             timeout(float): Timeout [s]. None means infinite timeout.
         """
+
         with Timeout(timeout, RuntimeError("Timeout waiting for hardware")):
             while self.value_channel.get_value() != value:
                 sleep(0.5)
 
     def _wait_ready(self, timeout=None):
         """Wait timeout seconds till status is ready.
+
         Args:
             timeout(float): Timeout [s]. None means infinite timeout.
         """
+
         with Timeout(timeout, RuntimeError("Timeout waiting for status ready")):
             while not self.get_state() == self.STATES.READY:
                 sleep(0.5)
@@ -109,11 +117,13 @@ class ExporterNState(AbstractNState):
 
     def _update_state(self, state=None):
         """To be used to update the state when emiting the "update" signal.
+
         Args:
             state (str): optional state value
         Returns:
             (enum 'HardwareObjectState'): state.
         """
+
         if not state:
             state = self.get_state()
         else:
@@ -123,6 +133,7 @@ class ExporterNState(AbstractNState):
 
     def _str2state(self, state):
         """Convert string state to HardwareObjectState enum value.
+
         Args:
             state (str): the state
         Returns:
@@ -135,22 +146,27 @@ class ExporterNState(AbstractNState):
 
     def get_state(self):
         """Get the device state.
+
         Returns:
             (enum 'HardwareObjectState'): Device state.
         """
+
         state = self.state_channel.get_value()
         return self._str2state(state)
 
     def abort(self):
         """Stop the action."""
+
         if self.get_state() != self.STATES.UNKNOWN:
             self._exporter.execute("abort")
 
     def _set_value(self, value):
         """Set device to value
+
         Args:
             value (str, int, float or enum): Value to be set.
         """
+
         # NB Workaround beacuse diffractomer does not send event on
         # change of actuators (light, scintillator, cryostream...)
         self.update_state(self.STATES.BUSY)
@@ -169,8 +185,10 @@ class ExporterNState(AbstractNState):
 
     def get_value(self):
         """Get the device value
+
         Returns:
             (Enum): Enum member, corresponding to the value or UNKNOWN.
         """
+
         _val = self.value_channel.get_value()
         return self.value_to_enum(_val)

--- a/mxcubecore/HardwareObjects/LimaEigerDetector.py
+++ b/mxcubecore/HardwareObjects/LimaEigerDetector.py
@@ -1,6 +1,7 @@
-"""LimaEigerDetector Class
-Lima Tango Device Server implementation of the Dectris Eiger2 Detector.
+"""Lima Tango Device Server implementation of the Dectris Eiger2 Detector.
+
 """
+
 import gevent
 import time
 import os
@@ -112,46 +113,45 @@ class LimaEigerDetector(AbstractDetector):
         mesh,
         mesh_num_lines,
     ):
-        """
-        diffractometer_positions = HWR.beamline.diffractometer.get_positions()
-        self.start_angles = list()
-        for i in range(number_of_images):
-            self.start_angles.append("%0.4f deg." % (start + osc_range * i))
-        self.header["file_comments"] = comment
-        self.header["N_oscillations"] = number_of_images
-        self.header["Oscillation_axis"] = "omega"
-        self.header["Chi"] = "0.0000 deg."
-        try:
-            self.header["Phi"] = "%0.4f deg." % diffractometer_positions.get(
-                "kappa_phi", -9999
-            )
-            self.header["Kappa"] = "%0.4f deg." % diffractometer_positions.get(
-                "kappa", -9999
-            )
-        except Exception:
-            self.header["Phi"] = "0.0000 deg."
-            self.header["Kappa"] = "0.0000 deg."
-        self.header["Alpha"] = "0.0000 deg."
-        self.header["Polarization"] = HWR.beamline.collect.bl_config.polarisation
-        self.header["Detector_2theta"] = "0.0000 deg."
-        self.header["Angle_increment"] = "%0.4f deg." % osc_range
-        self.header["Transmission"] = HWR.beamline.transmission.get_value()
-        self.header["Flux"] = HWR.beamline.flux.get_value()
-        self.header["Detector_Voffset"] = "0.0000 m"
-        self.header["Energy_range"] = "(0, 0) eV"
-        self.header["Trim_directory:"] = "(nil)"
-        self.header["Flat_field:"] = "(nil)"
-        self.header["Excluded_pixels:"] = " badpix_mask.tif"
-        self.header["N_excluded_pixels:"] = "= 321"
-        self.header["Threshold_setting"] = (
-            "%d eV" % self.get_channel_object("photon_energy").get_value()
-        )
-        self.header["Count_cutoff"] = "1048500"
-        self.header["Tau"] = "= 0 s"
-        self.header["Exposure_period"] = "%f s" % (exptime + self.get_deadtime())
-        self.header["Exposure_time"] = "%f s" % exptime
-        """
+        """Example of a header used for ISPyB
+        ::
 
+          diffractometer_positions = HWR.beamline.diffractometer.get_positions()
+          self.start_angles = list()
+          for i in range(number_of_images):
+              self.start_angles.append("%0.4f deg." % (start + osc_range * i))
+          self.header["file_comments"] = comment
+          self.header["N_oscillations"] = number_of_images
+          self.header["Oscillation_axis"] = "omega"
+          self.header["Chi"] = "0.0000 deg."
+          try:
+              self.header["Phi"] = "%0.4f deg." % diffractometer_positions.get(
+                  "kappa_phi", -9999)
+              self.header["Kappa"] = "%0.4f deg." % diffractometer_positions.get(
+                "kappa", -9999)
+          except Exception:
+              self.header["Phi"] = "0.0000 deg."
+              self.header["Kappa"] = "0.0000 deg."
+          self.header["Alpha"] = "0.0000 deg."
+          self.header["Polarization"] = HWR.beamline.collect.bl_config.polarisation
+          self.header["Detector_2theta"] = "0.0000 deg."
+          self.header["Angle_increment"] = "%0.4f deg." % osc_range
+          self.header["Transmission"] = HWR.beamline.transmission.get_value()
+          self.header["Flux"] = HWR.beamline.flux.get_value()
+          self.header["Detector_Voffset"] = "0.0000 m"
+          self.header["Energy_range"] = "(0, 0) eV"
+          self.header["Trim_directory:"] = "(nil)"
+          self.header["Flat_field:"] = "(nil)"
+          self.header["Excluded_pixels:"] = " badpix_mask.tif"
+          self.header["N_excluded_pixels:"] = "= 321"
+          self.header["Threshold_setting"] = (
+            "%d eV" % self.get_channel_object("photon_energy").get_value())
+          self.header["Count_cutoff"] = "1048500"
+          self.header["Tau"] = "= 0 s"
+          self.header["Exposure_period"] = "%f s" % (exptime + self.get_deadtime())
+          self.header["Exposure_time"] = "%f s" % exptime
+
+        """
         self.stop()
         self.wait_ready()
 
@@ -283,8 +283,7 @@ class LimaEigerDetector(AbstractDetector):
         return file_name
 
     def get_first_and_last_file(self, pt: PathTemplate) -> tuple:
-        """
-        Get complete path to first and last image
+        """Get complete path to first and last image.
 
         Args:
           Path template parameter
@@ -298,9 +297,8 @@ class LimaEigerDetector(AbstractDetector):
         return (pt.get_image_path() % start_num, pt.get_image_path() % end_num)
 
     def get_actual_file_path(self, master_file_path: str, image_number: int) -> tuple:
-        """
-        Get file path to image with the given image number <image_number> and
-        the master h5 file <master_file_path>
+        """Get file path to image with the given image number <image_number> and
+        the master h5 file <master_file_path>.
 
         Args:
             first_file_path: Path to master h5 file

--- a/mxcubecore/HardwareObjects/MD3UP.py
+++ b/mxcubecore/HardwareObjects/MD3UP.py
@@ -209,6 +209,7 @@ class MD3UP(Microdiff.Microdiff):
 
     def timeresolved_mesh_scan(self, timeout=900):
         """Start timeresolved mesh.
+
         Args:
             timeout(float): Timeout to wait the execution of the scan [s].
                             Default value is 15 min
@@ -229,6 +230,7 @@ class MD3UP(Microdiff.Microdiff):
     def get_timeresolved_mesh_nbframes(self):
         """Get the calculated number of frames for the continuous timeresolved
            mesh scan.
+
         Returns:
             (int): Number of frames.
         """
@@ -245,6 +247,7 @@ class MD3UP(Microdiff.Microdiff):
     def get_timeresolved_mesh_exptime(self):
         """Get the calculated exposure time for the continuous timeresolved
            mesh scan.
+
         Returns:
             (float): Exposure time [s].
         """

--- a/mxcubecore/HardwareObjects/Microdiff.py
+++ b/mxcubecore/HardwareObjects/Microdiff.py
@@ -371,21 +371,21 @@ class Microdiff(MiniDiff.MiniDiff):
                 logging.getLogger("HWR").exception("Cannot prepare centring")
 
     def set_light_in(self):
-        """Set the backlight in - used by the XMLRPC calls"""
+        """Set the backlight in - used by the XMLRPC calls."""
         logging.getLogger("HWR").info("Moving backlight in")
         light_hwobj = self.get_object_by_role("BackLightSwitch")
         light_hwobj.set_value(light_hwobj.VALUES.IN)
         self._wait_ready(20)
 
     def set_light_out(self):
-        """Set the backlight out - used by the XMLRPC calls"""
+        """Set the backlight out - used by the XMLRPC calls."""
         logging.getLogger("HWR").info("Moving backlight out")
         light_hwobj = self.get_object_by_role("BackLightSwitch")
         light_hwobj.set_value(light_hwobj.VALUES.OUT)
         self._wait_ready(20)
 
     def set_phase(self, phase, wait=False, timeout=None):
-        """Set the phase"""
+        """Set the phase of the diffractometer and move detector cover."""
         _use_custom = self.get_property("use_custom_phase_script", False)
         if not self._ready():
             logging.getLogger("HWR").exception("MD not ready - phase not set.")
@@ -595,6 +595,7 @@ class Microdiff(MiniDiff.MiniDiff):
         wait=False,
     ):
         """Do N scans continuously.
+
         Args:
             start (float): Position of omega for the first scan [deg].
             scan_range (float): range for each scan [deg].
@@ -641,7 +642,7 @@ class Microdiff(MiniDiff.MiniDiff):
         )
 
     def get_motors(self):
-        """Get motor_name:Motor dictionary"""
+        """Get motor_name:Motor dictionary."""
         return {
             "phi": self.phiMotor,
             "focus": self.focusMotor,
@@ -752,7 +753,9 @@ class Microdiff(MiniDiff.MiniDiff):
         self.current_centring_procedure.link(self.manualCentringDone)
 
     def interrupt_and_accept_centring(self):
-        """Used when plate. Kills the current 1 click centring infinite loop
+        """Used when plate.
+
+        Kills the current 1-click centring infinite loop
         and accepts fake centring - only save the motor positions
         """
         self.current_centring_procedure.kill()

--- a/mxcubecore/HardwareObjects/MicrodiffAperture.py
+++ b/mxcubecore/HardwareObjects/MicrodiffAperture.py
@@ -18,13 +18,15 @@
 #  You should have received a copy of the GNU General Lesser Public License
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 """
-MicrodiffAperture. Move the aperture in the beam to a specified value or
+MicrodiffAperture moves the aperture in the beam to a specified value or
 out of the beam.
+
 The factor, which serves to calculate the flux, can be a single value or a
 tuple of values per aperture size.
 
-Example xml file:
-<object class="MicrodiffAperture">
+Example xml file::
+
+  <object class="MicrodiffAperture">
   <username>aperture</username>
   <exporter_address>wid30bmd2s:9001</exporter_address>
   <value_channel_name>CurrentApertureDiameterIndex</value_channel_name>
@@ -34,7 +36,7 @@ Example xml file:
   <!-- or complete, corresponding to label: (index, size[um], factor) -->
   <values>{"A10": (0, 10, 0.15), "A20": (1, 20, 0.3), "A30": (2, 30, 0.63), "A50": (3, 50, 0.9), "A75": (4, 75, 0.96)}</values>
   <object role="inout" href="/udiff_apertureinout"/>
-</object>
+  </object>
 """
 from ast import literal_eval
 from enum import Enum
@@ -55,7 +57,7 @@ class MicrodiffAperture(ExporterNState):
         self.inout_obj = None
 
     def init(self):
-        """Initialize the aperture"""
+        """Initialize the aperture."""
         super().init()
 
         # check if we have values other that UKNOWN (no values in config)
@@ -68,7 +70,8 @@ class MicrodiffAperture(ExporterNState):
             self._initialise_inout()
 
     def _set_value(self, value):
-        """Set device to value
+        """Set device to value.
+
         Args:
             value (str, int, float or enum): Value to be set.
         """
@@ -82,13 +85,14 @@ class MicrodiffAperture(ExporterNState):
                 self.inout_obj.set_value(self.inout_obj.VALUES.IN, timeout=60)
 
     def _initialise_inout(self):
-        """Add IN and OUT to the values Enum"""
+        """Add ``IN`` and ``OUT`` to the values Enum."""
         values_dict = {item.name: item.value for item in self.inout_obj.VALUES}
         values_dict.update({item.name: item.value for item in self.VALUES})
         self.VALUES = Enum("ValueEnum", values_dict)
 
     def _initialise_values(self):
-        """Initialise the ValueEnum from the hardware
+        """Initialise the ValueEnum from the hardware.
+
         Raises:
             RuntimeError: No aperture diameters defined.
                           Factor and aperture diameter not the same number.
@@ -121,6 +125,7 @@ class MicrodiffAperture(ExporterNState):
 
     def get_factor(self, label):
         """Get the factor associated to a label.
+
         Args:
             (enum, str): label enum or name
         Returns:
@@ -138,6 +143,7 @@ class MicrodiffAperture(ExporterNState):
 
     def get_size(self, label):
         """Get the aperture size associated to a label.
+
         Args:
             (enum, str): label enum or name
         Returns:
@@ -158,7 +164,8 @@ class MicrodiffAperture(ExporterNState):
             raise RuntimeError("Unknown aperture size")
 
     def get_diameter_size_list(self):
-        """Get the list of values to be visible. Hide IN, OUT and UNKNOWN.
+        """Get the list of values to be visible. Hide ``IN``, ``OUT`` and ``UNKNOWN``.
+
         Returns:
             (list): List of availble aperture values (string).
         """

--- a/mxcubecore/HardwareObjects/MicrodiffLightBeamstop.py
+++ b/mxcubecore/HardwareObjects/MicrodiffLightBeamstop.py
@@ -1,16 +1,20 @@
 """
-Combine setting the back light IN with moving the beamstop out.
+Combine setting the back light ``IN`` with moving the beamstop out.
+
 This is used to set the back light in/out faster, than using
-the phase CENTRING - the beamstop motor moves only if needed.
-Example xml file:
-<device class="MicrodiffLightBeamstop">
+the phase CENTRING. The beamstop motor moves only if needed.
+
+Example xml file::
+
+  <device class="MicrodiffLightBeamstop">
   <username>Back Light</username>
   <exporter_address>wid30bmd2s:9001</exporter_address>
   <actuator_name>BackLightIsOn</actuator_name>
   <values>{"IN": True, "OUT": False}</values>
   <use_hwstate>True</use_hwstate>
   <object role="beamstop" href="/udiff_beamstop"/>
-</device>
+  </device>
+
 """
 
 from mxcubecore.HardwareObjects.ExporterNState import ExporterNState
@@ -20,7 +24,7 @@ __license__ = "LGPLv3+"
 
 
 class MicrodiffLightBeamstop(ExporterNState):
-    """Control backlight, move the beamstop to safety position"""
+    """Control backlight, move the beamstop to safety position."""
 
     def __init__(self, name):
         super().__init__(name)
@@ -36,6 +40,7 @@ class MicrodiffLightBeamstop(ExporterNState):
 
     def _set_value(self, value):
         """Set light to value. Move the beamstop, if needed.
+
         Args:
             value (enum): Value to be set.
         """
@@ -52,6 +57,7 @@ class MicrodiffLightBeamstop(ExporterNState):
 
     def handle_beamstop(self, value):
         """Move the beamstop as function of the value of the back light.
+
         Args:
             (enum): light value.
         """

--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -33,7 +33,9 @@ try:
     from mxcubecore.model import crystal_symmetry
     import ruamel.yaml as yaml
 except Exception:
-    logging.getLogger("HWR").warning("Cannot import dependenices needed for GPHL workflows - GPhL workflows might not work")
+    logging.getLogger("HWR").warning(
+        "Cannot import dependenices needed for GPHL workflows - GPhL workflows might not work"
+    )
 
 # This module is used as a self contained entity by the BES
 # workflows, so we need to make sure that this module can be
@@ -756,7 +758,7 @@ class DataCollection(TaskNode):
     def get_helical_point_index(self):
         """
         Descript. : Return indexes of points associated to the helical line
-        Args.     :
+
         Return    : index (integer), index (integer)
         """
         cp = self.get_centred_positions()
@@ -765,15 +767,17 @@ class DataCollection(TaskNode):
     def set_grid_id(self, grid_id):
         """
         Descript. : Sets grid id associated to the data collection
+
         Args.     : grid_id (integer)
+
         Return    :
         """
         self.grid_id = grid_id
 
     def get_display_name(self):
         """
-        Descript. : Returns display name depending from collection type
-        Args.     :
+        Descript. : Returns display name depending from collection type.
+
         Return    : display_name (string)
         """
         if self.is_helical():
@@ -808,9 +812,9 @@ class DataCollection(TaskNode):
         return self.online_processing_results
 
     def set_snapshot(self, snapshot):
-        self.acquisitions[
-            0
-        ].acquisition_parameters.centred_position.snapshot_image = snapshot
+        self.acquisitions[0].acquisition_parameters.centred_position.snapshot_image = (
+            snapshot
+        )
 
     def add_processing_msg(self, time, method, status, msg):
         self.processing_msg_list.append((time, method, status, msg))
@@ -920,7 +924,7 @@ class Characterisation(TaskNode):
     def get_point_index(self):
         """
         Descript. : Returns point index associated to the data collection
-        Args.     :
+
         Return    : index (integer)
         """
         cp = self.get_centred_positions()
@@ -929,7 +933,7 @@ class Characterisation(TaskNode):
     def get_display_name(self):
         """
         Descript. : Returns display name of the collection
-        Args.     :
+
         Return    : display_name (string)
         """
         index = self.get_point_index()
@@ -1274,10 +1278,10 @@ class XrayCentering(TaskNode):
 
 
 class XrayCentring2(TaskNode):
-    """X-ray centring (2022 version)
+    """X-ray centring (2022 version).
 
-    Contains all parameters necessary for X-ray centring
-    This object is passed to the QueueEntry and HardwareObject
+    Contains all parameters necessary for X-ray centring.
+    This object is passed to the QueueEntry and HardwareObject.
     Parameters not defined here must be set as defaults, somehow
     (transmission, grid step, ...)
     """
@@ -1362,18 +1366,18 @@ class XrayCentring2(TaskNode):
 
 
 class SampleCentring(TaskNode):
-    """Manual 3 click centering
+    """Manual 3-click centering
 
     kappa and kappa_phi settings are applied first, and assume that the
-    beamline does have axes with exactly these names
+    beamline does have axes with exactly these names.
 
     Other motor_positions are applied afterwards, but in random order.
-    motor_positions override kappa and kappa_phi if both are set
+    ``motor_positions`` override kappa and kappa_phi if both are set
 
     Since setting one motor can change the position of another
     (on ESRF ID30B setting kappa and kappa_phi changes the translation motors)
-     the order is important.
 
+    **the order is important**.
     """
 
     def __init__(self, name=None, kappa=None, kappa_phi=None, motor_positions=None):
@@ -1609,7 +1613,7 @@ class PathTemplate(object):
             logging.getLogger("HWR").debug(
                 "PathTemplate (DESY) - (to be defined) directory is %s" % self.directory
             )
-            #archive_directory = self.directory
+            # archive_directory = self.directory
             archive_directory = HWR.beamline.session.get_archive_directory()
         elif PathTemplate.synchrotron_name == "ALBA":
             logging.getLogger("HWR").debug(
@@ -2323,7 +2327,6 @@ class GphlWorkflow(TaskNode):
             else:
                 print("WARNING no GPHL_TEST_INPUT found. test using default values")
 
-
         # Set attributes directly from params
         self.strategy_settings = HWR.beamline.gphl_workflow.workflow_strategies.get(
             params["strategy_name"]
@@ -2480,6 +2483,7 @@ class GphlWorkflow(TaskNode):
                 self._cell_parameters = tuple(float(x) for x in value)
             else:
                 raise ValueError("invalid value for cell_parameters: %s" % str(value))
+
     @property
     def total_strategy_length(self):
         """Total strategy length for a single repetition
@@ -2490,7 +2494,6 @@ class GphlWorkflow(TaskNode):
             result *= len(energy_tags)
         #
         return result
-
 
     def calc_maximum_dose(self, energy=None, exposure_time=None, image_width=None):
         """Dose at transmission=100 for given energy, exposure time and image width
@@ -2505,30 +2508,22 @@ class GphlWorkflow(TaskNode):
         Returns:
             float: Maximum dose in MGy
         """
-        energy = (
-            energy
-            or HWR.beamline.energy.calculate_energy(self.wavelengths[0].wavelength)
+        energy = energy or HWR.beamline.energy.calculate_energy(
+            self.wavelengths[0].wavelength
         )
         dose_rate = HWR.beamline.gphl_workflow.maximum_dose_rate(energy)
         exposure_time = exposure_time or self.exposure_time
-        image_width = image_width  or self.image_width
+        image_width = image_width or self.image_width
         total_strategy_length = self.strategy_length * len(self.wavelengths)
-        if (dose_rate and exposure_time and image_width and total_strategy_length):
-            return (dose_rate * total_strategy_length * exposure_time / image_width)
+        if dose_rate and exposure_time and image_width and total_strategy_length:
+            return dose_rate * total_strategy_length * exposure_time / image_width
         msg = (
             "WARNING: Dose could not be calculated from:\n"
             " energy:%s keV, total_strategy_length:%s deg, exposure_time:%s s, "
             "image_width:%s deg, dose_rate: %s"
         )
         raise UserWarning(
-            msg
-            % (
-                energy,
-                total_strategy_length,
-                exposure_time,
-                image_width,
-                dose_rate
-            )
+            msg % (energy, total_strategy_length, exposure_time, image_width, dose_rate)
         )
         return 0
 
@@ -2597,42 +2592,37 @@ def addXrayCentring(parent_node, **centring_parameters):
 # Collect hardware object utility function.
 #
 def to_collect_dict(data_collection, session, sample, centred_pos=None):
-    """ return [{'comment': '',
-          'helical': 0,
-          'motors': {},
-          'take_video': False,
-          'take_snapshots': False,
-          'fileinfo': {'directory': '/data/id14eh4/inhouse/opid144/' +\
-                                    '20120808/RAW_DATA',
-                       'prefix': 'opid144', 'run_number': 1,
-                       'process_directory': '/data/id14eh4/inhouse/' +\
-                                            'opid144/20120808/PROCESSED_DATA'},
-          'in_queue': 0,
-          'detector_binning_mode': 2,
-          'shutterless': 0,
-          'sessionId': 32368,
-          'do_inducedraddam': False,
-          'sample_reference': {},
-          'processing': 'False',
-          'residues': '',
-          'dark': True,
-          'scan4d': 0,
-          'input_files': 1,
-          'oscillation_sequence': [{'exposure_time': 1.0,
-                                    'kappaStart': 0.0,
-                                    'phiStart': 0.0,
-                                    'start_image_number': 1,
-                                    'number_of_images': 1,
-                                    'overlap': 0.0,
-                                    'start': 0.0,
-                                    'range': 1.0,
-                                    'number_of_passes': 1}],
+    """Example of the parameters and file format for a data collection.
+
+    return:
+                                   'kappaStart': 0.0,
+
+                                   'phiStart': 0.0,
+
+                                   'start_image_number': 1,
+
+                                   'number_of_images': 1,
+
+                                   'overlap': 0.0,
+
+                                   'start': 0.0,
+
+                                   'range': 1.0,
+
+                                   'number_of_passes': 1}],
+
           'nb_sum_images': 0,
+
           'EDNA_files_dir': '',
+
           'anomalous': 'False',
+
           'file_exists': 0,
+
           'experiment_type': 'SAD',
-          'skip_images': 0}]"""
+
+          'skip_images': 0}]
+    """
 
     acquisition = data_collection.acquisitions[0]
     acq_params = acquisition.acquisition_parameters
@@ -2749,7 +2739,10 @@ def create_inverse_beam_sw(num_images, sw_size, osc_range, osc_start, run_number
     Creates subwedges for inverse beam, and interleves the result.
     Wedges W1 and W2 are created 180 degres apart, the result is
     interleaved and given on the form:
-    (W1_1, W2_1), ... (W1_n-1, W2_n-1), (W1_n, W2_n)
+
+    - (W1_1, W2_1), ...
+    - (W1_n-1, W2_n-1) ...
+    - (W1_n, W2_n)
 
     :param num_images: The total number of images
     :type num_images: int
@@ -2786,27 +2779,29 @@ def create_inverse_beam_sw(num_images, sw_size, osc_range, osc_start, run_number
 def create_interleave_sw(interleave_list, num_images, sw_size):
     """
     Creates subwedges for interleved collection.
+
     Wedges W1, W2, Wm (where m is num_collections) are created:
-    (W1_1, W2_1, ..., W1_m), ... (W1_n-1, W2_n-1, ..., Wm_n-1),
-    (W1_n, W2_n, ..., Wm_n)
+
+    - (W1_1, W2_1, ... W1_m)
+    - (W1_n-1, W2_n-1, ..., Wm_n-1)
+    - (W1_n, W2_n, ..., Wm_n)
 
     :param interleave_list: list of interleaved items
     :type interleave_list: list of dict
-
     :param num_images: number of images of first collection. Based on the
-    first collection certain number of subwedges will be created. If
-    first collection contains more images than others then in the end
-    the rest of images from first collections are created as last subwedge
-    :type num_images: int
+                     first collection certain number of subwedges will be created. If
+                     first collection contains more images than others then in the end
+                     the rest of images from first collections are created as last subwedge.
 
+    :type num_images: int
     :param sw_size: Number of images in each subwedge
     :type sw_size: int
-
     :returns: A list of tuples containing the swb wedges.
               The tuples are in the form:
               (collection_index, subwedge_index, subwedge_firt_image,
-               subwedge_start_osc)
+              subwedge_start_osc)
     :rtype: List [(...), (...)]
+
     """
     subwedges = []
     sw_first_image = None


### PR DESCRIPTION
I do not see any of the errors with docstrings when i run ``make html``
It was mostly to add a line between the first line description and the Args line.
Any file with an example for the xml configuration file was an issue, black and sphinx are not playing well. To fix this I use a block but I need everything to have the same indentation . 
That being said , It is displaying well in the docs.
 
@fabcor-maxiv How did you get the nice output in issue #894? 

On one hand  a block need to have everything with the same indent but just putting a line block for every line keeps the indentation but not as pretty

```
<device class="BlissActuator">
<username>Detector Cover</username>
<object href="/bliss" role="controller"/>
</device>
```

```
<device class="BlissActuator">
    <username>Detector Cover</username>
    <object href="/bliss" role="controller"/>
</device>
```

On my side, when I run ``make html`` , the error are mostly red like below
 WARNING: autosummary: failed to import mxcubecore.Command.exporter.MDEvents.

preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [100%] dev/autosummary/mxcubecore.HardwareObjects.BlissActuator
generating indices... genindex py-modindex done
highlighting module code... [100%] mxcubecore.utils.dataobject
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 107 warnings.