### PR TITLE
fix issue with skipped calls to init() for YAML HWOBJs

### DIFF
--- a/mxcubecore/HardwareRepository.py
+++ b/mxcubecore/HardwareRepository.py
@@ -174,7 +174,7 @@ def load_from_yaml(
 
         result._config = result.HOConfig(**config)
 
-        if objects:
+        if _container is None:
             load_time = 1000 * (time.time() - start_time)
             msg1 = "Start loading contents:"
             _table.append(


### PR DESCRIPTION
Only set 'msg0' variable when loading the 'beamline_config.yml' file. Otherwise the call to HWOBJ.init() will be skipped on line 225, if it have any sub-HWOBJs configured.

Currently, if you have an YAML file with `objects` section, the HWOBJ's `init()` method will not be invoked.