### PR TITLE
adapt hardware objects from mocked beamline to YAML

### DIFF
--- a/mxcubecore/HardwareObjects/Beamline.py
+++ b/mxcubecore/HardwareObjects/Beamline.py
@@ -77,9 +77,6 @@ class Beamline(ConfiguredObject):
         # Dictionary-of-dictionaries of default acquisition parameters
         default_acquisition_parameters = {}
 
-        # Dictionary of acquisition parameter limits
-        acquisition_limit_values = {}
-
         # int Starting run number for path_template
         run_number = 1
 
@@ -152,6 +149,15 @@ class Beamline(ConfiguredObject):
         (when all HardwareObjects have been created and initialized)
         """
         self._hardware_object_id_dict = self._get_id_dict()
+
+    @property
+    def acquisition_limit_values(self):
+        """
+        adds a proxy attribute, so that the default acquisition limits can be accessed with:
+
+           HWR.beamline.acquisition_limit_values
+        """
+        return self.config.default_acquisition_parameters["acquisition_limit_values"]
 
     def get_id(self, ho: HardwareObject) -> str:
         warn("Beamline.get_id is Deprecated. Use hwobj.id instead")

--- a/mxcubecore/HardwareObjects/BeamlineActions.py
+++ b/mxcubecore/HardwareObjects/BeamlineActions.py
@@ -166,8 +166,8 @@ class AnnotatedCommand(CommandObject):
 
 
 class BeamlineActions(HardwareObject):
-    def __init__(self, *args):
-        HardwareObject.__init__(self, *args)
+    def __init__(self, name):
+        HardwareObject.__init__(self, name)
         self._annotated_commands = []
         self._annotated_command_dict = {}
         self._command_list = []

--- a/mxcubecore/HardwareObjects/GenericDiffractometer.py
+++ b/mxcubecore/HardwareObjects/GenericDiffractometer.py
@@ -537,24 +537,6 @@ class GenericDiffractometer(HardwareObject):
         return self.motor_hwobj_dict.get("phi")
 
     @property
-    def kappa(self):
-        """kappa motor object
-
-        Returns:
-            AbstractActuator
-        """
-        return self.motor_hwobj_dict.get("kappa")
-
-    @property
-    def kappa_phi(self):
-        """kappa_phi motor object
-
-        Returns:
-            AbstractActuator
-        """
-        return self.motor_hwobj_dict.get("kappa_phi")
-
-    @property
     def centring_x(self):
         """centring_x motor object
 

--- a/mxcubecore/HardwareObjects/SampleView.py
+++ b/mxcubecore/HardwareObjects/SampleView.py
@@ -39,7 +39,6 @@ class SampleView(AbstractSampleView):
 
     def init(self):
         super(SampleView, self).init()
-        self._camera = self.get_object_by_role("camera")
         self._ui_snapshot_cb = None
         self._last_oav_image = None
 

--- a/mxcubecore/HardwareObjects/abstract/AbstractBeam.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractBeam.py
@@ -54,8 +54,8 @@ class AbstractBeam(HardwareObject):
     def __init__(self, name):
         super().__init__(name)
 
