### PR TITLE
Moved `set_is_ready` with deprecation warning to HardwareObject.

### DIFF
--- a/mxcubecore/BaseHardwareObjects.py
+++ b/mxcubecore/BaseHardwareObjects.py
@@ -778,6 +778,16 @@ class HardwareObjectMixin(CommandContainer):
         """
         return self._ready_event.is_set()
 
+    def set_is_ready(self, value: bool):
+        warnings.warn(
+            "set_is_ready method ported from Device is Deprecated and will be removed",
+            DeprecationWarning,
+        )
+        if value:
+            self.update_state(HardwareObjectState.READY)
+        else:
+            self.update_state(HardwareObjectState.OFF)
+
     def update_state(self, state: Optional[HardwareObjectState] = None) -> None:
         """Update self._state, and emit signal stateChanged if the state has changed.
 


### PR DESCRIPTION
The `Device` object defines three methods in addition to those defined on `HardwareObject`.

 - is_ready  - Also defined on `HardwareObject`
 - set_is_ready - Only defined on `Device`
 - userName - Previously refactored to name() (there are no reference to `userName()` in the code base)

Some objects that inherited `Device` where using the method called `set_is_ready` taking a boolean with the "ready state". `set_is_ready` was moved  to HardwareObject, with a deprecation warning. The logic of `set_is_ready` was translated to internally work with the states defined  in `HardwareObjectState` (still taking a boolean argument)
The semantics of  is_ready and set_is_ready should thus be compatible with that originally defined on `Device`. 

I will leave it up to each site to replace `set_is_ready` with the corresponding call to `self.update_state(HardwareObjectState.READY)`  and then depending on the situation `self.update_state(HardwareObjectState.BUSY|OFF)`. The `set_is_ready`  method defined on `HardwareObject` uses `HardwareObjectState.OFF`.

Closes #1372