### PR TITLE
make tests pass on xml_yaml_conversion branch

### DIFF
--- a/mxcubecore/configuration/mockup/procedure-mockup.yml
+++ b/mxcubecore/configuration/mockup/procedure-mockup.yml
@@ -1,6 +1,3 @@
 %YAML 1.2
 ---
-
-# The class to initialise, and init parameters
-_initialise_class:
-  class: mxcubecore.HardwareObjects.mockup.ProcedureMockup.ProcedureMockup
+class: mxcubecore.HardwareObjects.mockup.ProcedureMockup.ProcedureMockup

--- a/mxcubecore/configuration/mockup/test/beamline_config.yml
+++ b/mxcubecore/configuration/mockup/test/beamline_config.yml
@@ -2,10 +2,8 @@
 ---
 
 # The class to initialise, and init parameters
-_initialise_class:
-  class: mxcubecore.HardwareObjects.Beamline.Beamline
-  # Further key-value pairs here will be passed to the class init
-  # mode: devel
+class:
+  mxcubecore.HardwareObjects.Beamline.Beamline
 
 # objects
 #
@@ -15,7 +13,7 @@ _initialise_class:
 # NBNB some objects that do not currently have their own config files
 # would need those added (e.g. the centring methods)
 #
-_objects:
+objects:
   # The !!o0map and the lines starting with '- ' give you an *ordered* dictionary
   # And thus a reproducible loading order
   !!omap

--- a/test/pytest/test_base_hardware_objects.py
+++ b/test/pytest/test_base_hardware_objects.py
@@ -382,26 +382,6 @@ class TestHardwareObjectNode:
         # Check "len" matches expected count
         assert len(hw_obj_node) == count
 
-    def test_getattr(self, hw_obj_node: HardwareObjectNode):
-        """Test "__getattr__" method.
-
-        Args:
-            hw_obj_node (HardwareObjectNode): Object instance.
-        """
-
-        # Attempt to access attribute starting with "__", should raise an exception
-        with pytest.raises(AttributeError):
-            hw_obj_node.__name
-
-        # Check retrieving an attrubute that has been assigned to "_property_set"
-        hw_obj_node._property_set["test"] = 1
-        assert getattr(hw_obj_node, "test") == 1
-
-        # Check attempting to access an attribute,
-        # before it has been assigned to "_property_set"
-        with pytest.raises(AttributeError):
-            getattr(hw_obj_node, "test2")
-
     def test_setattr(self, hw_obj_node: HardwareObjectNode):
         """Test "__setattr__" method.
 

--- a/test/pytest/test_base_hardware_objects.py
+++ b/test/pytest/test_base_hardware_objects.py
@@ -944,7 +944,7 @@ class TestHardwareObjectNode:
         hw_obj_node: HardwareObjectNode,
         initial_obj_names: List[str],
     ):
-        """Test "objects_names" method.
+        """Test "_objects_names" method.
 
         Args:
             mocker (MockerFixture): Instance of the Pytest mocker fixture.
@@ -960,7 +960,7 @@ class TestHardwareObjectNode:
         )
 
         # Call method and verify output matches initial values
-        assert hw_obj_node.objects_names() == initial_obj_names
+        assert hw_obj_node._objects_names() == initial_obj_names
 
     @pytest.mark.parametrize(
         ("name", "value", "output_value"),

--- a/test/pytest/test_base_hardware_objects.py
+++ b/test/pytest/test_base_hardware_objects.py
@@ -93,7 +93,7 @@ def hw_obj_yml() -> Generator[HardwareObjectYaml, None, None]:
         Generator[HardwareObjectYaml, None, None]: New object instance.
     """
 
-    hw_obj_yml = HardwareObjectYaml(name="RootObject")
+    hw_obj_yml = HardwareObjectYaml("RootObject")
     yield hw_obj_yml
 
 
@@ -926,9 +926,7 @@ class TestHardwareObjectNode:
         if role.lower() in hw_obj_node._objects_by_role:
             assert res == hw_obj_node._objects_by_role[role.lower()]
         elif not None in _objects and sub_obj_role:
