### PR TITLE
Lint YAML files with `yamllint`

### DIFF
--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -1,15 +1,22 @@
+---
+
 name: Coverage Report
-on:
+
+on:  # yamllint disable-line rule:truthy
   pull_request:
     types: [opened, reopened, synchronize]
     paths:
       - '**.py'
+
 jobs:
   pytest-coverage:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+
     steps:
+
+    # yamllint disable-line rule:indentation
     - uses: actions/checkout@v3
 
     - name: Set up Python 3.10
@@ -18,16 +25,20 @@ jobs:
         python-version: "3.10"
 
     - name: Install dependencies
+      # yamllint disable rule:line-length
       run: |
         sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev
         python -m pip install --upgrade pip
         python -m pip install poetry --user
         python -m poetry install --extras=tango
+      # yamllint enable rule:line-length
 
     - name: Run and write pytest
+      # yamllint disable rule:line-length
       run: |
         set -o pipefail
         poetry run pytest --cov=mxcubecore --junitxml=pytest.xml --cov-report=term-missing:skip-covered | tee pytest-coverage.txt
+      # yamllint enable rule:line-length
 
     - name: Pytest coverage comment
       id: coverage-comment

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,5 +1,7 @@
+---
+
 name: Create/Update Tag
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - develop
@@ -7,6 +9,7 @@ jobs:
   create-version-tag:
     runs-on: ubuntu-latest
     steps:
+    # yamllint disable-line rule:indentation
     - uses: actions/checkout@v3
       with:
         token: ${{ secrets.CI_TOKEN }}
@@ -34,10 +37,12 @@ jobs:
         poetry publish
     - name: Read package version
       id: set-tag
+      # yamllint disable rule:line-length
       run: |
         pip install --upgrade pip
         pip install toml
         echo ::set-output name=tag_name::v$(python -c 'import toml; print(toml.load("./pyproject.toml")["tool"]["poetry"]["version"])')
+      # yamllint enable rule:line-length
 
     - name: Check tag exists
       id: check-tag-exists

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -6,7 +6,7 @@ name: "Pages"
 concurrency:
   group: "pages"
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
   pull_request:
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,29 +1,37 @@
+---
+
 name: Linting & Code Quality
-on:
+
+on:  # yamllint disable-line rule:truthy
   pull_request:
     types: [opened, reopened, synchronize]
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v3
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.8"
+      - uses: actions/checkout@v3
 
-    - name: Install openldap
-      run: |
-        sudo apt-get update && sudo apt-get upgrade -y
-        sudo apt-get install -y libldap2-dev libsasl2-dev slapd ldap-utils tox lcov valgrind
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install poetry --user
-        python -m poetry install
+      - name: Install openldap
+        # yamllint disable rule:line-length
+        run: |
+          sudo apt-get update && sudo apt-get upgrade -y
+          sudo apt-get install -y libldap2-dev libsasl2-dev slapd ldap-utils tox lcov valgrind
+        # yamllint enable rule:line-length
 
-    - name: Run Pre-Commit
-      run: |
-        poetry run pre-commit run --all-files
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry --user
+          python -m poetry install
+
+      - name: Run Pre-Commit
+        run: |
+          poetry run pre-commit run --all-files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
+---
+
 name: Pytest
-on:
+on:  # yamllint disable-line rule:truthy
   pull_request:
     types: [opened, reopened, synchronize]
     paths:
@@ -19,6 +21,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install openldap
+        # yamllint disable-line rule:line-length
         run: sudo apt-get update && sudo apt-get install -y libldap2-dev libsasl2-dev slapd ldap-utils tox lcov valgrind
 
       - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,22 @@
+---
+
 default_language_version:
   python: python3.8
+
 repos:
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args:
+          - --strict
+
   - repo: https://github.com/python-poetry/poetry
     rev: 1.5.0
     hooks:
       - id: poetry-check
