### PR TITLE
Fixed calls to super class for objects that used to use Device or Equipment

### DIFF
--- a/deprecated/HardwareObjects/Mar225.py
+++ b/deprecated/HardwareObjects/Mar225.py
@@ -3,7 +3,7 @@ from mxcubecore.BaseHardwareObjects import HardwareObject
 
 class Mar225(HardwareObject):
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
 
     def init(self):
         pass

--- a/deprecated/HardwareObjects/NamedState.py
+++ b/deprecated/HardwareObjects/NamedState.py
@@ -25,7 +25,7 @@ import logging
 
 class NamedState(HardwareObject):
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
         self.stateList = []
 
     def _init(self):

--- a/deprecated/HardwareObjects/SpecMotor.py
+++ b/deprecated/HardwareObjects/SpecMotor.py
@@ -2,11 +2,11 @@ from mxcubecore.BaseHardwareObjects import HardwareObject
 from SpecClient_gevent.SpecMotor import SpecMotorA
 
 
-class SpecMotor(Device, SpecMotorA):
+class SpecMotor(HardwareObject, SpecMotorA):
     (NOTINITIALIZED, UNUSABLE, READY, MOVESTARTED, MOVING, ONLIMIT) = (0, 1, 2, 3, 4, 5)
 
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
         SpecMotorA.__init__(self)
 
     def _init(self):
@@ -53,7 +53,7 @@ class SpecMotor(Device, SpecMotorA):
 
 class SpecVersionMotor(SpecMotor):
     def __init__(self, specversion, specname, username):
-        Device.__init__(self, specname)
+        super().__init__(specname)
         self.specversion = specversion
         self.specname = specname
         self.username = username

--- a/deprecated/HardwareObjects/SpecShell.py
+++ b/deprecated/HardwareObjects/SpecShell.py
@@ -30,7 +30,7 @@ class SpecOutputVar(QObject, SpecClient.SpecVariable.SpecVariableA):
 
 class SpecShell(HardwareObject):
     def __init__(self, *args):
-        Equipment.__init__(self, *args)
+        super().__init__(*args)
         self.isSpecReady = False
 
     def init(self):

--- a/deprecated/HardwareObjects/mockup/MachInfoMockup.py
+++ b/deprecated/HardwareObjects/mockup/MachInfoMockup.py
@@ -46,7 +46,7 @@ class MachInfoMockup(HardwareObject):
     default_topup_remaining = 70  # seconds
 
     def __init__(self, *args):
-        Equipment.__init__(self, *args)
+        super().__init__(*args)
 
         self.current = self.default_current
         self.lifetime = self.default_lifetime

--- a/mxcubecore/HardwareObjects/ALBA/ALBABackLight.py
+++ b/mxcubecore/HardwareObjects/ALBA/ALBABackLight.py
@@ -7,7 +7,7 @@ import time
 
 class ALBABackLight(HardwareObject):
     def __init__(self, *args):
-        Device.__init__(self, *args)
+        super().__init__(*args)
         self.limits = [None, None]
         self.state = None
         self.current_level = None

--- a/mxcubecore/HardwareObjects/ALBA/ALBABeamInfo.py
+++ b/mxcubecore/HardwareObjects/ALBA/ALBABeamInfo.py
@@ -32,7 +32,7 @@ class ALBABeamInfo(HardwareObject):
         """
         Descrip. :
         """
-        Equipment.__init__(self, *args)
+        super().__init__(*args)
 
         self.aperture_hwobj = None
         self.slits_hwobj = None

--- a/mxcubecore/HardwareObjects/ALBA/ALBAEnergy.py
+++ b/mxcubecore/HardwareObjects/ALBA/ALBAEnergy.py
@@ -6,7 +6,7 @@ from mxcubecore import HardwareRepository as HWR
 
 class ALBAEnergy(HardwareObject):
     def __init__(self, *args):
-        Device.__init__(self, *args)
+        super().__init__(*args)
         self.energy_position = None
         self.wavelength_position = None
 

