### PR TITLE
avoid reloading same HWOBJ for YAML files

### DIFF
--- a/mxcubecore/HardwareRepository.py
+++ b/mxcubecore/HardwareRepository.py
@@ -200,7 +200,8 @@ def load_from_yaml(
                         _container=result,
                         _table=_table,
                     )
-                    _instance.hardware_objects[fname] = hwobj
+                    if hwobj:
+                        _instance.hardware_objects[fname] = hwobj
 
             elif fext == ".xml":
                 msg1 = ""

--- a/mxcubecore/HardwareRepository.py
+++ b/mxcubecore/HardwareRepository.py
@@ -186,14 +186,22 @@ def load_from_yaml(
 
             fname, fext = os.path.splitext(config_file)
             if fext == ".yml":
-                hwobj = load_from_yaml(
-                    config_file,
-                    role=role1,
-                    yaml_export_directory=yaml_export_directory,
-                    _container=result,
-                    _table=_table,
-                )
-                _instance.hardware_objects[f"/{hwobj.load_name}"] = hwobj
+                fname = f"/{fname}"
+
+                # check if we already loaded this configuration file
+                hwobj = _instance.hardware_objects.get(fname)
+
+                if hwobj is None:
+                    # not loaded yet
+                    hwobj = load_from_yaml(
+                        config_file,
+                        role=role1,
+                        yaml_export_directory=yaml_export_directory,
+                        _container=result,
+                        _table=_table,
+                    )
+                    _instance.hardware_objects[fname] = hwobj
+
             elif fext == ".xml":
                 msg1 = ""
                 time0 = time.time()


### PR DESCRIPTION
Implement same behavior for YAML configured HWOBJs as for XML configured HWOBJs.

If an HWOBJ is already loaded, reuse it.

Also changes the behavior on missing YAML config files.  Now it adds an error message to the summary table, rather that aborting the load process with an exception. This is the same behavior as with missing XML files.