### PR TITLE
Tango poller: retry reading on tango errors

### DIFF
--- a/mxcubecore/Command/Tango.py
+++ b/mxcubecore/Command/Tango.py
@@ -159,7 +159,7 @@ class TangoChannel(ChannelObject):
         username=None,
         polling=None,
         timeout=10000,
-        **kwargs
+        **kwargs,
     ):
         ChannelObject.__init__(self, name, username, **kwargs)
 
@@ -173,13 +173,6 @@ class TangoChannel(ChannelObject):
         self.timeout = int(timeout)
         self.read_as_str = kwargs.get("read_as_str", False)
         self._device_initialized = gevent.event.Event()
-        #logging.getLogger("HWR").debug(
-        #    "creating Tango attribute %s/%s, polling=%s, timeout=%d",
-        #    self.device_name,
-        #    self.attribute_name,
-        #    polling,
-        #    self.timeout,
-        #)
         self.init_device()
         self.continue_init(None)
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,6 @@ force-exclude = '''
 #
   | deprecated/HardwareObjects/SpecScan.py
   | deprecated/HardwareObjects/mockup/MultiCollectMockup.py
-  | mxcubecore/Command/Tango.py
   | mxcubecore/HardwareObjects/ALBA/ALBAEpsActuator.py
   | mxcubecore/HardwareObjects/ALBA/ALBAFastShutter.py
   | deprecated/HardwareObjects/Server/__init__.py


### PR DESCRIPTION
When polling tango attributes, catch tango communication errors. On error, log a warning and try again reading the attribute again. In our case, we need this for a tango device that intermittently replies slowly, thus causing timeout errors.

As a small bonus, I tacked on changes to make mxcubecore/Command/Tango.py black compliant. 