### PR TITLE
docs: add section on removed set_property()

### DIFF
--- a/docs/source/dev/yaml_conf_migration.md
+++ b/docs/source/dev/yaml_conf_migration.md
@@ -186,3 +186,11 @@ class Shanxi(HardwareObject):
     def __init__(self, name):
         super().__init__(name)
 ```
+
+## `set_property()` method removed
+
+The hardware object method `set_property()` has been removed.
+It is no longer possible to set hardware object configuration properties from python code.
+For static properties, move them to the hardware object configuration file.
+If your code is setting properties dynamically,
+you need to refactor the code to not rely on this deprecated feature.


### PR DESCRIPTION
Adds a section on removed `set_property()` method to **YAML configuration migration** guide.

Here I assume that it was decided to drop this method. Not sure what was the actual decision was.