-        self._aperture = None
-        self._slits = None
+        self.aperture = None
+        self.slits = None
         self._definer = None
 
         self._beam_size_dict = {
@@ -86,20 +86,6 @@ class AbstractBeam(HardwareObject):
         _divergence_horizontal = self.get_property("beam_divergence_horizontal")
         self._beam_divergence = (_divergence_horizontal, _divergence_vertical)
         self._beam_position_on_screen = (0, 0)
-
-    @property
-    def aperture(self):
-        """
-        Returns aperture hwobj
-        """
-        return self._aperture
-
-    @property
-    def slits(self):
-        """
-        Returns slits hwobj
-        """
-        return self._slits
 
     @property
     def definer(self):
@@ -154,10 +140,10 @@ class AbstractBeam(HardwareObject):
             beam_shape (BeamShape enum): requested beam shape
         """
         if beam_shape == BeamShape.RECTANGULAR:
-            self._slits.set_horizontal_gap(beam_width)
-            self._slits.set_vertical_gap(beam_height)
+            self.slits.set_horizontal_gap(beam_width)
+            self.slits.set_vertical_gap(beam_height)
         elif beam_shape == BeamShape.ELIPTICAL:
-            self._aperture.set_diameter_size(beam_width)
+            self.aperture.set_diameter_size(beam_width)
 
     def get_beam_position_on_screen(self):
         """Get the beam position

--- a/mxcubecore/HardwareObjects/abstract/AbstractDetector.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractDetector.py
@@ -84,13 +84,10 @@ class AbstractDetector(HardwareObject):
         self._metadata = {}
 
     def init(self):
-        """Initialise some common paramerters"""
+        """Initialise some common parameters"""
         super().init()
 
-        try:
-            self._metadata = dict(self["beam"].get_properties())
-        except KeyError:
-            pass
+        self._metadata = self.get_property("beam", {})
 
         self._distance_motor_hwobj = self.get_object_by_role("detector_distance")
 

--- a/mxcubecore/HardwareObjects/abstract/AbstractSampleChanger.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractSampleChanger.py
@@ -209,11 +209,9 @@ class SampleChanger(Container, HardwareObject):
     TASK_FINISHED_EVENT = "taskFinished"
     CONTENTS_UPDATED_EVENT = "contentsUpdated"
 
-    def __init__(self, type_, scannable, *args, **kwargs):
+    def __init__(self, type_, scannable, name):
         super().__init__(type_, None, type_, scannable)
-        if len(args) == 0:
-            args = (type_,)
-        HardwareObject.__init__(self, *args, **kwargs)
+        HardwareObject.__init__(self, name)
         self.state = -1
         self.status = ""
         self._set_state(SampleChangerState.Unknown)

--- a/mxcubecore/HardwareObjects/abstract/AbstractSampleView.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractSampleView.py
@@ -35,7 +35,7 @@ class AbstractSampleView(HardwareObject):
 
     def __init__(self, name):
         super().__init__(name)
-        self._camera = None
+        self.camera = None
         self._focus = None
         self._zoom = None
         self._frontlight = None
@@ -66,14 +66,6 @@ class AbstractSampleView(HardwareObject):
             filename (str): The filename.
             duration (int): Duration time [s].
         """
-
-    @property
-    def camera(self):
-        """Get camera object.
-        Returns:
-            (AbstractCamera): Camera hardware object.
-        """
-        return self._camera
 
     @property
     def shapes(self):

--- a/mxcubecore/HardwareObjects/abstract/AbstractSlits.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractSlits.py
@@ -31,12 +31,12 @@ __version__ = "2.3"
 class AbstractSlits(HardwareObject, object):
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, *args):
+    def __init__(self, name: str):
         warn(
             "AbstractSlits is deprecated. Use specific motors instead",
             DeprecationWarning,
         )
-        HardwareObject.__init__(self, *args)
+        HardwareObject.__init__(self, name)
 
         self._value = [None, None]
         self._min_limits = [None, None]

--- a/mxcubecore/HardwareObjects/mockup/BeamMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/BeamMockup.py
@@ -48,23 +48,29 @@ class BeamMockup(AbstractBeam):
             self.get_property("beam_position", "[318, 238]")
         )
 
-        self._aperture = self.get_object_by_role("aperture")
-        if self._aperture is not None:
+        if self.aperture is None:
+            # backward compatibility hack to support loading from XML config file
+            self.aperture = self.get_object_by_role("aperture")
+
+        if self.aperture is not None:
             self.connect(
-                self._aperture,
+                self.aperture,
                 "diameterIndexChanged",
                 self.aperture_diameter_changed,
             )
 
-            ad = self._aperture.get_diameter_size() / 1000.0
+            ad = self.aperture.get_diameter_size() / 1000.0
             self._beam_size_dict["aperture"] = [ad, ad]
-            self._beam_info_dict["label"] = self._aperture.get_diameter_size()
+            self._beam_info_dict["label"] = self.aperture.get_diameter_size()
 
-        self._slits = self.get_object_by_role("slits")
-        if self._slits is not None:
-            self.connect(self._slits, "valueChanged", self.slits_gap_changed)
+        if self.slits is None:
+            # backward compatibility hack to support loading from XML config file
+            self.slits = self.get_object_by_role("slits")
 
-            sx, sy = self._slits.get_gaps()
+        if self.slits is not None:
+            self.connect(self.slits, "valueChanged", self.slits_gap_changed)
+
+            sx, sy = self.slits.get_gaps()
             self._beam_size_dict["slits"] = [sx, sy]
 
         self.evaluate_beam_info()
@@ -121,20 +127,20 @@ class BeamMockup(AbstractBeam):
             width_microns (int):
             height_microns (int):
         """
-        if self._slits:
-            self._slits.set_horizontal_gap(width_microns / 1000.0)
-            self._slits.set_vertical_gap(height_microns / 1000.0)
+        if self.slits:
+            self.slits.set_horizontal_gap(width_microns / 1000.0)
+            self.slits.set_vertical_gap(height_microns / 1000.0)
 
     def get_aperture_pos_name(self):
         """
         Returns (str): name of current aperture position
         """
-        if self._aperture:
-            return self._aperture.get_current_pos_name()
+        if self.aperture:
+            return self.aperture.get_current_pos_name()
 
     def get_available_size(self):
-        aperture_list = self._aperture.get_diameter_size_list()
+        aperture_list = self.aperture.get_diameter_size_list()
         return {"type": "enum", "values": aperture_list}
 
     def set_value(self, value):
-        self._aperture.set_diameter_size(value)
+        self.aperture.set_diameter_size(value)

--- a/mxcubecore/HardwareObjects/mockup/BeamlineActionsMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/BeamlineActionsMockup.py
@@ -72,5 +72,4 @@ class ComboTest2(AnnotatedCommand):
 
 
 class BeamlineActionsMockup(BeamlineActions):
-    def __init__(self, *args):
-        super().__init__(*args)
+    pass

--- a/mxcubecore/HardwareObjects/mockup/DetectorMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/DetectorMockup.py
@@ -20,6 +20,9 @@ class DetectorMockup(AbstractDetector):
         """
         AbstractDetector.__init__(self, name)
 
+        # 'slot' for child object
+        self.detector_distance = None
+
     def init(self):
         """
         Descript. :

--- a/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
@@ -38,11 +38,26 @@ class DiffractometerMockup(GenericDiffractometer):
     Descript. :
     """
 
-    def __init__(self, *args):
+    def __init__(self, name):
         """
         Descript. :
         """
-        GenericDiffractometer.__init__(self, *args)
+        GenericDiffractometer.__init__(self, name)
+
+        # child object slots
+        self.backlight = None
+        self.backlightswitch = None
+        self.beamstop_distance = None
+        self.focus = None
+        self.frontlight = None
+        self.frontlightswitch = None
+        self.kappa = None
+        self.kappa_phi = None
+        self.phi = None
+        self.phiy = None
+        self.phiz = None
+        self.sampx = None
+        self.sampy = None
 
     def init(self) -> bool:
         """

--- a/mxcubecore/HardwareObjects/mockup/MDCameraMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/MDCameraMockup.py
@@ -17,23 +17,25 @@ class MDCameraMockup(BaseHardwareObjects.Device):
     def __init__(self, name):
         BaseHardwareObjects.Device.__init__(self, name)
 
-    def _init(self):
         self._format = "MPEG1"
         self.stream_hash = "abc123"
         self.udiffVER_Ok = False
         self.badimg = 0
         self.pollInterval = 500
         self.connected = False
-        self.image_name = self.get_property("image_name")
-        self.image = HWR.get_hardware_repository().find_in_repository(self.image_name)
+
+    def init(self):
+        logging.getLogger("HWR").info("initializing camera object")
+
+        image_name = self.get_property("image_name")
+        self.image = HWR.get_hardware_repository().find_in_repository(image_name)
         self.set_is_ready(True)
         self._video_stream_process = None
         self._current_stream_size = "0, 0"
 
-    def init(self):
-        logging.getLogger("HWR").info("initializing camera object")
         if self.get_property("interval"):
             self.pollInterval = self.get_property("interval")
+
         self.stopper = False  # self.polling_timer(self.pollInterval, self.poll)
         gevent.spawn(self.poll)
 

--- a/mxcubecore/HardwareObjects/mockup/SampleChangerMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/SampleChangerMockup.py
@@ -12,8 +12,8 @@ class SampleChangerMockup(AbstractSampleChanger.SampleChanger):
     NO_OF_BASKETS = 5
     NO_OF_SAMPLES_IN_BASKET = 10
 
-    def __init__(self, *args, **kwargs):
-        super(SampleChangerMockup, self).__init__(self.__TYPE__, False, *args, **kwargs)
+    def __init__(self, name):
+        super(SampleChangerMockup, self).__init__(self.__TYPE__, False, name)
 
     def init(self):
         self._selected_sample = -1

--- a/mxcubecore/HardwareObjects/mockup/SlitsMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/SlitsMockup.py
@@ -25,8 +25,8 @@ __credits__ = ["MXCuBE collaboration"]
 
 
 class SlitsMockup(AbstractSlits):
-    def __init__(self, *args):
-        AbstractSlits.__init__(self, *args)
+    def __init__(self, name: str):
+        AbstractSlits.__init__(self, name)
 
     def init(self):
         self._value = [0.05, 0.05]


### PR DESCRIPTION
This makes the required changes to the hardware objects used by mocked beamline to work with YAML config files.

With this changes, it's possible to start the mocked beamline using YAML config files.

Note, this PR depends on code changes in these PRs: https://github.com/mxcube/mxcubecore/pull/997 and https://github.com/mxcube/mxcubecore/pull/996.

I have used YAML config files from this PR: https://github.com/mxcube/mxcubeweb/pull/1358