--- a/mxcubecore/HardwareObjects/ALBA/ALBAFrontLight.py
+++ b/mxcubecore/HardwareObjects/ALBA/ALBAFrontLight.py
@@ -5,7 +5,7 @@ import logging
 
 class ALBAFrontLight(HardwareObject):
     def __init__(self, *args):
-        Device.__init__(self, *args)
+        super().__init__(*args)
         self.limits = [None, None]
 
         self.state = None

--- a/mxcubecore/HardwareObjects/ALBA/ALBAMachineInfo.py
+++ b/mxcubecore/HardwareObjects/ALBA/ALBAMachineInfo.py
@@ -78,7 +78,7 @@ class ALBAMachineInfo(HardwareObject):
     """
 
     def __init__(self, name):
-        Equipment.__init__(self, name)
+        super().__init__(name)
         self.logger = logging.getLogger("HWR MachineInfo")
         self.logger.info("__init__()")
 

--- a/mxcubecore/HardwareObjects/ALBA/ALBASupervisor.py
+++ b/mxcubecore/HardwareObjects/ALBA/ALBASupervisor.py
@@ -5,7 +5,7 @@ import logging
 
 class ALBASupervisor(HardwareObject):
     def __init__(self, *args):
-        Device.__init__(self, *args)
+        super().__init__(*args)
 
     def init(self):
         self.state_chan = self.get_channel_object("state")

--- a/mxcubecore/HardwareObjects/ALBA/ALBATransmission.py
+++ b/mxcubecore/HardwareObjects/ALBA/ALBATransmission.py
@@ -4,7 +4,7 @@ from mxcubecore.BaseHardwareObjects import HardwareObject
 
 class ALBATransmission(HardwareObject):
     def __init__(self, *args):
-        Device.__init__(self, *args)
+        super().__init__(*args)
         self.transmission = None
 
     def init(self):

--- a/mxcubecore/HardwareObjects/ALBA/XalocMachineInfo.py
+++ b/mxcubecore/HardwareObjects/ALBA/XalocMachineInfo.py
@@ -78,7 +78,7 @@ class XalocMachineInfo(HardwareObject):
     """
 
     def __init__(self, name):
-        Equipment.__init__(self, name)
+        super().__init__(name)
         """
         Descript. :
         """

--- a/mxcubecore/HardwareObjects/BeamInfo.py
+++ b/mxcubecore/HardwareObjects/BeamInfo.py
@@ -33,7 +33,7 @@ class BeamInfo(HardwareObject):
         """
         Descrip. :
         """
-        Equipment.__init__(self, *args)
+        super().__init__(*args)
 
         self.aperture_hwobj = None
         self.beam_definer = None

--- a/mxcubecore/HardwareObjects/CatsMaint.py
+++ b/mxcubecore/HardwareObjects/CatsMaint.py
@@ -58,7 +58,7 @@ class CatsMaint(HardwareObject):
     """
 
     def __init__(self, *args, **kwargs):
-        Equipment.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self._state = None
         self._running = None

--- a/mxcubecore/HardwareObjects/DESY/DigitalZoomMotor.py
+++ b/mxcubecore/HardwareObjects/DESY/DigitalZoomMotor.py
@@ -43,7 +43,7 @@ class DigitalZoomMotor(AbstractMotor, Device):
 
     def __init__(self, name):
         AbstractMotor.__init__(self, name)
-        Device.__init__(self, name)
+        super().__init__(name)
         self.camera = None
 
     def init(self):

--- a/mxcubecore/HardwareObjects/EMBL/EMBLBeamstop.py
+++ b/mxcubecore/HardwareObjects/EMBL/EMBLBeamstop.py
@@ -28,7 +28,7 @@ __category__ = "General"
 
 class EMBLBeamstop(Device, AbstractMotor):
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
 
         self.distance = None
         self.default_size = None

--- a/mxcubecore/HardwareObjects/EMBL/EMBLDoorInterlock.py
+++ b/mxcubecore/HardwareObjects/EMBL/EMBLDoorInterlock.py
@@ -40,7 +40,7 @@ class EMBLDoorInterlock(HardwareObject):
 
     def __init__(self, name):
 
-        Device.__init__(self, name)
+        super().__init__(name)
 
         self.use_door_interlock = None
         self.door_interlock_state = None

--- a/mxcubecore/HardwareObjects/EMBL/EMBLImageTracking.py
+++ b/mxcubecore/HardwareObjects/EMBL/EMBLImageTracking.py
@@ -37,7 +37,7 @@ class EMBLImageTracking(HardwareObject):
     """
 
     def __init__(self, *args):
