### PR TITLE
NState: support non-enum types of values

### DIFF
--- a/mxcubecore/HardwareObjects/abstract/AbstractNState.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractNState.py
@@ -61,6 +61,14 @@ class AbstractNState(AbstractActuator):
         Returns:
             (bool): True if within the values.
         """
+        if not isinstance(value, self.VALUES):
+            # Handle the cases when value is of other type then self.VALUE enum type,
+            # for example when the member is specified as a string.
+            #
+            # Note, this if case can be dropped once we set the earliest supported
+            # version of python to 3.12.
+            return value in self.VALUES.__members__
+
         return value in self.VALUES
 
     def set_limits(self, limits):


### PR DESCRIPTION
Make it passible to use the 'bare' types of values for AbstractNState derived hardware objects.

For example if an AbstractNState have following valid values:

  self.VALUES = Enum("ValueEnum", {"LEVEL1": 1, "LEVEL2": 2})

This patch makes "LEVEL1" and "LEVEL2" values valid, in addition to self.VALUES.LEVEL1 and self.VALUES.LEVEL2.

This is needed when getting the hardware objects values REST API from the front-end. For example when using BeamDefinerMockup HWOBJ.