-#      - id: poetry-lock
+
   - repo: https://github.com/myint/autoflake
     rev: v1.6.0
     hooks:
@@ -17,19 +28,19 @@ repos:
           - --in-place
           - --remove-duplicate-keys
           - --ignore-pass-after-docstring
+
   - repo: https://github.com/psf/black
     rev: 22.8.0
     hooks:
-    - id: black
-      name: Black
+      - id: black
+        name: Black
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
       - id: trailing-whitespace
-        #
-        # Exclude files below from trailing-whitespace checks until we get around fixing them.
-        # This way we can check that all other files are trailing-whitespace clean in CI.
-        #
+        # Exclude files from trailing-whitespace checks until we get around fixing them.
+        # This way we can check that other files are trailing-whitespace clean in CI.
         exclude: |
             (?x)^(
                 mxcubecore/configuration/.*|
@@ -47,10 +58,8 @@ repos:
                 mxcubecore/HardwareObjects/ESRF/ID29XRFSpectrum\.py
             )$
       - id: end-of-file-fixer
-        #
-        # Exclude files below from end-of-file-fixer checks until we get around fixing them.
-        # This way we can check that all other files are end-of-file-fixer clean in CI.
-        #
+        # Exclude files from end-of-file-fixer checks until we get around fixing them.
+        # This way we can check that other files are end-of-file-fixer clean in CI.
         exclude: |
             (?x)^(
                 mxcubecore/configuration/.*|
@@ -60,7 +69,7 @@ repos:
             )$
       - id: check-case-conflict
       - id: check-merge-conflict
-        # exclude files where underlines are not distinguishable from merge conflicts
+        # Exclude files where underlines are not distinguishable from merge conflicts.
         exclude: /README\.rst$|^docs/.*\.rst$
       - id: check-symlinks
       - id: check-xml
@@ -68,18 +77,3 @@ repos:
         exclude: ^.drone\.yml
       - id: mixed-line-ending
         args: ["--fix=lf"]
-  # - repo: https://github.com/PyCQA/isort
-  #   rev: 5.10.1
-  #   hooks:
-  #     - id: isort
-  #       name: Import Sort
-  #       args:
-  #         - --settings=.
-  #       exclude: (/__init__\.py$|deprecated/|mxcubecore/HardwareObjects/(ALBA|ASLS|DESY|EMBL|ESRF|LNLS|MAXIV|SOLEIL|ANSTO|Gphl|Arinax))
-  # - repo: https://github.com/PyCQA/flake8
-  #   rev: 4.0.1
-  #   hooks:
-  #   - id: flake8
-  #     name: Flake8
-  #     additional_dependencies: ["flake8-bugbear==22.9.11"]
-  #     exclude: (utils/pyispyb_client/|deprecated/|mxcubecore/HardwareObjects/(ALBA|ASLS|DESY|EMBL|ESRF|LNLS|MAXIV|SOLEIL|ANSTO|Gphl|Arinax))

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,6 +25,7 @@ build:
     - "git fetch --unshallow || true"
     - "mamba env create --file conda-environment-dev.yml --force"
     - "mamba run --name mxcubecore poetry install --only=docs,main"
+    # yamllint disable-line rule:line-length
     - "mamba run --name mxcubecore sphinx-build -T -E -b html -c ./docs/ ./docs/source/ ${READTHEDOCS_OUTPUT}/html/"
 
 

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+---
+
+extends: default
+
+rules:
+  # Match line length to the one set by `black` the Python formatter
+  line-length:
+    max: 88

--- a/conda-environment-dev.yml
+++ b/conda-environment-dev.yml
@@ -1,3 +1,5 @@
+---
+
 name: mxcubecore
 channels:
   - conda-forge

