### PR TITLE
miscellaneous cleanup fixes

### DIFF
--- a/docs/source/dev/queue.md
+++ b/docs/source/dev/queue.md
@@ -40,7 +40,7 @@ The model consists of an object called `QueueModel` that has a tree structure of
 The combination of a `QueueEntry` and its model (`QueueModel`) is often referred to as a *task*, and makes up the entity that will be executed when the queue is executed.
 
 The one-to-one mapping makes it possible to represent a queue and construct the queue entries from the queue model objects. In this way, the tree of queue model objects defines the queue. A task or collection protocol can be added to the queue by adding the *queue model object* to the `QueueModel`. For instance, a rotational data collection is added to the queue by adding a `DataCollectionTaskNode` to the `QueueModel`. This method of adding tasks to the queue is used by the Workflow engines, while the interfaces directly attach a `TaskNode` object to the corresponding `QueueEntry` which is then
-*enqueued*
+*enqueued*.
 
 ## Task creation - creation of QueueEntry and QueueModel
 A task is created by creating a `Tasknode` and  attaching it to a corresponding `QueueEntry`. The `QueueEntry` is added or *enqueued* to the queue via the method `QueueManager.enqueue`.

--- a/mxcubecore/HardwareObjects/BeamlineActions.py
+++ b/mxcubecore/HardwareObjects/BeamlineActions.py
@@ -180,7 +180,7 @@ class BeamlineActions(HardwareObject):
         _cls_name = parts[-1]
         self._annotated_commands.append(_cls_name)
 
-        # Assume import from current module if only class name givien (no module)
+        # assume import from current module if only class name given (no module)
         if len(parts) == 1:
             _cls = getattr(sys.modules[__name__], _cls_name)
         else:

--- a/mxcubecore/HardwareObjects/QueueManager.py
+++ b/mxcubecore/HardwareObjects/QueueManager.py
@@ -8,7 +8,6 @@ container of the queue, note the inheritance from QueueEntryContainer. See the
 documentation for the queue_entry module for more information.
 """
 import logging
-import traceback
 import gevent
 import traceback
 

--- a/mxcubecore/HardwareObjects/QueueModel.py
+++ b/mxcubecore/HardwareObjects/QueueModel.py
@@ -150,7 +150,7 @@ class QueueModel(HardwareObject):
         Adds the child node <child>. Raises the exception TypeError
         if child is not of type TaskNode.
 
-        Moves the child (reparents it) if it already has a parent.
+        Moves the child (re-parents it) if it already has a parent.
 
         :param child: TaskNode to add
         :type child: TaskNode

--- a/mxcubecore/HardwareObjects/abstract/AbstractBeam.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractBeam.py
@@ -19,7 +19,7 @@
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 
 """
-AbstracBeam class - methods to define the size and shape of the beam.
+AbstractBeam class - methods to define the size and shape of the beam.
 
 emits:
 - beamSizeChanged (self._beam_width, self._beam_height)

--- a/mxcubecore/HardwareObjects/mockup/BeamlineActionsMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/BeamlineActionsMockup.py
@@ -1,14 +1,10 @@
 from typing_extensions import Literal
 
 from pydantic import BaseModel, Field
-from mxcubecore.TaskUtils import task
-from mxcubecore.CommandContainer import CommandObject
 from mxcubecore.HardwareObjects.BeamlineActions import (
     BeamlineActions,
-    ControllerCommand,
     AnnotatedCommand,
 )
-from mxcubecore.utils.conversion import camel_to_snake
 
 import gevent
 import logging

