### PR TITLE
bring back 'Ring Current' widget in mocked beamline

### DIFF
--- a/mxcubecore/HardwareObjects/mockup/MachineInfoMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/MachineInfoMockup.py
@@ -10,10 +10,8 @@ information by :
 
     - produces a current value that varies with time
     - simulates a control room message that changes with some condition
-      ()
-    - simulates
 
-[Emited signals]
+[Emitted signals]
 machInfoChanged
    pars:  values (dict)
 

--- a/mxcubecore/HardwareObjects/mockup/MachineInfoMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/MachineInfoMockup.py
@@ -88,7 +88,7 @@ class MachineInfoMockup(AbstractMachineInfo):
             values["attention"] = self.attention
             self._mach_info_dict = values
 
-            self.emit("machInfoChanged", values)
+            self.emit("valueChanged", values)
 
     def get_current(self) -> float:
         """Override method."""


### PR DESCRIPTION
Emit 'valueChanged' signal when mocked Machine Info state changes. Seems that 'machInfoChanged' signal have been replaced depricated in favour of 'valueChanged'.
    
This brings back 'Ring Current' widget when running MXCuBE agains the mocked beamline.

Also, fixes some typos in the docs string.