--- a/mxcubecore/configuration/alba_xaloc13/beamline_config.yml
+++ b/mxcubecore/configuration/alba_xaloc13/beamline_config.yml
@@ -1,3 +1,8 @@
+---
+
+# yamllint disable rule:comments-indentation
+# yamllint disable rule:indentation
+
 # FIRST DRAFT of ALAB xaloc13 configuration. TO BE EDITED
 
 # The class to initialise, and init parameters
@@ -15,8 +20,8 @@ _initialise_class:
 # would need those added (e.g. the centring methods)
 #
 _objects:
-    # The !!o0map and the lines starting with '- ' give you an *orderd* dictionary
-    # And thus a reproducible loading order
+  # The !!o0map and the lines starting with '- ' give you an *orderd* dictionary
+  # And thus a reproducible loading order
   !!omap
     # The values are the file paths to the configuration file for the
     # object, relative to the configuration file path(s)
@@ -103,7 +108,7 @@ acquisition_limit_values:
         - 6000.0
     osc_range:         # (degrees)
         - -2165.0
-        -  2165.0
+        - 2165.0
     number_of_images:  # (int)
         - 1
         - 9999

--- a/mxcubecore/configuration/embl_hh_p14/beamline_config.yml
+++ b/mxcubecore/configuration/embl_hh_p14/beamline_config.yml
@@ -1,3 +1,5 @@
+---
+
 # FIRST DRAFT of EMBL P14 configuration. TO BE EDITED
 
 # The class to initialise, and init parameters
@@ -54,7 +56,7 @@ _objects:
     - image_tracking: image-tracking.xml
     - gphl_workflow: gphl-workflow.xml
     - gphl_connection: gphl-setup.xml
-#    - centring: centring.xml
+    # - centring: centring.xml
     # Analysis:
     - offline_processing: auto-processing.xml
     - online_processing: parallel-processing.xml
@@ -64,8 +66,8 @@ _objects:
     - ppu_control: ppu_control.xml
 # Non-object attributes:
 advanced_methods:
-  - MeshScan
-  - XrayCentering
+    - MeshScan
+    - XrayCentering
 tunable_wavelength: true
 disable_num_passes: false
 run_online_processing: true

--- a/mxcubecore/configuration/esrf_id30a2/gphl-setup.yml
+++ b/mxcubecore/configuration/esrf_id30a2/gphl-setup.yml
@@ -1,3 +1,8 @@
+---
+
+# yamllint disable rule:comments
+# yamllint disable rule:comments-indentation
+# yamllint disable rule:line-length
 
 _initialise_class:
     class: mxcubecore.HardwareObjects.Gphl.GphlWorkflowConnection.GphlWorkflowConnection

--- a/mxcubecore/configuration/esrf_id30a2/gphl-workflow.yml
+++ b/mxcubecore/configuration/esrf_id30a2/gphl-workflow.yml
@@ -1,3 +1,10 @@
+---
+
+# yamllint disable rule:comments-indentation
+# yamllint disable rule:hyphens
+# yamllint disable rule:indentation
+# yamllint disable rule:line-length
+
 _initialise_class:
     class: mxcubecore.HardwareObjects.Gphl.GphlWorkflow.GphlWorkflow
 

--- a/mxcubecore/configuration/lnls_manaca/beamline_config.yml
+++ b/mxcubecore/configuration/lnls_manaca/beamline_config.yml
@@ -1,3 +1,5 @@
+---
+
 # The class to initialise, and init parameters
 _initialise_class:
     class: mxcubecore.HardwareObjects.Beamline.Beamline
@@ -49,9 +51,9 @@ _objects:
     - collect: mxcollect.xml
     - xrf_spectrum: xrf.xml
     - energy_scan: energyscan.xml
-#    - gphl_workflow: gphl-workflow.xml
-#    - gphl_connection: gphl-setup.xml
-#    - centring: centring.xml
+    # - gphl_workflow: gphl-workflow.xml
+    # - gphl_connection: gphl-setup.xml
+    # - centring: centring.xml
     # Analysis:
     - offline_processing: auto_processing.xml
     - online_processing: parallel_processing.xml
