### PR TITLE
Use capitalized PowerOn/PowerOff commands in SC maint hwobjs

### DIFF
--- a/mxcubecore/HardwareObjects/ISARAMaint.py
+++ b/mxcubecore/HardwareObjects/ISARAMaint.py
@@ -68,8 +68,8 @@ class ISARAMaint(Equipment):
         super().__init__(name)
 
         self._commands_state = dict(
-            powerOn=False,
-            powerOff=False,
+            PowerOn=False,
+            PowerOff=False,
             openLid=True,
             closeLid=True,
             home=True,
@@ -128,8 +128,8 @@ class ISARAMaint(Equipment):
         #
         # update 'power' commands
         #
-        self._commands_state["powerOn"] = not self._powered
-        self._commands_state["powerOff"] = self._powered
+        self._commands_state["PowerOn"] = not self._powered
+        self._commands_state["PowerOff"] = self._powered
 
         #
         # update 'positions' commands
@@ -188,9 +188,9 @@ class ISARAMaint(Equipment):
             raise RuntimeError(f"Can't power {state} sample changer, {isara_err}.")
 
     def send_command(self, cmd_name, _args=None):
-        if cmd_name == "powerOn":
+        if cmd_name == "PowerOn":
             self._toggle_power(True)
-        elif cmd_name == "powerOff":
+        elif cmd_name == "PowerOff":
             self._toggle_power(False)
         elif cmd_name == "openLid":
             self.isara_dev.OpenLid()
@@ -221,8 +221,8 @@ class ISARAMaint(Equipment):
             [
                 "Power",
                 [
-                    ["powerOn", "PowerOn", "Switch Power On"],
-                    ["powerOff", "PowerOff", "Switch Power Off"],
+                    ["PowerOn", "PowerOn", "Switch Power On"],
+                    ["PowerOff", "PowerOff", "Switch Power Off"],
                 ],
             ],
             [

--- a/mxcubecore/HardwareObjects/mockup/CatsMaintMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/CatsMaintMockup.py
@@ -291,8 +291,8 @@ class CatsMaintMockup(Equipment):
         }
 
         cmd_state = {
-            "powerOn": (not self._powered) and _ready,
-            "powerOff": (self._powered) and _ready,
+            "PowerOn": (not self._powered) and _ready,
+            "PowerOff": (self._powered) and _ready,
             "regulon": (not self._regulating) and _ready,
             "openlid1": (not self._lid1state) and self._powered and _ready,
             "closelid1": self._lid1state and self._powered and _ready,
@@ -321,8 +321,8 @@ class CatsMaintMockup(Equipment):
             [
                 "Power",
                 [
-                    ["powerOn", "PowerOn", "Switch Power On"],
-                    ["powerOff", "PowerOff", "Switch Power Off"],
+                    ["PowerOn", "PowerOn", "Switch Power On"],
+                    ["PowerOff", "PowerOff", "Switch Power Off"],
                     ["regulon", "Regulation On", "Swich LN2 Regulation On"],
                 ],
             ],
@@ -396,9 +396,9 @@ class CatsMaintMockup(Equipment):
             else:
                 raise Exception("Cannot detect type of TOOL in Cats. Command ignored")
 
-        if cmd_name == "powerOn":
+        if cmd_name == "PowerOn":
             self._do_power_state(True)
-        if cmd_name == "powerOff":
+        if cmd_name == "PowerOff":
             self._do_power_state(False)
 
         if cmd_name == "regulon":

--- a/test/pytest/test_hwo_isara_maint.py
+++ b/test/pytest/test_hwo_isara_maint.py
@@ -172,8 +172,8 @@ def test_power_on_home(isara_maint: ISARAMaint):
     #
     _, commands_state, message = isara_maint.get_global_state()
     assert commands_state == dict(
-        powerOn=False,
-        powerOff=True,
+        PowerOn=False,
+        PowerOff=True,
         openLid=True,
         closeLid=True,
         home=False,
@@ -200,7 +200,7 @@ def test_power_off(isara_maint: ISARAMaint):
     cb_tracker.wait_for_callback()
 
     # issue 'power off' command
-    isara_maint.send_command("powerOff")
+    isara_maint.send_command("PowerOff")
     cb_tracker.wait_for_callback()
 
     #
@@ -208,8 +208,8 @@ def test_power_off(isara_maint: ISARAMaint):
     #
     _, commands_state, _ = isara_maint.get_global_state()
     assert commands_state == dict(
-        powerOn=True,
-        powerOff=False,
+        PowerOn=True,
+        PowerOff=False,
         openLid=True,
         closeLid=True,
         home=False,
@@ -299,7 +299,7 @@ def test_manual_mode_error(isara_maint: ISARAMaint):
     # trying to power on or off the robot, should generate an appropriate error message
     #
     with pytest.raises(RuntimeError, match="power off .*not in remote mode"):
-        isara_maint.send_command("powerOff")
+        isara_maint.send_command("PowerOff")
 
     with pytest.raises(RuntimeError, match="power on .*not in remote mode"):
-        isara_maint.send_command("powerOn")
+        isara_maint.send_command("PowerOn")


### PR DESCRIPTION
The mxcubeweb have changed the capitalization of power commands:
    
      powerOn -> PowerOn
      powerOff -> PowerOff
    
Update ISARCatsMaint and CatsMaintMockup hardware objects to use the new capitalization.