### PR TITLE
Deprecating Device and Equipment

### DIFF
--- a/mxcubecore/BaseHardwareObjects.py
+++ b/mxcubecore/BaseHardwareObjects.py
@@ -1138,6 +1138,12 @@ class Device(HardwareObject):
 
     (NOTREADY, READY) = (0, 1)  # device states
 
+    def __init_subclass__(cls, **kwargs):
+        warnings.warn(
+            f"{cls.__name__} will be deprecated.", DeprecationWarning, stacklevel=2
+        )
+        super().__init_subclass__(**kwargs)
+
     def __init__(self, name):
         warnings.warn(
             "class Device is Deprecated and will be removed",
@@ -1230,6 +1236,12 @@ class Equipment(HardwareObject, DeviceContainer):
 
     NB This class needs refactoring. Since many (soon: all??) contained
      objects are no longer of class Device, the code in here is unlikely to work."""
+
+    def __init_subclass__(cls, **kwargs):
+        warnings.warn(
+            f"{cls.__name__} will be deprecated.", DeprecationWarning, stacklevel=2
+        )
+        super().__init_subclass__(**kwargs)
 
     def __init__(self, name):
         HardwareObject.__init__(self, name)

--- a/mxcubecore/BaseHardwareObjects.py
+++ b/mxcubecore/BaseHardwareObjects.py
@@ -27,6 +27,8 @@ from collections import OrderedDict
 import logging
 from gevent import event, Timeout
 import pydantic
+import warnings
+
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -1137,6 +1139,10 @@ class Device(HardwareObject):
     (NOTREADY, READY) = (0, 1)  # device states
 
     def __init__(self, name):
+        warnings.warn(
+            "class Device is Deprecated and will be removed",
+            DeprecationWarning,
+        )
         HardwareObject.__init__(self, name)
 
         self.state = Device.NOTREADY
@@ -1228,6 +1234,10 @@ class Equipment(HardwareObject, DeviceContainer):
     def __init__(self, name):
         HardwareObject.__init__(self, name)
         DeviceContainer.__init__(self)
+        warnings.warn(
+            "class Equipment is Deprecated and will be removed",
+            DeprecationWarning,
+        )
 
         self.__ready = None
 


### PR DESCRIPTION
The `Device` and `Equipment` classes are still in the code base but now with a deprecation warning. There are still a few more objects that use Device and Equipment to look at. Please have a look at your site specific and local code, let me know and make the necessary changes. I will follow up with a PR that removes `Equipment` and `Device`