--- a/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
@@ -42,7 +42,7 @@ class DiffractometerMockup(GenericDiffractometer):
         """
         GenericDiffractometer.__init__(self, *args)
 
-    def init(self) -> bool:
+    def init(self):
         """
         Descript. :
         """

--- a/mxcubecore/HardwareObjects/mockup/SampleChangerMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/SampleChangerMockup.py
@@ -1,4 +1,3 @@
-import gevent
 import time
 import logging
 

--- a/mxcubecore/HardwareRepository.py
+++ b/mxcubecore/HardwareRepository.py
@@ -683,19 +683,6 @@ class __HardwareRepositoryClient:
         """Return a Procedure given its name (see get_hardware_object())"""
         return self.get_hardware_object(procedure_name)
 
-    # def get_connection(self, connection_name):
-    #     """Return the Connection object for a Spec connection, given its name
-    #
-    #     Parameters :
-    #       connectionName -- a Spec version name ('host:port' string)
-    #
-    #     Return :
-    #       the corresponding SpecConnection object
-    #     """
-    #     connections_manager = SpecConnectionsManager.SpecConnectionsManager()
-    #
-    #     return connections_manager.get_connection(connection_name)
-
     def is_device(self, name):
         """Check if a Hardware Object is a Device
 

--- a/mxcubecore/HardwareRepository.py
+++ b/mxcubecore/HardwareRepository.py
@@ -269,7 +269,7 @@ def set_user_file_directory(user_file_directory):
 
 
 def init_hardware_repository(configuration_path):
-    """Initialise hardweare repository - must be run at program start
+    """Initialise hardware repository - must be run at program start
 
     Args:
         configuration_path (str): PATHSEP-separated string of directories

--- a/mxcubecore/model/common.py
+++ b/mxcubecore/model/common.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional, Union
+from typing import Optional
 from pydantic import BaseModel, Field
 
 

--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -579,28 +579,6 @@ class Basket(TaskNode):
 
 
 class DataCollection(TaskNode):
-    """
-    Adds the child node <child>. Raises the exception TypeError
-    if child is not of type TaskNode.
-
-    Moves the child (reparents it) if it already has a parent.
-
-    :param parent: Parent TaskNode object.
-    :type parent: TaskNode
-
-    :param acquisition_list: List of Acquisition objects.
-    :type acquisition_list: list
-
-    :crystal: Crystal object
-    :type crystal: Crystal
-
-    :param processing_paremeters: Parameters used by autoproessing software.
-    :type processing_parameters: ProcessingParameters
-
-    :returns: None
-    :rtype: None
-    """
-
     def __init__(
         self,
         acquisition_list=None,

--- a/mxcubecore/queue_entry/base_queue_entry.py
+++ b/mxcubecore/queue_entry/base_queue_entry.py
@@ -242,8 +242,8 @@ class BaseQueueEntry(QueueEntryContainer):
     def set_view(self, view, view_set_queue_entry=True):
         """
         Sets the view of this queue entry to <view>. Makes the
-        correspodning bi-directional connection if view_set_queue_entry
-        is set to True. Which is normaly case, it can be usefull with
+        corresponding bidirectional connection if view_set_queue_entry
+        is set to True. Which is normally case, it can be useful with
         'uni-directional' connection in some rare cases.
 
         :param view: The view to associate with this entry
@@ -275,7 +275,7 @@ class BaseQueueEntry(QueueEntryContainer):
 
     def set_enabled(self, state):
         """
-        Enables or disables this entry, controls wether this item
+        Enables or disables this entry, controls if this item
         should be executed (enabled) or not (disabled)
 
         :param state: Enabled if state is True otherwise disabled.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,8 +115,6 @@ mxcubecore/HardwareObjects/SOLEIL/SOLEILqueue_entry.py,
 mxcubecore/HardwareObjects/TangoLimaMpegVideo.py,
 mxcubecore/HardwareObjects/XSDataMXCuBEv1_4.py,
 mxcubecore/HardwareObjects/XSDataMXv1.py,
-mxcubecore/model/common.py,
-mxcubecore/model/queue_model_objects.py,
 """
 
 [tool.black]
@@ -133,8 +131,6 @@ force-exclude = '''
   | buck-out
   | build
   | dist
-  # this file contains invalid python syntax
-  | mxcubecore/HardwareObjects/ESRF/ESRFMultiCollect.py
 #
 # Exclude files below from black checks until we get around fixing them.
 # This way we can check that all other files are black clean in CI.
@@ -153,8 +149,6 @@ force-exclude = '''
   | mxcubecore/HardwareObjects/DESY/P11DetectorCover.py
   | mxcubecore/HardwareObjects/Beamline.py
   | mxcubecore/HardwareObjects/DESY/P11DetectorDistance.py
-  | mxcubecore/HardwareObjects/DESY/P11Pinhole.py
-  | mxcubecore/HardwareObjects/DESY/P11EDNACharacterisation.py
   | mxcubecore/HardwareObjects/DESY/P11Shutter.py
   | mxcubecore/HardwareObjects/EMBL/EMBLAperture.py
   | mxcubecore/HardwareObjects/EMBL/EMBLBSD.py