-            assert isinstance(res, HardwareObject) and res.name() == "TestHWObj3"
-        # else:
-        #     assert res is None
+            assert isinstance(res, HardwareObject) and res.name == "TestHWObj3"
 
     @pytest.mark.parametrize(
         "initial_obj_names",

--- a/test/pytest/test_base_hardware_objects.py
+++ b/test/pytest/test_base_hardware_objects.py
@@ -396,19 +396,7 @@ class TestHardwareObjectNode:
         assert "test1" in hw_obj_node.__dict__.keys()
         assert getattr(hw_obj_node, "test1") == 1
         assert "test1" not in hw_obj_node._property_set.keys()
-
-        # Assign a key/value to "_property_set"
-        hw_obj_node._property_set["test2"] = 0
-
-        # Set a new value against the value we just added
-        setattr(hw_obj_node, "test2", 1)
-
-        # Check that the key/value was not assigned to "__dict__"
-        assert "test2" not in hw_obj_node.__dict__.keys()
-
-        # Check that the value returned is correct
-        assert getattr(hw_obj_node, "test2") == 1
-        assert hw_obj_node._property_set["test2"] == 1
+        assert hw_obj_node.test1 == 1
 
     @pytest.mark.parametrize(
         "key",

--- a/test/pytest/test_base_hardware_objects.py
+++ b/test/pytest/test_base_hardware_objects.py
@@ -745,44 +745,6 @@ class TestHardwareObjectNode:
             # Index key in "_objects_names" should point to last item in "_objects"
             assert _objects_names.index(name) == len(_objects) - 1
 
-    @pytest.mark.parametrize(
-        ("name", "initial_obj_names", "in_names"),
-        (
-            ("key1", ["key1", "key2", "key3"], True),
-            ("key4", ["key1", "key2", "key3"], False),
-        ),
-    )
-    def test_has_object(
-        self,
-        mocker: "MockerFixture",
-        hw_obj_node: HardwareObjectNode,
-        name: str,
-        initial_obj_names: List[str],
-        in_names: bool,
-    ):
-        """Test "has_object" method.
-
-        Args:
-            mocker (MockerFixture): Instance of the Pytest mocker fixture.
-            hw_obj_node (HardwareObjectNode): Object instance.
-            name (str): Name.
-            initial_obj_names (List[str]): Initial object names.
-            in_names (bool): Result expected from method.
-        """
-
-        # Patch "__objects_names" to test with known values
-        mocker.patch.object(
-            hw_obj_node,
-            "_HardwareObjectNode__objects_names",
-            new=initial_obj_names,
-        )
-
-        # Call method
-        res = hw_obj_node.has_object(object_name=name)
-
-        # Check result matches expectations
-        assert res == in_names
-
     @pytest.mark.parametrize("name", ("key1", "key2", "key3", "key4"))
     @pytest.mark.parametrize(
         ("initial_obj_names", "initial_objects"),

--- a/test/pytest/test_command_container.py
+++ b/test/pytest/test_command_container.py
@@ -825,8 +825,8 @@ class TestCommandContainer:
             optional (bool): Whether an error should be logged where no result is returned.
         """
 
-        # Patch "name" to test in isolation
-        mocker.patch.object(cmd_container, "name", create=True, return_value="test")
+        # Patch "id" to test in isolation
+        mocker.patch.object(cmd_container, "id", create=True, return_value="test")
 
         # Patch "__channels" with known values to test
         mocker.patch.object(

--- a/test/pytest/test_procedure.py
+++ b/test/pytest/test_procedure.py
@@ -5,7 +5,7 @@ from mxcubecore.HardwareObjects.abstract.AbstractProcedure import ProcedureState
 
 def test_procedure_init(beamline):
     assert (
-        beamline.config.mock_procedure is not None
+        beamline.mock_procedure is not None
     ), "MockProcedure hardware objects is None (not initialized)"
     # The methods are defined with abc.abstractmethod which will raise
     # an exception if the method is not defined. So there is no need to test for
@@ -14,17 +14,17 @@ def test_procedure_init(beamline):
 
 def test_procedure_start(beamline):
     data = procedure_model.MockDataModel(**{"exposure_time": 5})
-    beamline.config.mock_procedure.start(data)
+    beamline.mock_procedure.start(data)
     gevent.sleep(1)
-    assert beamline.config.mock_procedure.state == ProcedureState.BUSY
-    beamline.config.mock_procedure.wait()
-    assert beamline.config.mock_procedure.state == ProcedureState.READY
+    assert beamline.mock_procedure.state == ProcedureState.BUSY
+    beamline.mock_procedure.wait()
+    assert beamline.mock_procedure.state == ProcedureState.READY
 
 
 def test_procedure_stop(beamline):
     data = procedure_model.MockDataModel(**{"exposure_time": 5})
-    beamline.config.mock_procedure.start(data)
+    beamline.mock_procedure.start(data)
     gevent.sleep(1)
-    assert beamline.config.mock_procedure.state == ProcedureState.BUSY
-    beamline.config.mock_procedure.stop()
-    assert beamline.config.mock_procedure.state == ProcedureState.READY
+    assert beamline.mock_procedure.state == ProcedureState.BUSY
+    beamline.mock_procedure.stop()
+    assert beamline.mock_procedure.state == ProcedureState.READY


### PR DESCRIPTION
Changes needed on `xml_yaml_conversion` branch for tests to pass.

Some tests are removed, as they where testing removed features.
Some tests are adapted to changes made on `xml_yaml_conversion` branch.