### PR TITLE
[type hint] fix for Python 3.8 incompatible typehints

### DIFF
--- a/mxcubecore/HardwareObjects/Harvester.py
+++ b/mxcubecore/HardwareObjects/Harvester.py
@@ -40,6 +40,7 @@ It has some functionalities, like Harvest Sample, etc....
     </object>
 -----------------------------------------------------------------
 """
+from __future__ import annotations
 import gevent
 import logging
 from typing import Optional


### PR DESCRIPTION
@marcus-oscarsson  @woutdenolf As suggest i had the the line to fix the [issue](https://github.com/mxcube/mxcubecore/issues/1030)