-        Device.__init__(self, *args)
+        super().__init__(*args)
 
         self.state = None
         self.state_dict = {"image_tracking": False, "filter_frames": False}

--- a/mxcubecore/HardwareObjects/EMBL/EMBLMotorsGroup.py
+++ b/mxcubecore/HardwareObjects/EMBL/EMBLMotorsGroup.py
@@ -97,7 +97,7 @@ class EMBLMotorsGroup(HardwareObject):
 
     def __init__(self, name):
 
-        Device.__init__(self, name)
+        super().__init__(name)
         self.server_address = None
         self.group_address = None
         self.motors_list = None

--- a/mxcubecore/HardwareObjects/EMBL/EMBLPPUControl.py
+++ b/mxcubecore/HardwareObjects/EMBL/EMBLPPUControl.py
@@ -13,7 +13,7 @@ class EMBLPPUControl(HardwareObject):
     """
 
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
 
         self.all_status = None
         self.status_result = None

--- a/mxcubecore/HardwareObjects/ESRF/BlissTurret.py
+++ b/mxcubecore/HardwareObjects/ESRF/BlissTurret.py
@@ -4,7 +4,7 @@ from bliss.config import static
 
 class BlissTurret(HardwareObject):
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
 
     def init(self):
         self.username = self.turret_name

--- a/mxcubecore/HardwareObjects/ESRF/BlissVolpi.py
+++ b/mxcubecore/HardwareObjects/ESRF/BlissVolpi.py
@@ -5,7 +5,7 @@ from bliss.config import static
 class BlissVolpi(HardwareObject):
     def __init__(self, name):
         # AbstractMotor.__init__(self, name)
-        Device.__init__(self, name)
+        super().__init__(name)
 
     def init(self):
         self.username = self.volpi_name

--- a/mxcubecore/HardwareObjects/ESRF/ESRFCryoMon.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFCryoMon.py
@@ -8,7 +8,7 @@ CRYO_STATUS = ["OFF", "SATURATED", "READY", "WARNING", "FROZEN", "UNKNOWN"]
 
 class ESRFCryoMon(HardwareObject):
     def __init__(self, *args, **kwargs):
-        Device.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.n2level = None
         self.temp = None

--- a/mxcubecore/HardwareObjects/ESRF/ID231BeamInfo.py
+++ b/mxcubecore/HardwareObjects/ESRF/ID231BeamInfo.py
@@ -25,7 +25,7 @@ from mxcubecore import HardwareRepository as HWR
 
 class BeamInfo(HardwareObject):
     def __init__(self, *args):
-        Equipment.__init__(self, *args)
+        super().__init__(*args)
 
         self.beam_size_slits = [9999, 9999]
         self.beam_size_aperture = [9999, 9999]

--- a/mxcubecore/HardwareObjects/ESRF/ID23PhotonFlux.py
+++ b/mxcubecore/HardwareObjects/ESRF/ID23PhotonFlux.py
@@ -10,7 +10,7 @@ from mxcubecore import HardwareRepository as HWR
 
 class ID23PhotonFlux(HardwareObject):
     def __init__(self, *args, **kwargs):
-        Equipment.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.threshold = []
 
     def init(self):

--- a/mxcubecore/HardwareObjects/ESRF/ID29PhotonFlux.py
+++ b/mxcubecore/HardwareObjects/ESRF/ID29PhotonFlux.py
@@ -10,7 +10,7 @@ from mxcubecore import HardwareRepository as HWR
 
 class ID29PhotonFlux(HardwareObject):
     def __init__(self, *args, **kwargs):
-        Equipment.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def init(self):
         self.counter = self.get_object_by_role("counter")

--- a/mxcubecore/HardwareObjects/ESRF/ID30A3PhotonFlux.py
+++ b/mxcubecore/HardwareObjects/ESRF/ID30A3PhotonFlux.py
@@ -6,7 +6,7 @@ from PyTango.gevent import DeviceProxy
 
 class ID30A3PhotonFlux(HardwareObject):
     def __init__(self, *args, **kwargs):
-        Equipment.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def init(self):
         controller = self.get_object_by_role("controller")

--- a/mxcubecore/HardwareObjects/ESRF/ID30Cryo.py
+++ b/mxcubecore/HardwareObjects/ESRF/ID30Cryo.py
@@ -8,7 +8,7 @@ class ID30Cryo(HardwareObject):
     states = {0: "out", 1: "in"}
 
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
 
     def init(self):
         controller = self.get_object_by_role("controller")

--- a/mxcubecore/HardwareObjects/ESRF/ID30Light.py
+++ b/mxcubecore/HardwareObjects/ESRF/ID30Light.py
@@ -10,7 +10,7 @@ class ID30Light(Device, AbstractMotor):
     (NOTINITIALIZED, UNUSABLE, READY, MOVESTARTED, MOVING, ONLIMIT) = (0, 1, 2, 3, 4, 5)
 
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
 
     def init(self):
         controller = self.get_object_by_role("controller")

--- a/mxcubecore/HardwareObjects/ESRF/TangoKeithleyPhotonFlux.py
+++ b/mxcubecore/HardwareObjects/ESRF/TangoKeithleyPhotonFlux.py
@@ -8,7 +8,7 @@ from PyTango import DeviceProxy
 
 class TangoKeithleyPhotonFlux(HardwareObject):
     def __init__(self, *args, **kwargs):
-        Equipment.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def init(self):
         self.get_object_by_role("controller")

--- a/mxcubecore/HardwareObjects/FlexHCDMaintenance.py
+++ b/mxcubecore/HardwareObjects/FlexHCDMaintenance.py
@@ -34,7 +34,7 @@ class FlexHCDMaintenance(HardwareObject):
     """
 
     def __init__(self, *args, **kwargs):