@@ -63,8 +65,8 @@ _objects:
 
 # Non-object attributes:
 advanced_methods:
-  - MeshScan
-  - XrayCentering
+    - MeshScan
+    - XrayCentering
 
 tunable_wavelength: true
 disable_num_passes: true
@@ -83,7 +85,7 @@ default_acquisition_parameters:
         first_image: 1
         overlap: 0
         num_images: 1
-        detector_mode: 1 # Remove as not in practice used ?
+        detector_mode: 1  # Remove as not in practice used ?
         inverse_beam: false
         take_dark_current: true
         skip_existing_images: true
@@ -125,11 +127,11 @@ acquisition_limit_values:
         - 240.0
 
 available_methods:
-    datacollection: True
-    characterisation: True
-    helical: True
-    xrf_scan: True
-    energy_scan: True
+    datacollection: True  # yamllint disable-line rule:truthy
+    characterisation: True  # yamllint disable-line rule:truthy
+    helical: True  # yamllint disable-line rule:truthy
+    xrf_scan: True  # yamllint disable-line rule:truthy
+    energy_scan: True  # yamllint disable-line rule:truthy
     mesh_scan: fals
 
 undulators:

--- a/mxcubecore/configuration/lnls_sol/beamline_config.yml
+++ b/mxcubecore/configuration/lnls_sol/beamline_config.yml
@@ -1,3 +1,7 @@
+---
+
+# yamllint disable rule:comments-indentation
+
 # The class to initialise, and init parameters
 _initialise_class:
     class: mxcubecore.HardwareObjects.Beamline.Beamline
@@ -63,8 +67,8 @@ _objects:
 
 # Non-object attributes:
 advanced_methods:
-  - MeshScan
-  - XrayCentering
+    - MeshScan
+    - XrayCentering
 
 tunable_wavelength: true
 disable_num_passes: true
@@ -83,7 +87,7 @@ default_acquisition_parameters:
         first_image: 1
         overlap: 0
         num_images: 1
-        detector_mode: 1 # Remove as not in practice used ?
+        detector_mode: 1  # Remove as not in practice used ?
         inverse_beam: false
         take_dark_current: true
         skip_existing_images: true
@@ -125,11 +129,11 @@ acquisition_limit_values:
         - 240.0
 
 available_methods:
-    datacollection: True
-    characterisation: True
-    helical: True
-    xrf_scan: True
-    energy_scan: True
+    datacollection: True  # yamllint disable-line rule:truthy
+    characterisation: True  # yamllint disable-line rule:truthy
+    helical: True  # yamllint disable-line rule:truthy
+    xrf_scan: True  # yamllint disable-line rule:truthy
+    energy_scan: True  # yamllint disable-line rule:truthy
     mesh_scan: fals
 
 undulators:

--- a/mxcubecore/configuration/mockup/gphl/gphl-setup.yml
+++ b/mxcubecore/configuration/mockup/gphl/gphl-setup.yml
@@ -1,3 +1,7 @@
+---
+
+# yamllint disable rule:comments
+# yamllint disable rule:line-length
 
 _initialise_class:
     class: mxcubecore.HardwareObjects.Gphl.GphlWorkflowConnection.GphlWorkflowConnection
@@ -5,8 +9,8 @@ _initialise_class:
 directory_locations:
     # Directory locations. Can also be used with ${} syntax in this file
     GPHL_INSTALLATION: /alt/rhfogh/Software/GPhL/gphl_release
-#    GPHL_INSTALLATION: /alt/rhfogh/Software/GPhL/nightly_20230823/Files_workflow_TRUNK_alpha-bdg
-#    GPHL_INSTALLATION: /alt/rhfogh/Software/GPhL/nightly_20230602/Files_workflow_BETA_beta-academic
+    # GPHL_INSTALLATION: /alt/rhfogh/Software/GPhL/nightly_20230823/Files_workflow_TRUNK_alpha-bdg
+    # GPHL_INSTALLATION: /alt/rhfogh/Software/GPhL/nightly_20230602/Files_workflow_BETA_beta-academic
 
 
 # If set, run workflow through ssh with selected options

