### PR TITLE
Prevent re-loading same YAML config file twice

### DIFF
--- a/mxcubecore/HardwareRepository.py
+++ b/mxcubecore/HardwareRepository.py
@@ -186,6 +186,14 @@ def load_from_yaml(
 
             fname, fext = os.path.splitext(config_file)
             if fext == ".yml":
+                fname = f"/{fname}"
+
+                # check if we already loaded this configuration file
+                if _instance.hardware_objects.get(fname) is not None:
+                    raise Exception(
+                        f"Configuration file '{config_file}', referenced in '{configuration_file}, "
+                        f"has been loaded earlier. Refusing to load it a second time."
+                    )
                 hwobj = load_from_yaml(
                     config_file,
                     role=role1,
@@ -195,7 +203,8 @@ def load_from_yaml(
                 )
                 if hwobj:
                     # only add if we successfully loaded the object
-                    _instance.hardware_objects[f"/{hwobj.load_name}"] = hwobj
+                    _instance.hardware_objects[fname] = hwobj
+
             elif fext == ".xml":
                 msg1 = ""
                 time0 = time.time()

--- a/mxcubecore/HardwareRepository.py
+++ b/mxcubecore/HardwareRepository.py
@@ -193,7 +193,9 @@ def load_from_yaml(
                     _container=result,
                     _table=_table,
                 )
-                _instance.hardware_objects[f"/{hwobj.load_name}"] = hwobj
+                if hwobj:
+                    # only add if we successfully loaded the object
+                    _instance.hardware_objects[f"/{hwobj.load_name}"] = hwobj
             elif fext == ".xml":
                 msg1 = ""
                 time0 = time.time()


### PR DESCRIPTION
As discussed here: https://github.com/mxcube/mxcubecore/pull/997#issuecomment-2311657405

When loading hardware objects from YAML configuration file, check if that file have been loaded earlier. Raise an error if we detect that same file is being reloaded.
    
The aim is to enforce strict tree-like structure of hardware objects. This to avoid confusion of the situations when same hardware object is attached at different points.