-        Equipment.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def init(self):
         self._sc = self.get_object_by_role("sample_changer")

--- a/mxcubecore/HardwareObjects/Grob.py
+++ b/mxcubecore/HardwareObjects/Grob.py
@@ -4,7 +4,7 @@ from grob import grob_control
 
 class Grob(HardwareObject):
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
         self.SampleTableMotor = grob_control.SampleTableMotor
         self.GonioMotor = grob_control.GonioMotor
         self.SampleMotor = grob_control.SampleMotor

--- a/mxcubecore/HardwareObjects/GrobMotor.py
+++ b/mxcubecore/HardwareObjects/GrobMotor.py
@@ -8,7 +8,7 @@ class GrobMotor(Device, AbstractMotor):
     (NOTINITIALIZED, UNUSABLE, READY, MOVESTARTED, MOVING, ONLIMIT) = (0, 1, 2, 3, 4, 5)
 
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
 
     def init(self):
         self.motorState = GrobMotor.NOTINITIALIZED

--- a/mxcubecore/HardwareObjects/GrobSampleChanger.py
+++ b/mxcubecore/HardwareObjects/GrobSampleChanger.py
@@ -18,7 +18,7 @@ class GrobSampleChanger(HardwareObject):
     ALWAYS_ALLOW_MOUNTING = True
 
     def __init__(self, *args, **kwargs):
-        Equipment.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def init(self):
         self._procedure = ""