--- a/mxcubecore/configuration/mockup/gphl/gphl-workflow.yml
+++ b/mxcubecore/configuration/mockup/gphl/gphl-workflow.yml
@@ -1,3 +1,11 @@
+---
+
+# yamllint disable rule:comments-indentation
+# yamllint disable rule:indentation
+# yamllint disable rule:hyphens
+# yamllint disable rule:line-length
+
+
 _initialise_class:
     class: mxcubecore.HardwareObjects.Gphl.GphlWorkflow.GphlWorkflow
 

--- a/mxcubecore/configuration/mockup/gphl/gphl_wf_automation_interface.yml
+++ b/mxcubecore/configuration/mockup/gphl/gphl_wf_automation_interface.yml
@@ -1,3 +1,8 @@
+---
+
+  # yamllint disable rule:comments-indentation
+  # yamllint disable rule:line-length
+
   ### Calling interface (for automation)
   # This section is specific to the automated MXCuBE-web version, intended for MASSIF-1.
   # It shows the interfaces between the Global Phasing workflow and a calling
@@ -7,34 +12,35 @@
   # The parameters are a node ID and a task dictionary.
   # The parameters relevant for GΦL  are, in yaml notation:
 
+  # yamllint disable-line rule:indentation
   task:
 
     parameters:
       # Process control and ???
-      wfpath: Gphl			# Mandatory – specifies  GΦL workflow
-      automation_mode: MASSIF1	# Optional,  defaults to None (manual)
-      shape:  some_shape_name		# Used for EDNA workflow, I do not know  what for
+      wfpath: Gphl  # Mandatory – specifies  GΦL workflow
+      automation_mode: MASSIF1  # Optional,  defaults to None (manual)
+      shape: some_shape_name  # Used for EDNA workflow, I do not know  what for
 
       # Strategy control
-      strategy_name:  "Native data collection"	# (str) Mandatory.
+      strategy_name: "Native data collection"  # (str) Mandatory.
       # Options are: ‘Native data collection’, ‘Phasing (SAD)’
       # ‘Two-wavelength MAD’, ‘Three-wavelength MAD’, ‘Diffractometer calibration’
 
       # directory and file names. All optional, default to session default
       # See File Locations in manual
-      prefix: <path_template.base_prefix>		# (str)
-      suffix: <path_template.suffix>		# (str) Optional
-      subdir: <Image path subdirectory>		# (str) Optional
+      prefix: <path_template.base_prefix>  # (str)
+      suffix: <path_template.suffix>  # (str) Optional
+      subdir: <Image path subdirectory>  # (str) Optional
 
       # Optional, overriding configured defaults:
-      decay_limit: 25	#  (%).
+      decay_limit: 25  # (%).
       # Minimum % intensity remaining at target resolution if using recommended dose budget
       # dose_budget = 2 * resolution**2 * log(100. / decay_limit) / relative_sensitivity
-      maximum_dose_budget: 20	# (MGy). Maximum when calculating budget from resolution
-      characterisation_budget_fraction: 0.05	# Dose to use for characterisation
+      maximum_dose_budget: 20  # (MGy). Maximum when calculating budget from resolution
+      characterisation_budget_fraction: 0.05  # Dose to use for characterisation
 
       # Strategy name, matching strategylib.nml.
-      auto_acq_parameters: # (list of dict) automation parameters for acquisitions. Optional.
+      auto_acq_parameters:  # (list of dict) automation parameters for acquisitions. Optional.
         # The standard workflows have two acquisitions, characterisation and main;
         # diffractometer calibration has only one, and future workflows may have more.
         # The dictionaries are applied to the acquisitions in order;
