### PR TITLE
XRF centred position

### DIFF
--- a/mxcubecore/HardwareObjects/abstract/AbstractEnergyScan.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractEnergyScan.py
@@ -13,6 +13,7 @@ class AbstractEnergyScan(object):
         self.data_collect_task = None
         self._egyscan_task = None
         self.scanning = False
+        self.cpos = None
 
     def open_safety_shutter(self, timeout):
         """
@@ -141,7 +142,14 @@ class AbstractEnergyScan(object):
 
     # def start_energy_scan(
     def start_energy_scan(
-        self, element, edge, directory, prefix, session_id=None, blsample_id=None
+        self,
+        element,
+        edge,
+        directory,
+        prefix,
+        session_id=None,
+        blsample_id=None,
+        cpos=None,
     ):
         if self._egyscan_task and not self._egyscan_task.ready():
             raise RuntimeError("Scan already started.")
@@ -152,7 +160,7 @@ class AbstractEnergyScan(object):
         STATICPARS_DICT = self.get_static_parameters(
             self.get_property("config_file"), element, edge
         )
-
+        self.cpos = cpos
         self.energy_scan_parameters = STATICPARS_DICT
         self.energy_scan_parameters["element"] = element
         self.energy_scan_parameters["edge"] = edge

--- a/mxcubecore/HardwareObjects/abstract/AbstractXRFSpectrum.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractXRFSpectrum.py
@@ -59,6 +59,7 @@ class AbstractXRFSpectrum(HardwareObject):
         self.lims = None
         self.spectrum_info_dict = {}
         self.default_integration_time = None
+        self.cpos = None
 
     def init(self):
         """Initialisation"""
@@ -76,8 +77,9 @@ class AbstractXRFSpectrum(HardwareObject):
         archive_dir=None,
         session_id=None,
         blsample_id=None,
+        cpos=None,
     ):
-        """Start the procedure. Called by the queu_model.
+        """Start the procedure. Called by the queue_model.
 
         Args:
             integration_time (float): Inregration time [s].
@@ -87,6 +89,7 @@ class AbstractXRFSpectrum(HardwareObject):
             session_id (int): Session ID number (from ISpyB)
             blsample_id (int): Sample ID number (from ISpyB)
         """
+        self.cpos = cpos
         self.spectrum_info_dict = {"sessionId": session_id, "blSampleId": blsample_id}
         integration_time = integration_time or self.default_integration_time
         self.spectrum_info_dict["exposureTime"] = integration_time

--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -1160,6 +1160,7 @@ class XRFSpectrum(TaskNode):
         self.set_requires_centring(True)
         self.centred_position = cpos
         self.adjust_transmission = True
+        self.shape = None
 
         if not sample:
             self.sample = Sample()

--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -1055,6 +1055,7 @@ class EnergyScan(TaskNode):
         self.comments = None
         self.set_requires_centring(True)
         self.centred_position = cpos
+        self.shape = None
 
         if not sample:
             self.sample = Sample()

--- a/mxcubecore/queue_entry/energy_scan.py
+++ b/mxcubecore/queue_entry/energy_scan.py
@@ -55,6 +55,10 @@ class EnergyScanQueueEntry(BaseQueueEntry):
             energy_scan = self.get_data_model()
             self.get_view().setText(1, "Starting energy scan")
 
+            if energy_scan.shape is not None:
+                point = HWR.beamline.sample_view.get_shape(energy_scan.shape)
+                energy_scan.centred_position = point.get_centred_position()
+
             sample_model = self.get_data_model().get_sample_node()
 
             sample_lims_id = sample_model.lims_id
@@ -71,6 +75,7 @@ class EnergyScanQueueEntry(BaseQueueEntry):
                 energy_scan.path_template.get_prefix(),
                 HWR.beamline.session.session_id,
                 sample_lims_id,
+                cpos=energy_scan.centred_position,
             )
 
         HWR.beamline.energy_scan.ready_event.wait()

--- a/mxcubecore/queue_entry/xrf_spectrum.py
+++ b/mxcubecore/queue_entry/xrf_spectrum.py
@@ -54,11 +54,12 @@ class XrfSpectrumQueueEntry(BaseQueueEntry):
     def execute(self):
         """Execute"""
         super().execute()
-
         if HWR.beamline.xrf_spectrum is not None:
             xrf_spectrum = self.get_data_model()
+            if xrf_spectrum.shape is not None:
+                point = HWR.beamline.sample_view.get_shape(xrf_spectrum.shape)
+                xrf_spectrum.centred_position = point.get_centred_position()
             self.get_view().setText(1, "Starting xrf spectrum")
-
             path_template = xrf_spectrum.path_template
             HWR.beamline.xrf_spectrum.start_spectrum(
                 integration_time=xrf_spectrum.count_time,
@@ -67,6 +68,7 @@ class XrfSpectrumQueueEntry(BaseQueueEntry):
                 prefix=f"{path_template.get_prefix()}_{path_template.run_number}",
                 session_id=HWR.beamline.session.session_id,
                 blsample_id=xrf_spectrum._node_id,
+                cpos=xrf_spectrum.centred_position,
             )
             HWR.beamline.xrf_spectrum._ready_event.wait()
             HWR.beamline.xrf_spectrum._ready_event.clear()


### PR DESCRIPTION
We have the need to know the centred positions for the XRF and Energy Scans. By default, mxcubecore does not do anything with that although there are some traces of such info in the code.

This MR adds the centred position in the XRF hwobj so our custom hwobj has the info to be used in the method `_execute_spectrum`. Mxcubeweb already loosely links XRF task with a centering point, so this MR closes the gap at hwobj level
 
Update: same for Energy scan

Small addition for mxcubeweb https://github.com/mxcube/mxcubeweb/pull/1349