### PR TITLE
actions: notify teams upon new discussion in category

### DIFF
--- a/.github/workflows/discussions.yml
+++ b/.github/workflows/discussions.yml
@@ -1,0 +1,90 @@
+---
+# This workflow notifies working groups about new discussions in their corresponding
+# categories, by mentioning the Team in a first comment.
+# It is necessary since GitHub doesn't support subsriptions to discussion categories
+# see related feature request: https://github.com/orgs/community/discussions/3951
+# If GitHub implements this feature, this workflow becomes obsolete.
+
+# To work, this workflow requires a GitHub App installed on the repository with the
+# following permissions:
+#   - Write and Read of repository Discussions
+#   - Read of Organization members (needed for reading the teams)
+
+# !! You need to make sure that the app's id and a generated private key are saved
+# as corresponding organization secrets !!
+
+name: Notify Team on New Discussion
+"on":
+  discussion:
+    types: [created]
+
+jobs:
+  notify_team:
+    runs-on: ubuntu-latest
+    steps:
+      # First generate the app token for authentication
+      - name: Get GitHub App token
+        id: github-app-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Notify Team
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.github-app-token.outputs.token }}
+          script: |
+            const discussion = context.payload.discussion;
+            const category = discussion.category.name;
+
+            const query = `
+              query($discussionNumber: Int!) {
+                repository(
+                  owner: "${context.repo.owner}",
+                  name: "${context.repo.repo}"
+                ) {
+                  discussion(number: $discussionNumber) {
+                    id
+                  }
+                }
+              }
+            `;
+
+            const mutation = `
+              mutation($discussionId: ID!, $body: String!) {
+                addDiscussionComment(
+                  input: {discussionId: $discussionId, body: $body}
+                ) {
+                  comment {
+                    id
+                    body
+                  }
+                }
+              }
+            `;
+
+            const response = await github.graphql(query, {
+              discussionNumber: discussion.number
+            });
+
+            const discussionId = response.repository.discussion.id;
+
+            const teams = await github.rest.teams.list({
+              org: context.repo.owner,
+            });
+
+            const team = teams.data.find(t => t.name === category);
+
+            if (team) {
+              const teamMention = `${context.repo.owner}/${team.slug}`;
+              const commentBody = `@${teamMention} A new discussion was created in the`
+                                   + ` "${category}" category: ${discussion.html_url}`;
+
+              await github.graphql(mutation, {
+                discussionId: discussionId,
+                body: commentBody
+              });
+            } else {
+              console.log(`No team found for category: ${category}`);
+            }


### PR DESCRIPTION
This PR aims at making the communication in Work Groups easier. Instead of having one discussion, the idea was to use Github's discussion categories, so that different discussions can be grouped under one topic (i.e. Cybersecurity, Automation, ...). There is an issue however regarding Github's notification system, as you cannot subscribe to a category in the discussion session. 
To fix this issue, this PR adds an action that triggers every time there is a new discussion, it then checks for the category in which the discussion has started and notifies every member in the corresponding Team. By adding the "@team" as a comment in the discussion.
For it to work the category name must be the same as the team name (otherwise no notification will be added). Additionally, a secret should be added as "DISCUSSIONS_NOTIFICATIONS" which allows reading of teams in the organization and the writing of comments in the discussions section.