### PR TITLE
fix initialization of EnergyScanMockup objects

### DIFF
--- a/mxcubecore/HardwareObjects/mockup/EnergyScanMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/EnergyScanMockup.py
@@ -164,11 +164,7 @@ chooch_graph_data = (
 )
 
 
-class EnergyScanMockup(AbstractEnergyScan, HardwareObject):
-    def __init__(self, name):
-        AbstractEnergyScan.__init__(self)
-        HardwareObject.__init__(self, name)
-
+class EnergyScanMockup(AbstractEnergyScan):
     def init(self):
 
         self.ready_event = gevent.event.Event()


### PR DESCRIPTION
In 1350c6665dcb336ebd8bb6df7f7318d00dfb117a commit, the AbstractEnergyScan class has been changed to extend HardwareObject. It's `AbstractEnergyScan.__init__()` method now takes a string parameter. This change breaks current `EnergyScanMockup.__init__()` method, as it calls `AbstractEnergyScan.__init__()` without any arguments.

Remove the `EnergyScanMockup.__init__()` method, as it's no longer needed. This fixes the issue with creating EnergyScanMockup objects.

Note, due to the issues with creating EnergyScanMockup objects, the `test_beamline_routes.py::test_beamline_get_all_attribute` test of mxcubeweb is broken. It fails on this line: https://github.com/mxcube/mxcubeweb/blob/develop/test/test_beamline_routes.py#L59

Once this is merged, we need to bump mxcubecore version in mxcubeweb to fix the tests.