### PR TITLE
CatsMaintMockup: fix call to super __init__()

### DIFF
--- a/mxcubecore/HardwareObjects/mockup/CatsMaintMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/CatsMaintMockup.py
@@ -44,7 +44,7 @@ class CatsMaintMockup(HardwareObject):
     """
 
     def __init__(self, *args, **kwargs):
-        Equipment.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self._state = "READY"
         self._running = 0


### PR DESCRIPTION
The CatsMaintMockup does not inherit Equipment class anymore.

This fixes issue with loading `sample_changer_maintenance` HWO when running mxcubeweb with mocked beamline.