--- a/mxcubecore/HardwareObjects/MAXIV/BIOMAXEiger.py
+++ b/mxcubecore/HardwareObjects/MAXIV/BIOMAXEiger.py
@@ -39,7 +39,7 @@ class BIOMAXEiger(HardwareObject):
         """
         Descrip. :
         """
-        Equipment.__init__(self, *args)
+        super().__init__(*args)
 
         self.device = None
         self.file_suffix = None

--- a/mxcubecore/HardwareObjects/MAXIV/BIOMAXMD3Camera.py
+++ b/mxcubecore/HardwareObjects/MAXIV/BIOMAXMD3Camera.py
@@ -28,7 +28,7 @@ class BIOMAXMD3Camera(HardwareObject):
     }
 
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
         self.set_is_ready(True)
 
     def init(self):

--- a/mxcubecore/HardwareObjects/Mar225.py
+++ b/mxcubecore/HardwareObjects/Mar225.py
@@ -3,7 +3,7 @@ from mxcubecore.BaseHardwareObjects import HardwareObject
 
 class Mar225(HardwareObject):
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
 
     def init(self):
         pass

--- a/mxcubecore/HardwareObjects/MicrodiffInOut.py
+++ b/mxcubecore/HardwareObjects/MicrodiffInOut.py
@@ -19,7 +19,7 @@ Example xml file:
 
 class MicrodiffInOut(HardwareObject):
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
         self.actuatorState = "unknown"
         self.username = "unknown"
         # default timeout - 5 sec

--- a/mxcubecore/HardwareObjects/MiniDiff.py
+++ b/mxcubecore/HardwareObjects/MiniDiff.py
@@ -108,7 +108,7 @@ class MiniDiff(HardwareObject):
     # MOVE_TO_BEAM_MODE = "Move to Beam"
 
     def __init__(self, *args):
