### PR TITLE
[mount_sample] Simplified mount_sample and related logic - Part 1

### DIFF
--- a/mxcubecore/HardwareObjects/EMBLFlexHCD.py
+++ b/mxcubecore/HardwareObjects/EMBLFlexHCD.py
@@ -355,23 +355,6 @@ class EMBLFlexHCD(SampleChanger):
 
         self._update_selection()
 
-    @task
-    def load_sample(
-        self,
-        holderLength,
-        sample_id=None,
-        sample_location=None,
-        sampleIsLoadedCallback=None,
-        failureCallback=None,
-        prepareCentring=True,
-    ):
-        # self._assert_ready()
-        cell, basket, sample = sample_location
-        sample = self.get_component_by_address(
-            Pin.get_sample_address(cell, basket, sample)
-        )
-        return self.load(sample)
-
     def chained_load(self, old_sample, sample):
         return self._do_load(sample)
 

--- a/mxcubecore/HardwareObjects/FlexHCD.py
+++ b/mxcubecore/HardwareObjects/FlexHCD.py
@@ -286,23 +286,6 @@ class FlexHCD(SampleChanger):
 
         self._update_selection()
 
-    @task
-    def load_sample(
-        self,
-        holderLength,
-        sample_id=None,
-        sample_location=None,
-        sampleIsLoadedCallback=None,
-        failureCallback=None,
-        prepareCentring=True,
-    ):
-        self._assert_ready()
-        cell, basket, sample = sample_location
-        sample = self.get_component_by_address(
-            Pin.get_sample_address(cell, basket, sample)
-        )
-        return self.load(sample)
-
     def chained_load(self, old_sample, sample):
         self._assert_ready()
         if self.exporter_addr:

--- a/mxcubecore/HardwareObjects/GrobSampleChanger.py
+++ b/mxcubecore/HardwareObjects/GrobSampleChanger.py
@@ -153,23 +153,24 @@ class GrobSampleChanger(HardwareObject):
             self._sample_transfer_done
         )
 