@@ -48,7 +54,7 @@
         # init_spot_dir, if set, turns off the workflow-driven characterisation
         # resolution, energies, and transmission are taken from the current values in this case
         # unless explicitly set
-        - exposure_time: 0.04 # (s) Optional, default configured. Mandatory if init_spot_dir is set
+        - exposure_time: 0.04  # (s) Optional, default configured. Mandatory if init_spot_dir is set
           image_width: 0.1    # (°) Optional, default configured. Mandatory if init_spot_dir is set
 #          use_dose: 20.0 # (MGy) NB Optional, for entire experiment. Overrides, dose budget
 #          transmission: 100.0 # (%) NB Optional  Overrides use_dose. Defaults to current valuee if init_spot_dir is set
@@ -72,17 +78,17 @@
         # This example lists all options, for documentation purposes
         # All are optional (except when init_spot_dir is set) and should normally
         # be left empty so the default is used.
-        - resolution: 1.7 # (Å) Optional. Defaults to current value, or to diffraction plan aimed_resolution
-          energies: (12.4,) # tuple(keV) List of energies  to use in experiment. two or three for MAD (only).
+        - resolution: 1.7  # (Å) Optional. Defaults to current value, or to diffraction plan aimed_resolution
+          energies: (12.4,)  # tuple(keV) List of energies  to use in experiment. two or three for MAD (only).
           # First wavelength will be used for calculating strategies, dose budget, etc.
           # Optional, except for MAD - will default to current beamline energy.
-          exposure_time: 0.04 # (s) Optional, default configured. Mandatory if init_spot_dir is set
-          image_width: 0.1    # (°) Optional, default configured. Mandatory if init_spot_dir is set
-          wedge_width: 15.0 # (°)  Optional, default configured. Wedge  width (for interleaving)
-          snapshot_count: 2 # Optional, default configured.
-          use_dose: 20.0 # (MGy) NB Optional, for entire experiment. Defaults to calculated dose budget
+          exposure_time: 0.04  # (s) Optional, default configured. Mandatory if init_spot_dir is set
+          image_width: 0.1  # (°) Optional, default configured. Mandatory if init_spot_dir is set
+          wedge_width: 15.0  # (°)  Optional, default configured. Wedge  width (for interleaving)
+          snapshot_count: 2  # Optional, default configured.
+          use_dose: 20.0  # (MGy) NB Optional, for entire experiment. Defaults to calculated dose budget
           # and resets transmission and maybe exposure time
-          transmission: 80.0 # (%) NB Optional  Overrides use_dose. Defaults to current valuee if init_spot_dir is set
+          transmission: 80.0  # (%) NB Optional  Overrides use_dose. Defaults to current valuee if init_spot_dir is set
           # Otherwise is set from dose budget and resolution.
           # If set this value will reset the dose budget
           # Strategy variant
@@ -94,12 +100,12 @@
           # startign point. Used to override XDS cell, symmetry determination
           use_cell_for_processing: false
 
-          strategy_options: # (dict) parameters strategy calculation (stratcal). See below
+          strategy_options:  # (dict) parameters strategy calculation (stratcal). See below
 
 #             strategy options. Control the stratcal strategy calculation program.
 #             maximum_chi is automaticaly reduced to match kappa motor limits.
             maximum_chi: 48.0  # (°) Optional. Maximum chi value allowed for strategies. Default 48
-            angular tolerance: 1.0 # (°) Optional. Tolerance to distinguish strategy orientations
+            angular tolerance: 1.0  # (°) Optional. Tolerance to distinguish strategy orientations
 
     # Other parameters are set (ultimately) from ISPyB. These are all optional:
     # From crystal description:

--- a/mxcubecore/configuration/mockup/gphl/gphl_wf_test_parameters.yml
+++ b/mxcubecore/configuration/mockup/gphl/gphl_wf_test_parameters.yml
@@ -1,3 +1,11 @@
+---
+
+  # yamllint disable rule:colons
+  # yamllint disable rule:comments
+  # yamllint disable rule:comments-indentation
+  # yamllint disable rule:indentation
+  # yamllint disable rule:line-length
+
   ### Calling interface (for automation)
   # This section is specific to the automated MXCuBE-web version, intended for MASSIF-1.
   # It shows the interfaces between the Global Phasing workflow and a calling
@@ -119,6 +127,7 @@
 # and resets transmission and maybe exposure time
 #          repetition_count: 1
 #          snapshot_count: 2
+          # yamllint disable-line rule:truthy
           skip_collection: True  # Causes GPhL collection simulation (only!) to do nothing
 
     # Other parameters are set (ultimately) from ISPyB. These are all optional:

--- a/mxcubecore/configuration/mockup/procedure-mockup.yml
+++ b/mxcubecore/configuration/mockup/procedure-mockup.yml
@@ -1,3 +1,5 @@
+---
+
 # The class to initialise, and init parameters
 _initialise_class:
     class: mxcubecore.HardwareObjects.mockup.ProcedureMockup.ProcedureMockup

--- a/mxcubecore/configuration/mockup/qt/beamline_config.yml
+++ b/mxcubecore/configuration/mockup/qt/beamline_config.yml
@@ -1,3 +1,8 @@
+---
+
+# yamllint disable rule:comments-indentation
+# yamllint disable rule:indentation
+
 # The class to initialise, and init parameters
 _initialise_class:
     class: mxcubecore.HardwareObjects.Beamline.Beamline
@@ -89,8 +94,8 @@ default_acquisition_parameters:
     characterisation:
         # Defaults for chareacterisation. Missing values are taken from default
         osc_range: 1
-        opt_sad: False
-        account_rad_damage: True
+        opt_sad: False  # yamllint disable-line rule:truthy
+        account_rad_damage: True  # yamllint disable-line rule:truthy
         strategy_complexity: 0
         max_crystal_vdim: 1.0
         min_crystal_vdim: 1.0

--- a/mxcubecore/configuration/mockup/test/beamline_config.yml
+++ b/mxcubecore/configuration/mockup/test/beamline_config.yml
@@ -1,3 +1,8 @@
+---
+
+# yamllint disable rule:comments
+# yamllint disable rule:comments-indentation
+
 # The class to initialise, and init parameters
 _initialise_class:
     class: mxcubecore.HardwareObjects.Beamline.Beamline
@@ -58,8 +63,8 @@ _objects:
     - mock_procedure: procedure-mockup.yml
 # Non-object attributes:
 advanced_methods:
-  - MeshScan
-  - XrayCentering
+    - MeshScan
+    - XrayCentering
 tunable_wavelength: true
 disable_num_passes: false
 run_online_processing: false

--- a/mxcubecore/configuration/mockup/web/beamline_config.yml
+++ b/mxcubecore/configuration/mockup/web/beamline_config.yml
@@ -1,3 +1,6 @@
+---
+
+
 # The class to initialise, and init parameters
 _initialise_class:
     class: mxcubecore.HardwareObjects.Beamline.Beamline
@@ -46,7 +49,7 @@ _objects:
     - collect: collect-mockup.xml
     - xrf_spectrum: xrf-spectrum-mockup.xml
     - energy_scan: energyscan-mockup.xml
-#    - imaging: xray-imaging.xml # Only in EMBL as of 201907
+    # - imaging: xray-imaging.xml # Only in EMBL as of 201907
     - gphl_connection: gphl-setup.yml
     - gphl_workflow: gphl-workflow.yml
     # - centring: centring.xml
@@ -57,8 +60,8 @@ _objects:
     # - beam_realign: # Skipped - optional
 # Non-object attributes:
 advanced_methods:
-  - MeshScan
-  - XrayCentering
+    - MeshScan
+    - XrayCentering
 tunable_wavelength: true
 disable_num_passes: false
 run_online_processing: false
@@ -88,8 +91,8 @@ default_acquisition_parameters:
     characterisation:
         # Defaults for chareacterisation. Missing values are taken from default
         osc_range: 1
-        opt_sad: False
-        account_rad_damage: True
+        opt_sad: False  # yamllint disable-line rule:truthy
+        account_rad_damage: True  # yamllint disable-line rule:truthy
         strategy_complexity: 0
         strategy_program: Optimal
         max_crystal_vdim: 1.0

--- a/mxcubecore/configuration/mockup/xray_centring2.yml
+++ b/mxcubecore/configuration/mockup/xray_centring2.yml
@@ -1,2 +1,4 @@
+---
+
 _initialise_class:
   class: mxcubecore.HardwareObjects.mockup.XrayCentringMockup.XrayCentringMockup

--- a/mxcubecore/configuration/soleil_px1/beamline_config.yml
+++ b/mxcubecore/configuration/soleil_px1/beamline_config.yml
@@ -1,3 +1,7 @@
+---
+
+# yamllint disable rule:comments-indentation
+
 # FIRST DRAFT of SOLEIL px1 configuration. TO BE EDITED
 
 # The class to initialise, and init parameters
@@ -15,8 +19,9 @@ _initialise_class:
 # would need those added (e.g. the centring methods)
 #
 _objects:
-    # The !!o0map and the lines starting with '- ' give you an *orderd* dictionary
-    # And thus a reproducible loading order
+  # The !!o0map and the lines starting with '- ' give you an *orderd* dictionary
+  # And thus a reproducible loading order
+  # yamllint disable-line rule:indentation
   !!omap
     # The values are the file paths to the configuration file for the
     # object, relative to the configuration file path(s)
@@ -58,9 +63,9 @@ _objects:
     - characterisation: data-analysis.xml
     # - beam_realign: # Skipped - optional
 # Non-object attributes:
-#advanced_methods:
-#    - MeshScan
-#    - XrayCentering
+# advanced_methods:
+#     - MeshScan
+#     - XrayCentering
 tunable_wavelength: true
 disable_num_passes: false
 run_number: 1
@@ -112,7 +117,7 @@ acquisition_limit_values:
         - 0.01
         - 10.0
     osc_range:         # (degrees)
-        -  -0.0
+        - -0.0
         - 760.0
     number_of_images:  # (int)
         - 1

--- a/mxcubecore/configuration/soleil_px2/beamline_config.yml
+++ b/mxcubecore/configuration/soleil_px2/beamline_config.yml
@@ -1,3 +1,7 @@
+---
+
+# yamllint disable rule:comments-indentation
+
 # FIRST DRAFT of SOLEIL px2 configuration. TO BE EDITED
 
 # The class to initialise, and init parameters
@@ -15,8 +19,9 @@ _initialise_class:
 # would need those added (e.g. the centring methods)
 #
 _objects:
-    # The !!o0map and the lines starting with '- ' give you an *orderd* dictionary
-    # And thus a reproducible loading order
+  # The !!o0map and the lines starting with '- ' give you an *orderd* dictionary
+  # And thus a reproducible loading order
+  # yamllint disable-line rule:indentation
   !!omap
     # The values are the file paths to the configuration file for the
     # object, relative to the configuration file path(s)
@@ -108,7 +113,7 @@ acquisition_limit_values:
         - 1
         - 99999
     kappa:             # (degrees)
-        -  -9.0
+        - -9.0
         - 240.0
 #    kappa_phi:         # (degrees)
 #        - 0.0


### PR DESCRIPTION
There is now a configuration file for `yamllint`
and a `pre-commit` hook.

Some of the most straightforward linting issues were fixed. The other ones are ignored and should be handled in the future.