-        Equipment.__init__(self, *args)
+        super().__init__(*args)
 
         qmo.CentredPosition.set_diffractometer_motor_names(
             "phi",

--- a/mxcubecore/HardwareObjects/MotorWPositions.py
+++ b/mxcubecore/HardwareObjects/MotorWPositions.py
@@ -52,7 +52,7 @@ class MotorWPositions(AbstractMotor, Device):
 
     def __init__(self, name):
         AbstractMotor.__init__(self, name)
-        Device.__init__(self, name)
+        super().__init__(name)
         self.predefined_positions = {}
         self.motor = None
         self.delta = 0.001

--- a/mxcubecore/HardwareObjects/Q315dist.py
+++ b/mxcubecore/HardwareObjects/Q315dist.py
@@ -7,7 +7,7 @@ class Q315dist(BaseHardwareObjects.Equipment):
         self.connect("equipmentReady", self.equipmentReady)
         self.connect("equipmentNotReady", self.equipmentNotReady)
 
-        return BaseHardwareObjects.Equipment._init(self)
+        return BaseHardwareObjects.super()._init()
 
     def init(self):
         self.detm = self.get_deviceby_role("detm")

--- a/mxcubecore/HardwareObjects/RobodiffFShut.py
+++ b/mxcubecore/HardwareObjects/RobodiffFShut.py
@@ -3,7 +3,7 @@ from mxcubecore.BaseHardwareObjects import HardwareObject
 
 class RobodiffFShut(HardwareObject):
     def __init__(self, name):
-        Equipment.__init__(self, name)
+        super().__init__(name)
 
     def init(self):
         self.robodiff = self.get_object_by_role("robot")

--- a/mxcubecore/HardwareObjects/RobodiffLight.py
+++ b/mxcubecore/HardwareObjects/RobodiffLight.py
@@ -10,7 +10,7 @@ class RobodiffLight(Device, AbstractMotor):
     (NOTINITIALIZED, UNUSABLE, READY, MOVESTARTED, MOVING, ONLIMIT) = (0, 1, 2, 3, 4, 5)
 
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
 
     def init(self):
         controller = self.get_object_by_role("controller")

--- a/mxcubecore/HardwareObjects/RobodiffMotor.py
+++ b/mxcubecore/HardwareObjects/RobodiffMotor.py
@@ -7,7 +7,7 @@ class RobodiffMotor(HardwareObject):
     (NOTINITIALIZED, UNUSABLE, READY, MOVESTARTED, MOVING, ONLIMIT) = (0, 1, 2, 3, 4, 5)
 
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
         self.__initialized = False
 
     def init(self):

--- a/mxcubecore/HardwareObjects/SOLEIL/PX1/PX1BeamInfo.py
+++ b/mxcubecore/HardwareObjects/SOLEIL/PX1/PX1BeamInfo.py
@@ -25,7 +25,7 @@ from mxcubecore.BaseHardwareObjects import HardwareObject
 
 class PX1BeamInfo(HardwareObject):
     def __init__(self, *args):
-        Equipment.__init__(self, *args)
+        super().__init__(*args)
 
         self.beam_position = [None, None]
         self.beam_size = [100, 100]

--- a/mxcubecore/HardwareObjects/SOLEIL/PX1/PX1EnergyScan.py
+++ b/mxcubecore/HardwareObjects/SOLEIL/PX1/PX1EnergyScan.py
@@ -46,7 +46,7 @@ class PX1EnergyScan(AbstractEnergyScan, Equipment):
 
     def __init__(self, name):
         AbstractEnergyScan.__init__(self)
-        Equipment.__init__(self, name)
+        super().__init__(name)
 
         self.scanning = False
         self.stopping = False

--- a/mxcubecore/HardwareObjects/SOLEIL/PX1/PX1Environment.py
+++ b/mxcubecore/HardwareObjects/SOLEIL/PX1/PX1Environment.py
@@ -72,7 +72,7 @@ class EnvironemntState:
 
 class PX1Environment(HardwareObject):
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
         self.auth = None
         self.device = None
 

--- a/mxcubecore/HardwareObjects/SOLEIL/PX1/PX1Resolution.py
+++ b/mxcubecore/HardwareObjects/SOLEIL/PX1/PX1Resolution.py
@@ -51,7 +51,7 @@ class PX1Resolution(HardwareObject):
         self.currentDistance = self.distance_chan.get_value()
         self._nominal_value = self.resolution_chan.get_value()
 
-        return Equipment._init(self)
+        return super()._init()
 
     def connect_notify(self, signal):
         if signal == "stateChanged":

--- a/mxcubecore/HardwareObjects/SOLEIL/PX1/PX1TangoLight.py
+++ b/mxcubecore/HardwareObjects/SOLEIL/PX1/PX1TangoLight.py
@@ -8,7 +8,7 @@ from mxcubecore.Command.Tango import DeviceProxy
 
 class PX1TangoLight(HardwareObject):
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
         self.currentState = "unknown"
 
     def init(self):

--- a/mxcubecore/HardwareObjects/SOLEIL/PX2/PX2Attenuator.py
+++ b/mxcubecore/HardwareObjects/SOLEIL/PX2/PX2Attenuator.py
@@ -21,7 +21,7 @@ class PX2Attenuator(HardwareObject):
     }
 
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
 
         self.labels = []
         self.attno = 0

--- a/mxcubecore/HardwareObjects/SOLEIL/PX2/PX2BeamInfo.py
+++ b/mxcubecore/HardwareObjects/SOLEIL/PX2/PX2BeamInfo.py
@@ -36,7 +36,7 @@ from mxcubecore.BaseHardwareObjects import HardwareObject
 
 class PX2BeamInfo(HardwareObject):
     def __init__(self, *args):
-        Equipment.__init__(self, *args)
+        super().__init__(*args)
 
         self.beam_position = [328, 220]  # [None, None]
         self.beam_size = [0.010, 0.005]  # [None, None]

