### PR TITLE
CI: run pytests on package version changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,8 @@ name: Pytest
     types: [opened, reopened, synchronize]
     paths:
       - '**.py'
+      - 'pyproject.toml'
+      - 'poetry.lock'
 jobs:
   Python:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Trigger pytest if project definition or poetry lock is updated.

Make sure that we test the (potentially) new versions of dependency packages.