@@ -185,6 +179,7 @@ force-exclude = '''
   | mxcubecore/HardwareObjects/ESRF/ID231BeamCmds.py
   | mxcubecore/HardwareObjects/ESRF/ID232BeamDefiner.py
   | mxcubecore/HardwareObjects/ESRF/ESRFEnergyScan.py
+  | mxcubecore/HardwareObjects/ESRF/ESRFMultiCollect.py
   | mxcubecore/HardwareObjects/ESRF/ID29EnergyScan.py
   | mxcubecore/HardwareObjects/ESRF/ID232MultiCollect.py
   | mxcubecore/HardwareObjects/ESRF/ID29MultiCollect.py
@@ -216,7 +211,6 @@ force-exclude = '''
   | mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
   | mxcubecore/HardwareObjects/ISPyBClient.py
   | mxcubecore/HardwareObjects/MAXIV/BIOMAXEiger.py
-  | mxcubecore/HardwareObjects/MotorsNPosition.py
   | mxcubecore/HardwareObjects/MAXIV/BIOMAXMD3.py
   | mxcubecore/HardwareObjects/PlateManipulatorMaintenance.py
   | mxcubecore/HardwareObjects/MAXIV/BIOMAXCollect.py
@@ -225,7 +219,6 @@ force-exclude = '''
   | mxcubecore/HardwareObjects/SOLEIL/PX2/PX2Resolution.py
   | mxcubecore/HardwareObjects/SOLEIL/PX1/PX1Pilatus.py
   | mxcubecore/HardwareObjects/SOLEIL/PX2/PX2Collect.py
-  | mxcubecore/HardwareObjects/SOLEIL/SOLEILLdapLogin.py
   | mxcubecore/HardwareObjects/SOLEIL/TangoDCMotor.py
   | mxcubecore/HardwareObjects/SOLEIL/PX1/PX1Collect.py
   | mxcubecore/HardwareObjects/SOLEIL/SOLEILMachineInfo.py
@@ -234,9 +227,7 @@ force-exclude = '''
   | mxcubecore/HardwareObjects/abstract/sample_changer/Crims.py
   | mxcubecore/HardwareObjects/abstract/AbstractCollect.py
   | mxcubecore/HardwareObjects/mockup/MotorMockup.py
-  | mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
   | mxcubecore/HardwareObjects/mockup/ShutterMockup.py
-  | mxcubecore/HardwareObjects/mockup/XRFSpectrumMockup.py
   | mxcubecore/Poller.py
   | mxcubecore/HardwareObjects/mockup/PlateManipulatorMockup.py
   | mxcubecore/model/crystal_symmetry.py

--- a/test/pytest/test_command_container.py
+++ b/test/pytest/test_command_container.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 @pytest.fixture(scope="function")
 def cmd_object() -> Generator[CommandObject, None, None]:
-    """Pytest fixture to instanciate a new "CommandObject" object.
+    """Pytest fixture to instantiate a new "CommandObject" object.
 
     Yields:
         Generator[CommandObject, None, None]: New object instance.
@@ -32,7 +32,7 @@ def cmd_object() -> Generator[CommandObject, None, None]:
 
 @pytest.fixture(scope="function")
 def channel_object() -> Generator[ChannelObject, None, None]:
-    """Pytest fixture to instanciate a new "ChannelObject" object.
+    """Pytest fixture to instantiate a new "ChannelObject" object.
 
     Yields:
         Generator[ChannelObject, None, None]: New object instance.
@@ -44,7 +44,7 @@ def channel_object() -> Generator[ChannelObject, None, None]:
 
 @pytest.fixture(scope="function")
 def cmd_container() -> Generator[CommandContainer, None, None]:
-    """Pytest fixture to instanciate a new "CommandContainer" object.
+    """Pytest fixture to instantiate a new "CommandContainer" object.
 
     Yields:
         Generator[CommandContainer, None, None]: New object instance.

--- a/test/pytest/test_hwo_maxiv_mach_info.py
+++ b/test/pytest/test_hwo_maxiv_mach_info.py
@@ -2,7 +2,7 @@ import math
 import pytest
 from gevent.event import Event
 from tango.server import Device, attribute, command
-from tango.test_context import DeviceTestContext, MultiDeviceTestContext
+from tango.test_context import MultiDeviceTestContext
 from mxcubecore.HardwareObjects.MAXIV.MachInfo import MachInfo
 
 


### PR DESCRIPTION
- fix typos and wording in comments and doc strings
- remove incorrect type hint
- remove commented out code
- remove unused and duplicated imports
- trim linters exclude lists