-    def load_sample(
+    def load(
         self,
-        holderLength,
+        sample=None,
         sample_id=None,
-        sample_location=None,
+        holderLength=None,
         successCallback=None,
         failureCallback=None,
         prepareCentring=None,
         prepareCentringMotors={},
         prepare_centring=None,
         prepare_centring_motors=None,
+        wait=True,
     ):
         self._successCallback = successCallback
         self._failureCallback = failureCallback
         self._holderlength = holderLength
         self._sample_id = sample_id
-        self._sample_location = sample_location
+        self._sample_location = sample
 
         if self._get_loaded_sampleNum():
             self._procedure = "UNLOAD_LOAD"

--- a/mxcubecore/HardwareObjects/Harvester.py
+++ b/mxcubecore/HardwareObjects/Harvester.py
@@ -164,7 +164,6 @@ class Harvester(HardwareObject):
         return : respond
         """
         ret = None
-        timeout = kwargs.pop("timeout", 0)
         if args:
             args_str = "%s" % "\t".join(map(str, args))
         if kwargs.pop("command", None):
@@ -512,29 +511,25 @@ class Harvester(HardwareObject):
         return self._execute_cmd_exporter("getNbRemainingPins", command=True)
 
     def queue_harvest_sample(
-        self, data_model, sample_uuid: str, current_queue: dict
+        self, sample_loc_str, sample_uuid: str, current_queue_list: list[str]
     ) -> None:
         """
         While queue execution send harvest request
-        current_queue : a build representation of the queue based on
-        python dictionaries
+        current_queue_list : a build representation of the queue based
         """
 
-        current_queue_list = list(current_queue)
         current_queue_index = None
         try:
-            current_queue_index = current_queue_list.index(data_model.loc_str)
+            current_queue_index = current_queue_list.index(sample_loc_str)
         except (ValueError, IndexError):
             current_queue_index = None
 
         wait_before_load = not self.get_room_temperature_mode()
-        if sample_uuid in ["undefined", "", None]:
-            sample_uuid = current_queue[data_model.loc_str]["code"]
 
         if self.get_number_of_available_pin() > 0:
             gevent.sleep(2)
 
-            if current_queue_index == 1:
+            if current_queue_index == 0:
                 logging.getLogger("user_level_log").info("Harvesting First Sample")
 
                 harvest_res = self.harvest_sample_before_mount(
@@ -577,28 +572,13 @@ class Harvester(HardwareObject):
                 "There is no more Pins in the Harvester, Stopping queue", ""
             )
 
-    def queue_harvest_next_sample(
-        self, data_model, sample_uuid: str, current_queue: dict
-    ):
+    def queue_harvest_next_sample(self, next_sample_loc_str: str, sample_uuid: str):
         """
         While queue execution send harvest request
         on next sample of the queue list
-        current_queue : a build representation of the queue based on
-        python dictionaries
         """
-        current_queue_list = list(current_queue)
-        next_sample = None
-        try:
-            next_sample = current_queue_list[
-                current_queue_list.index(data_model.loc_str) + 1
-            ]
-        except (ValueError, IndexError):
-            next_sample = None
 
-        if sample_uuid in ["undefined", "", None]:
-            sample_uuid = current_queue[data_model.loc_str]["code"]
-
-        if next_sample is not None and self.get_number_of_available_pin() > 0:
+        if next_sample_loc_str is not None and self.get_number_of_available_pin() > 0:
             logging.getLogger("user_level_log").info("Harvesting Next Sample")
 
             self._wait_ready(None)

--- a/mxcubecore/HardwareObjects/PlateManipulator.py
+++ b/mxcubecore/HardwareObjects/PlateManipulator.py
@@ -86,13 +86,13 @@ class Xtal(Sample):
 
     def get_cell(self):
         return self.get_drop().get_cell()
-    
+
     def get_basket_no(self):
         """
         In this cas we assume a drop is a basket or puck
         """
         return self.get_drop().get_index() + 1
-    
+
     def get_cell_no(self):
         """
         In this cas we assume wells in the row is a cell
@@ -249,7 +249,7 @@ class PlateManipulator(SampleChanger):
             self.num_rows = self.get_property("numRows")
             self.num_drops = self.get_property("numDrops")
 
-        self.reference_pos_x = self.get_property("referencePosX")        
+        self.reference_pos_x = self.get_property("referencePosX")
         if not self.reference_pos_x:
             self.reference_pos_x = 0.5
 
@@ -295,13 +295,13 @@ class PlateManipulator(SampleChanger):
             return True
         else:
             raise Exception("barcode unknown")
-        
+
 
     def hw_get_loaded_sample_location(self):
         loaded_sample = None
         if(self.chan_drop_location):
             loaded_sample = self.chan_drop_location.get_value()
-        
+
             return (
                 chr(65 + loaded_sample[0])
                 + str(loaded_sample[1] +1)
@@ -398,13 +398,13 @@ class PlateManipulator(SampleChanger):
     def load(self, sample=None, wait=True):
         comp = self._resolve_component(sample)
         coords = comp.get_coords()
-        res = self.load_sample(coords)
+        res = self._load_sample(coords)
         if res:
             self._set_loaded_sample(comp)
             comp._set_loaded(True, True)
         return res
 
-    def load_sample(self, sample_location=None, pos_x=None, pos_y=None, wait=True):
+    def _load_sample(self, sample_location=None, pos_x=None, pos_y=None, wait=True):
         """
         Location is estimated by sample location and reference positions.
         """
@@ -448,7 +448,7 @@ class PlateManipulator(SampleChanger):
 
             return True
         except:
-             return False   
+             return False
 
     def _do_unload(self, sample_slot=None):
         """
@@ -474,7 +474,7 @@ class PlateManipulator(SampleChanger):
         if self.get_token() is None:
             raise Exception("No plate barcode defined")
         self._load_data(self.get_token())
-    
+
     def sync_with_crims(self):
         """
         Descript. :
@@ -677,7 +677,7 @@ class PlateManipulator(SampleChanger):
     def move_to_crystal_position(self, crystal_uuid):
         """
          Descript. : Move Diff to crystal position
-         Get crystal_uuid from processing plan for loaded sample/drop 
+         Get crystal_uuid from processing plan for loaded sample/drop
         """
         ret = None
         if crystal_uuid in ["undefined", None]:
@@ -691,7 +691,7 @@ class PlateManipulator(SampleChanger):
                     if (row == ord(x.row) - 65  and  col == x.column -1 and drop == x.shelf -1):
                         crystal_uuid = x.crystal_uuid
             else : raise Exception("No processing_plan OR Crystal Found in this well")
-        
+
 
         if self.cmd_move_to_crystal_position and crystal_uuid:
                 try:

--- a/mxcubecore/HardwareObjects/QueueManager.py
+++ b/mxcubecore/HardwareObjects/QueueManager.py
@@ -15,6 +15,7 @@ import gevent
 
 from mxcubecore import queue_entry
 from mxcubecore.BaseHardwareObjects import HardwareObject
+from mxcubecore.model.queue_model_enumerables import CENTRING_METHOD
 from mxcubecore.queue_entry import base_queue_entry
 from mxcubecore.queue_entry.base_queue_entry import QUEUE_ENTRY_STATUS
 
@@ -25,6 +26,7 @@ class QueueManager(HardwareObject, QueueEntryContainer):
     def __init__(self, name):
         HardwareObject.__init__(self, name)
         QueueEntryContainer.__init__(self)
+        self.centring_method = CENTRING_METHOD.NONE
         self._root_task = None
         self._paused_event = gevent.event.Event()
         self._paused_event.set()

--- a/mxcubecore/HardwareObjects/Robodiff.py
+++ b/mxcubecore/HardwareObjects/Robodiff.py
@@ -196,22 +196,6 @@ class Robodiff(SampleChanger):
             self._update_selection()
 
     @task
-    def load_sample(
-        self,
-        holderLength,
-        sample_id=None,
-        sample_location=None,
-        sampleIsLoadedCallback=None,
-        failureCallback=None,
-        prepareCentring=True,
-    ):
-        cell, basket, sample = sample_location
-        sample = self.get_component_by_address(
-            Pin.get_sample_address(cell, basket, sample)
-        )
-        return self.load(sample)
-
-    @task
     def unload_sample(
         self,
         holderLength,

--- a/mxcubecore/HardwareObjects/abstract/AbstractSampleChanger.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractSampleChanger.py
@@ -102,6 +102,7 @@ SampleChanger.INFO_CHANGED_EVENT
 SampleChanger.LOADED_SAMPLE_CHANGED_EVENT
 SampleChanger.SELECTION_CHANGED_EVENT
 SampleChanger.TASK_FINISHED_EVENT
+SampleChanger.PROGRESS_MESSAGE
 
 Tools for SC Classes
 ----------------------
@@ -211,6 +212,7 @@ class SampleChanger(Container, HardwareObject):
     SELECTION_CHANGED_EVENT = "selectionChanged"
     TASK_FINISHED_EVENT = "taskFinished"
     CONTENTS_UPDATED_EVENT = "contentsUpdated"
+    PROGRESS_MESSAGE = "progress_message"
 
     def __init__(self, type_, scannable, *args, **kwargs):
         super().__init__(type_, None, type_, scannable)
@@ -219,6 +221,7 @@ class SampleChanger(Container, HardwareObject):
         HardwareObject.__init__(self, *args, **kwargs)
         self.state = -1
         self.status = ""
+        self._progress_message = ""
         self._set_state(SampleChangerState.Unknown)
         self.task = None
         self.task_proc = None
@@ -310,6 +313,24 @@ class SampleChanger(Container, HardwareObject):
         :rtype: str
         """
         return self.status
+
+    @property
+    def progress_message(self) -> str:
+        """
+        Returns:
+            Current progress message
+        """
+        self._progress_message
+
+    def set_progress_message(self, message: str) -> None:
+        """
+        Set progress message describing the current sample changer activity.
+
+        Args:
+            message: string describing current sample changer activity.
+        """
+        self._progress_message = message
+        self._trigger_progress_message(message)
 
     def get_task_error(self):
         """
@@ -825,6 +846,9 @@ class SampleChanger(Container, HardwareObject):
         if cur != component:
             Container._set_selected_component(self, component)
             self._trigger_selection_changed_event()
+
+    def trigger_progress_message(self, message: str):
+        self.emit(self.PROGRESS_MESSAGE, (message,))
 
     # ########################    PRIVATE    #########################
 

--- a/mxcubecore/HardwareObjects/mockup/PlateManipulatorMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/PlateManipulatorMockup.py
@@ -95,7 +95,7 @@ class Xtal(Sample.Sample):
         In this cas we assume a drop is a basket or puck
         """
         return self.get_drop().get_index() + 1
-    
+
     def get_cell_no(self):
         """
         In this cas we assume a well in the row is a cell
@@ -247,10 +247,10 @@ class PlateManipulatorMockup(AbstractSampleChanger.SampleChanger):
         AbstractSampleChanger.SampleChanger.init(self)
 
         self.update_state(self.STATES.READY)
-    
+
     def _read_state(self):
         return 'ready'
-    
+
     def _ready(self):
         return True
 
@@ -328,12 +328,20 @@ class PlateManipulatorMockup(AbstractSampleChanger.SampleChanger):
                 self._do_select(sample)
             self._set_loaded_sample(sample)
 
-    def load_sample(self, sample_location=None):
+    def load(self, sample=None, wait=True):
+        comp = self._resolve_component(sample)
+        coords = comp.get_coords()
+        res = self._load_sample(coords)
+        if res:
+            self._set_loaded_sample(comp)
+            comp._set_loaded(True, True)
+        return res
+
+    def _load_sample(self, sample_location=None):
         """
         Descript. : function to move to plate location.
                     Location is estimated by sample location and reference positions.
         """
-
         row = sample_location[0] - 1
         col = (sample_location[1] - 1) / self.num_drops
         drop = sample_location[1] - self.num_drops * col
@@ -549,7 +557,7 @@ class PlateManipulatorMockup(AbstractSampleChanger.SampleChanger):
         plate_info_dict["num_drops"] = self.num_drops
         plate_info_dict["plate_label"] = self.plate_label or  "Demo plate label"
         plate_info_dict["plate_barcode"] = self.plate_barcode or  ""
-        
+
         return plate_info_dict
 
     def get_plate_location(self):

--- a/mxcubecore/HardwareObjects/mockup/SampleChangerMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/SampleChangerMockup.py
@@ -42,9 +42,6 @@ class SampleChangerMockup(AbstractSampleChanger.SampleChanger):
     def get_log_filename(self):
         return self.log_filename
 
-    def load_sample(self, holder_length, sample_location=None, wait=False):
-        self.load(sample_location, wait)
-
     def load(self, sample, wait=False):
         self.emit("fsmConditionChanged", "sample_mounting_sample_changer", True)
         previous_sample = self.get_loaded_sample()

--- a/mxcubecore/model/queue_model_enumerables.py
+++ b/mxcubecore/model/queue_model_enumerables.py
@@ -70,9 +70,9 @@ EDNARefImages = namedtuple("EDNARefImages", ["FOUR", "TWO", "ONE", "NONE"])
 EDNA_NUM_REF_IMAGES = EDNARefImages(0, 1, 2, 3)
 
 CentringMethod = namedtuple(
-    "CentringMethod", ["MANUAL", "LOOP", "FULLY_AUTOMATIC", "XRAY"]
+    "CentringMethod", ["MANUAL", "LOOP", "FULLY_AUTOMATIC", "XRAY", "NONE"]
 )
-CENTRING_METHOD = CentringMethod(0, 1, 2, 3)
+CENTRING_METHOD = CentringMethod(0, 1, 2, 3, 4)
 
 WorkflowType = namedtuple(
     "WorkflowType", ["BURN", "WF1", "WF2", "LineScan", "MeshScan", "XrayCentring"]


### PR DESCRIPTION
Related to issue #970 

- Removed `SampleChanger.load_sample` and replaced it with `SampleChanger.load`

The `SampleChanger.mount_sample` method uses a method called `load_sample` that are only defined on a few sample changers and not defined in `AbstractSampleChanger`. `SampleChanger.mount_sample` seems to be the only place where `load_sample` is used. Perhaps one of the Qt developers could confirm that its not used directly by the UI or some site specific qt related code.

- Introduced a progress message signal on `AbstractSampleChanger`
- Introduced a centering_method setting that is meant to be application wide on the `SampleView` HardwareObject