--- a/mxcubecore/HardwareObjects/SOLEIL/SOLEILCatsMaint.py
+++ b/mxcubecore/HardwareObjects/SOLEIL/SOLEILCatsMaint.py
@@ -36,7 +36,7 @@ class SOLEILCatsMaint(HardwareObject):
 
     def __init__(self, *args, **kwargs):
         logging.info("CatsMaint: __init__")
-        Equipment.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def init(self):
         logging.info("CatsMaint: init")

--- a/mxcubecore/HardwareObjects/SOLEIL/SOLEILFlux.py
+++ b/mxcubecore/HardwareObjects/SOLEIL/SOLEILFlux.py
@@ -5,7 +5,7 @@ import PyTango
 
 class SOLEILFlux(HardwareObject):
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
 
     def init(self):
         self.flux_channel = self.get_channel_object("flux")

--- a/mxcubecore/HardwareObjects/SOLEIL/SOLEILPss.py
+++ b/mxcubecore/HardwareObjects/SOLEIL/SOLEILPss.py
@@ -13,7 +13,7 @@ class SOLEILPss(HardwareObject):
     READ_CMD, READ_OUT = (0, 1)
 
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
 
         self.wagoState = "unknown"
         self.__oldValue = None

--- a/mxcubecore/HardwareObjects/SOLEIL/TangoDCMotor.py
+++ b/mxcubecore/HardwareObjects/SOLEIL/TangoDCMotor.py
@@ -38,7 +38,7 @@ class TangoDCMotor(HardwareObject):
 
         # State values as expected by Motor bricks
 
-        Device.__init__(self, name)
+        super().__init__(name)
         self.GUIstep = 0.1
         self.motor_states = MotorStates()
 

--- a/mxcubecore/HardwareObjects/SpecMotor.py
+++ b/mxcubecore/HardwareObjects/SpecMotor.py
@@ -2,11 +2,11 @@ from mxcubecore.BaseHardwareObjects import HardwareObject
 from SpecClient_gevent.SpecMotor import SpecMotorA
 
 
-class SpecMotor(Device, SpecMotorA):
+class SpecMotor(HardwareObject, SpecMotorA):
     (NOTINITIALIZED, UNUSABLE, READY, MOVESTARTED, MOVING, ONLIMIT) = (0, 1, 2, 3, 4, 5)
 
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
         SpecMotorA.__init__(self)
 
     def _init(self):
@@ -53,7 +53,7 @@ class SpecMotor(Device, SpecMotorA):
 
 class SpecVersionMotor(SpecMotor):
     def __init__(self, specversion, specname, username):
-        Device.__init__(self, specname)
+        super().__init__(specname)
         self.specversion = specversion
         self.specname = specname
         self.username = username

--- a/mxcubecore/HardwareObjects/SpecShell.py
+++ b/mxcubecore/HardwareObjects/SpecShell.py
@@ -30,7 +30,7 @@ class SpecOutputVar(QObject, SpecClient.SpecVariable.SpecVariableA):
 
 class SpecShell(HardwareObject):
     def __init__(self, *args):
-        Equipment.__init__(self, *args)
+        super().__init__(*args)
         self.isSpecReady = False
 
     def init(self):

--- a/mxcubecore/HardwareObjects/mockup/BIOMAXEigerMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/BIOMAXEigerMockup.py
@@ -38,7 +38,7 @@ class BIOMAXEigerMockup(HardwareObject):
         """
         Descrip. :
         """
-        Equipment.__init__(self, *args)
+        super().__init__(*args)
 
         self.device = None
         self.file_suffix = None

--- a/mxcubecore/HardwareObjects/mockup/MicrodiffInOutMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/MicrodiffInOutMockup.py
@@ -18,7 +18,7 @@ Example xml file:
 
 class MicrodiffInOutMockup(HardwareObject):
     def __init__(self, name):
-        Device.__init__(self, name)
+        super().__init__(name)
         self.actuatorState = "unknown"
         self.username = "unknown"
         # default timeout - 3 sec


### PR DESCRIPTION
Missed a few explicit calls to super class in a previous PR. Making sure that the right super class is called and using `super` instead