### PR TITLE
Checkbeam in BeamlineActions

### DIFF
--- a/mxcubecore/HardwareObjects/BeamlineActions.py
+++ b/mxcubecore/HardwareObjects/BeamlineActions.py
@@ -127,7 +127,7 @@ class HWObjActuatorCommand(CommandObject):
             elif self._running:
                 self.emit("commandReplyArrived", (str(self.name()), res))
 
-        self.running = False
+        self._running = False
 
     def value(self):
         """Return the current command vaue.

--- a/mxcubecore/HardwareObjects/ESRF/ESRFPhotonFlux.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFPhotonFlux.py
@@ -18,7 +18,7 @@
 #  You should have received a copy of the GNU General Lesser Public License
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 
-""" Photon fluc calculations
+""" Photon flux calculations
 Example xml_ configuration:
 
 .. code-block:: xml
@@ -29,7 +29,7 @@ Example xml_ configuration:
    <object role="aperture" href="/udiff_aperture"/>
    <counter_name>i0</counter_name>
    <beam_check_name>checkbeam</beam_check_name>
-   <object role="check_beam" href="/check_beam"/>
+   <object role="monitor_beam" href="/monitor_beam"/>
  </object>
 """
 import logging
@@ -49,7 +49,7 @@ class ESRFPhotonFlux(AbstractFlux):
         self._aperture = None
         self.threshold = None
         self._beam_check_obj = None
-        self._checkbeam_obj = None
+        self._monitorbeam_obj = None
 
     def init(self):
         """Initialisation"""
@@ -78,7 +78,7 @@ class ESRFPhotonFlux(AbstractFlux):
         if beam_check:
             self._beam_check_obj = getattr(controller, beam_check)
 
-        self._checkbeam_obj = self.get_object_by_role("check_beam")
+        self._monitorbeam_obj = self.get_object_by_role("monitor_beam")
 
         try:
             HWR.beamline.safety_shutter.connect("stateChanged", self.update_value)
@@ -144,9 +144,9 @@ class ESRFPhotonFlux(AbstractFlux):
                                               (default);
                              if timeout is None: wait forever.
         """
-        if self._checkbeam_obj:
+        if self._monitorbeam_obj:
             try:
-                check = self._checkbeam_obj.get_value().value
+                check = self._monitorbeam_obj.get_value().value
             except AttributeError:
                 check = False
             if check is True:

--- a/mxcubecore/HardwareObjects/GenericNState.py
+++ b/mxcubecore/HardwareObjects/GenericNState.py
@@ -1,0 +1,49 @@
+# encoding: utf-8
+#
+#  Project: MXCuBE
+#  https://github.com/mxcube
+#
+#  This file is part of MXCuBE software.
+#
+#  MXCuBE is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  MXCuBE is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU General Lesser Public License
+#  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Concrete Implementation of AbstartNState
+Example xml_ configuration:
+
+.. code-block:: xml
+
+ <object class="GenericNState">
+   <username>Check Beam</username>
+   <actuator_name>checkbeam</actuator_name>
+   <values>{"TRUE": True, "FALSE": False}</values>
+ </object>
+"""
+from mxcubecore.HardwareObjects.abstract.AbstractNState import AbstractNState
+
+
+class GenericNState(AbstractNState):
+    def get_value(self):
+        """Get the device value
+        Returns:
+            (Enum): Enum member, corresponding to the value or UNKNOWN.
+        """
+        return self._nominal_value
+
+    def _set_value(self, value):
+        """Set the value.
+        Args:
+            value (Enum): target value
+        """
+        self.update_value(value)

--- a/mxcubecore/HardwareObjects/NState.py
+++ b/mxcubecore/HardwareObjects/NState.py
@@ -19,25 +19,31 @@
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 
 """
-Concrete Implementation of AbstartNState
-Example xml_ configuration:
+Concrete Implementation of AbstartNState - overloads the get_value
+and _set_value abstract methods.
+Example xml configuration:
 
 .. code-block:: xml
 
- <object class="GenericNState">
-   <username>Check Beam</username>
-   <actuator_name>checkbeam</actuator_name>
-   <values>{"TRUE": True, "FALSE": False}</values>
+ <object class="NState">
+   <username>Beam Monitoring</username>
+   <actuator_name>beam_monitor</actuator_name>
+   <values>{"ENABLED": True, "DISABLED": False}</values>
  </object>
 """
 from mxcubecore.HardwareObjects.abstract.AbstractNState import AbstractNState
 
+__copyright__ = """ Copyright © by the MXCuBE collaboration """
+__license__ = "LGPLv3+"
 
-class GenericNState(AbstractNState):
+
+class NState(AbstractNState):
+    """Overload get_value and _set_value abstract methods"""
+
     def get_value(self):
         """Get the device value
         Returns:
-            (Enum): Enum member, corresponding to the value or UNKNOWN.
+            (Enum): VALUES Enum member
         """
         return self._nominal_value
 

--- a/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
@@ -785,11 +785,9 @@ class AbstractMultiCollect(object):
             flux_threshold = self.get_property("flux_threshold", 0)
             cryo_threshold = self.get_property("cryo_threshold", 0)
 
-            check_flux = self.get_property("check_flux", False)
             check_cryo = self.get_property("check_cryo", False)
 
-            if check_flux:
-                HWR.beamline.flux.wait_for_beam()
+            HWR.beamline.flux.wait_for_beam()
 
             # Wait for cryo
             # from time to time cryo does not answer

--- a/mxcubecore/HardwareObjects/abstract/AbstractNState.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractNState.py
@@ -49,6 +49,10 @@ class AbstractNState(AbstractActuator):
         """Initilise the predefined values"""
         super().init()
         self.initialise_values()
+        # default_value should be an Enum, if defined
+        if self.default_value and not isinstance(self.default_value, Enum):
+            self.default_value = self.value_to_enum(self.default_value)
+            self.update_value(self.default_value)
 
     def validate_value(self, value):
         """Check if the value is one of the predefined values.
@@ -87,17 +91,18 @@ class AbstractNState(AbstractActuator):
         except (ValueError, TypeError):
             pass
 
-    def value_to_enum(self, value):
+    def value_to_enum(self, value, idx=0):
         """Tranform a value to Enum
         Args:
            value(str, int, float, tuple): value
+           idx(int): Index in the value, if tuple
         Returns:
             (Enum): Enum member, corresponding to the value or UNKNOWN.
         """
         for enum_var in self.VALUES.__members__.values():
             if value == enum_var.value:
                 return enum_var
-            if isinstance(enum_var.value, tuple) and value == enum_var.value[0]:
+            if isinstance(enum_var.value, tuple) and value == enum_var.value[idx]:
                 return enum_var
 
         return self.VALUES.UNKNOWN

--- a/mxcubecore/HardwareObjects/abstract/AbstractNState.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractNState.py
@@ -50,7 +50,7 @@ class AbstractNState(AbstractActuator):
         super().init()
         self.initialise_values()
         # default_value should be an Enum, if defined
-        if self.default_value and not isinstance(self.default_value, Enum):
+        if self.default_value is not None and not isinstance(self.default_value, Enum):
             self.default_value = self.value_to_enum(self.default_value)
             self.update_value(self.default_value)
 


### PR DESCRIPTION
- Define GenericNState to overload get_value and _set_value when no hardware involved. To be used by BeamlineActions.
- AbstractNState default_value should be an Enum. Impossible to set it as such in the config file, so do it at init().
- BeamlineActions typo fixed.