### PR TITLE
adds support for configuring commands and channels using YAML

### DIFF
--- a/docs/source/dev/commands_channels.md
+++ b/docs/source/dev/commands_channels.md
@@ -1,0 +1,297 @@
+# Commands and Channels
+
+The mxcubecore provides a hardware object-level abstraction
+for communicating using various flavors of control system protocols.
+A hardware object can utilize instances of
+[`CommandObject`](#mxcubecore.CommandContainer.CommandObject) and
+[`ChannelObject`](#mxcubecore.CommandContainer.ChannelObject) objects.
+These objects provide a uniform API for accessing a specific control system.
+Mxcubecore provides support for using protocols such as
+[_Tango_](https://www.tango-controls.org/),
+[_EPICS_](https://docs.epics-controls.org),
+_exporter_ and more.
+
+The `CommandObject` and `ChannelObject` objects can be created using the `add_command()` and `add_channel()` methods of hardware objects.
+Another option is to specify them in the hardware object's configuration file.
+If `CommandObject` and `ChannelObject` are specified in the configuration file,
+the specified objects will be automatically created during hardware object initialization.
+
+## Configuration files format
+
+The general format for specifying `CommandObject` and `ChannelObject` objects is as follows:
+
+```yaml
+class: <hardware-object-class>
+<protocol>:                      # protocol in use, tango / exporter / epics / etc
+  <end-point>:                   # tango device / exporter address / EPICS prefix / etc
+    commands:
+      <command-1-name>:          # command's MXCuBE name
+        <config-prop-1>: <val-1>
+        <config-prop-2>: <val-2>
+    channels:
+      <channel-1-name>:          # channel's MXCuBE Name
+        <config-prop-1>: <val-1>
+        <config-prop-2>: <val-2>
+```
+
+The `CommandObject` and `ChannelObject` specification are grouped by the protocol they are using.
+Each protocol have its own dedicated section in the configuration file.
+The semantics for the protocol are similar but protocol-specific, see below for details.
+
+Currently, the following protocols can be configured using YAML configuration files:
+
+ - [Tango](#tango-protocol)
+ - [exporter](#exporter-protocol)
+ - [EPICS](#epics-protocol)
+
+## Tango Protocol
+
+The format for specifying _tango_ `CommandObject` and `ChannelObject` objects is as follows:
+
+```yaml
+class: <hardware-object-class>
+tango:
+  <tango-device-name>:
+    commands:
+      <command-1-name>:
+        <config-prop-1>: <val-1>
+      <command-2-name>:
+        <config-prop-1>: <val-1>
+    channels:
+      <channel-1-name>:
+        <config-prop-1>: <val-1>
+        <config-prop-2>: <val-2>
+      <channel-2-name>:
+        <config-prop-1>: <val-1>
+```
+
+`<tango-device-name>` specifies the tango device to use.
+Multiple `<tango-device-name>` sections can be specified, in order to use different tango devices.
+Each `<tango-device-name>` contains optional `commands` and `channels` sections.
+These sections specify `CommandObject` and `ChannelObject` object to create using the `<tango-device-name>` tango device.
+
+### Commands
+
+`commands` is a dictionary where each key specifies a `CommandObject` object.
+The key defines the MXCuBE name for the command.
+The values specify an optional dictionary with configuration properties for the `CommandObject` object.
+The following configuration properties are supported:
+
+| property | purpose            | default             |
+|----------|--------------------|---------------------|
+| name     | tango command name | MXCuBE command name |
+
+### Channels
+
+`channels` is a dictionary where each key specifies a `ChannelObject` object.
+The key defines the MXCuBE name for the channel.
+The values specify an optional dictionary with configuration properties for the `ChannelObject` object.
+The following configuration properties are supported:
+
+| property       | purpose                            | default             |
+|----------------|------------------------------------|---------------------|
+| attribute      | tango attribute name               | MXCuBE channel name |
+| polling_period | polling periodicity, milliseconds  | polling is disabled |
+| timeout        | tango device timeout, milliseconds | 10000               |
+
+By default, a tango `ChannelObject` object will use tango attribute change event, in order to receive new attribute values.
+For this to work, the tango device must send the change events for the attribute.
+For cases where such events are not sent, the attribute polling can be enabled.
+If `polling` property is specified, MXCuBE will poll the tango attribute with specified periodicity.
+
+### Example
+
+Below is an example of a hardware object that specifies Tango commands and channels.
+
+```yaml
+class: MyTango
+tango:
+  some/tango/device:
+    commands:
+      Open:
+      Close:
+      Reset:
+        name: Reboot
+    channels:
+      State:
+      Volume:
+          attribute: currentVolume
+          poll: 1024
+```
+
+In the above example, commands `Open`, `Close` and `Reset` as well as channels `State` and `Volume` are configured.
+All command and channel objects are bound to the commands and attributes of the _some/tango/device_ tango device.
+
+`Open` and `Close` commands are bound to _Open_ and _Close_ Tango commands.
+The `Reset` has a configuration property that binds it to _Reboot_ tango command.
+
+The `State` channel will be mapped to _State_ attribute of the Tango device.
+Its value will be updated via Tango change events.
+
+The `Volume` channel will be mapped to the _currentVolume_ attribute of the tango device.
+The _currentVolume_ attribute's value will be polled every 1024 milliseconds.
+
+## Exporter Protocol
+
+The format for specifying _exporter_ `CommandObject` and `ChannelObject` objects is as follows:
+
+```yaml
+class: <hardware-object-class>
+tango:
+  <exporter-address>:
+    commands:
+      <command-1-name>:
+        <config-prop-1>: <val-1>
+      <command-2-name>:
+        <config-prop-1>: <val-1>
+    channels:
+      <channel-1-name>:
+        <config-prop-1>: <val-1>
+      <channel-2-name>:
+        <config-prop-1>: <val-1>
+```
+
+`<exporter-address>` specifies the exporter address to use.
+Multiple `<exporter-address>` sections can be specified to use devices at different addresses.
+Each `<exporter-address>` contains optional `commands` and `channels` sections.
+These sections specify `CommandObject` and `ChannelObject` objects to create using the `<exporter-address>` tango device.
+
+`<exporter-address>` specifies the exporter's host and port number.
+It has the following format: `<host>:<port>`.
+`<host>` is the host name or IP address to use.
+`<port>` is the TCP port number to use.
+Note that, due to YAML parsing rules, you need to use quotes when specifying the exporter address.
+Below is an example of an exporter address that can be used in a YAML configuration file:
+
+```
+"foo.example.com:9001"
+```
+
+### Commands
+
+`commands` is a dictionary where each key specifies a `CommandObject` object.
+The key defines the MXCuBE name for the command.
+The values specify an optional dictionary with configuration properties for the `CommandObject` object.
+The following configuration properties are supported:
+
+| property | purpose               | default             |
+|----------|-----------------------|---------------------|
+| name     | exporter command name | MXCuBE command name |
+
+### Channels
+
+`channels` is a dictionary where each key specifies a `ChannelObject` object.
+The key defines the MXCuBE name for the channel.
+The values specify an optional dictionary with configuration properties for the `ChannelObject` object.
+The following configuration properties are supported:
+
+| property  | purpose                  | default             |
+|-----------|--------------------------|---------------------|
+| attribute | exporter attribute name  | MXCuBE channel name |
+
+### Example
+
+Below is an example of a hardware object that specifies exporter commands and channels.
+
+```yaml
+class: MyExporter
+exporter:
+  "foo.example.com:9001":
+    commands:
+      Open:
+      Close:
+      Reset:
+        name: Reboot
+    channels:
+      State:
+      Volume:
+          attribute: currentVolume
+```
+
+In the above example, commands `Open`, `Close` and `Reset` as well as `State` and `Volume` channels are configured.
+All command and channel objects are bound to the exporter host _foo.example.com_ at port _9001_.
+
+`Open` and `Close` commands are bound to _Open_ and _Close_ exporter commands.
+The `Reset` has a configuration property that binds it to the _Reboot_ exporter command.
+
+The `State` channel will be mapped to _State_ exporter attribute.
+The `Volume` channel will be mapped to _currentVolume_ exporter attribute.
+
+## EPICS Protocol
+
+The format for specifying _EPICS_ `ChannelObject` objects is as follows:
+
+```yaml
+class: EpicsCommunicator
+epics:
+  <prefix>:
+    channels:
+      <channel-1-name>:
+        <config-prop-1>: <val-1>
+        <config-prop-2>: <val-2>
+      <channel-2-name>:
+        <config-prop-1>: <val-1>
+```
+
+`<prefix>` specifies the EPICS PV prefix to use for that section.
+Multiple `<prefix>` sections can be specified, in case not all channels share a common prefix.
+Each `<prefix>` contains a `channels` section, which specifies `ChannelObject` objects to create.
+
+It is also possible to use the empty string, `""`, as the prefix.
+This is useful in cases where none of the channels share a common prefix.
+See [below](#pv-names) for details on how channel PV names are determined.
+
+### Channels
+
+`channels` is a dictionary where each key specifies a `ChannelObject` object.
+The key defines the MXCuBE name for the channel.
+The values specify an optional dictionary with configuration properties for the `ChannelObject` object.
+The following configuration properties are supported:
+
+| property | purpose               | default             |
+|----------|-----------------------|---------------------|
+| suffix   | PV name suffix        | MXCuBE channel name |
+| poll     | polling periodicity   |                     |
+
+#### PV names
+
+The PV name of a channel is determined by concatenating its section's prefix and the specified `suffix`.
+If no suffix is specified, the channel's MXCuBE name is used in place of the `suffix`.
+Observe an example configuration below:
+
+```yaml
+class: EpicsCommunicator
+epics:
+  "FOO:B:":
+    channels:
+      State:
+        suffix: pv_1.STAT
+      Vol:
+        suffix: volume.VAL
+      Freq:
+```
+
+Her we have an `FOO:B:` prefix specified, with channels `State`, `Vol` and `Freq`.
+The `State` channel will use `FOO:B:pv_1.STAT` PV name, specified by section's prefix and the `suffix` configuration property.
+The `Vol` channel's PV name will be`FOO:B:volume.VAL`.
+The `Freq` channel's PV name becomes `FOO:B:Freq`, specified by section's prefix and channel's MXCuBE name.
+
+### Example
+
+Below is an example of a hardware object that specifies EPICS channels.
+
+```yaml
+class: EpicsCommunicator
+epics:
+  "MNC:B:PB04.":
+    channels:
+      State:
+      Volume:
+          suffix: vlm
+          poll: 512
+```
+
+In the above example channels `State` and `Volume` are configured.
+The `State` channel will be mapped to PV name _MNC:B:PB04.State_.
+The `Volume` channel will be mapped to PV name _MNC:B:PB04.vlm_.
+For `Volume` channel, polling will be enabled.

--- a/docs/source/dev/configuration_files.md
+++ b/docs/source/dev/configuration_files.md
@@ -59,18 +59,27 @@ and an `init()` function that is executed after configured parameters and contai
 Below is an example YAML configuration file:
 
 ```yaml
-class: ISPyBClientMockup.ISPyBClientMockup
+class: Orkhon.Erdenet
 configuration:
-  base_result_url: https://your.limsresults.org
-  login_type: proposal
+  altai: big
+  choir: 52
 objects:
-  lims_rest: lims_rest.yaml
+  darkhan: darkhan.yaml
   session: session.yaml
+tango:
+  "some/tango/device":
+    commands:
+      Open:
+      Close:
+    channels:
+      State:
 ```
 
-This file specifies a hardware object, which is an instance of the `ISPyBClientMockup` class.
-That object will have two configuration properties `base_result_url` and `login_type`.
-Two child objects with roles `lims_rest` and `session` will be loaded from the specified configuration files.
+This file specifies a hardware object, which is an instance of the `Erdenet` class from `Orkhon` module.
+That object will have two configuration properties `altai` and `choir`.
+Two child objects with roles `darkhan` and `session` will be loaded from the specified configuration files.
+The hardware object will also have access to command objects `Open` and `Close`, and a `State` channel object.
+See [Commands and Channels](commands_channels.md) section for details on how to specify command and channel bindings.
 
 ### Accessing configuration properties
 

--- a/docs/source/dev/index.rst
+++ b/docs/source/dev/index.rst
@@ -12,7 +12,14 @@ Developer documentation
     :maxdepth: 2
     :titlesonly:
 
-    *
-
+    contributing
+    docs
+    configuration_files
+    commands_channels
+    queue
+    abstract_classes
+    api
+    json-schema-generated-user-interface
+    yaml_conf_migration
 
 ..  # EOF

--- a/mxcubecore/CommandContainer.py
+++ b/mxcubecore/CommandContainer.py
@@ -18,15 +18,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 
-"""CommandContainer module
-
-Classes:
-- CommandContainer, a special mixin class to be used with
-Hardware Objects. It defines a container
-for command launchers and channels (see Command package).
-- C*Object, command launcher & channel base class
-"""
-
 from __future__ import absolute_import
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 
@@ -51,6 +42,8 @@ class ConnectionError(Exception):
 
 
 class CommandObject:
+    """Command launcher base class"""
+
     def __init__(self, name: str, username: Optional[str] = None, **kwargs) -> None:
         """
         Args:
@@ -170,6 +163,8 @@ class CommandObject:
 
 
 class ChannelObject:
+    """Channel base class"""
+
     def __init__(self, name: str, username: Optional[str] = None, **kwargs) -> None:
         """
         Args:

--- a/mxcubecore/HardwareRepository.py
+++ b/mxcubecore/HardwareRepository.py
@@ -45,6 +45,7 @@ from mxcubecore.utils.conversion import string_types, make_table
 from mxcubecore.dispatcher import dispatcher
 from mxcubecore import BaseHardwareObjects
 from mxcubecore import HardwareObjectFileParser
+from mxcubecore.protocols_config import setup_commands_channels
 
 from warnings import warn
 
@@ -172,6 +173,8 @@ def load_from_yaml(
         config = configuration.pop("configuration", {})
         # Set configuration with non-object properties.
         result._config = result.HOConfig(**config)
+
+        setup_commands_channels(result, configuration)
 
         if _container is None:
             load_time = 1000 * (time.time() - start_time)

--- a/mxcubecore/model/protocols/epics.py
+++ b/mxcubecore/model/protocols/epics.py
@@ -1,0 +1,47 @@
+"""Models the `epics` section of YAML hardware configuration file.
+
+Provides an API to read configured EPICS channels.
+"""
+from typing import Optional, Iterable, Tuple, Dict
+from pydantic import BaseModel
+
+
+class Channel(BaseModel):
+    """EPICS channel configuration."""
+
+    suffix: Optional[str]
+    poll: Optional[int]
+
+
+class Prefix(BaseModel):
+    """Configuration of an EPICS prefix section."""
+
+    channels: Optional[Dict[str, Optional[Channel]]]
+
+    def get_channels(self) -> Iterable[Tuple[str, Channel]]:
+        """Get all channels configured for prefix.
+
+        This method will fill in optional configuration properties for a channel.
+        """
+
+        if self.channels is None:
+            return []
+
+        for channel_name, channel_config in self.channels.items():
+            if channel_config is None:
+                channel_config = Channel()
+
+            if channel_config.suffix is None:
+                channel_config.suffix = channel_name
+
+            yield channel_name, channel_config
+
+
+class EpicsConfig(BaseModel):
+    """The 'epics' section of the hardware object's YAML configuration file."""
+
+    __root__: Dict[str, Prefix]
+
+    def get_prefixes(self) -> Iterable[Tuple[str, Prefix]]:
+        """Get all prefixes specified in this section."""
+        return list(self.__root__.items())

--- a/mxcubecore/model/protocols/exporter.py
+++ b/mxcubecore/model/protocols/exporter.py
@@ -1,0 +1,71 @@
+"""Models the `exporter` section of YAML hardware configuration file.
+
+Provides an API to read configured exporter channels and commands.
+"""
+from typing import Optional, Iterable, Tuple, Dict
+from pydantic import BaseModel
+
+
+class Command(BaseModel):
+    """Exporter command configuration."""
+
+    # name of the exporter device command
+    name: Optional[str]
+
+
+class Channel(BaseModel):
+    """Exporter channel configuration."""
+
+    attribute: Optional[str]
+
+
+class Address(BaseModel):
+    """Configuration of an exporter end point."""
+
+    commands: Optional[Dict[str, Optional[Command]]]
+    channels: Optional[Dict[str, Optional[Channel]]]
+
+    def get_commands(self) -> Iterable[tuple[str, Command]]:
+        """Get all commands configured for this exporter address.
+
+        This method will fill in optional configuration properties the commands.
+        """
+
+        if self.commands is None:
+            return []
+
+        for command_name, command_config in self.commands.items():
+            if command_config is None:
+                command_config = Command()
+
+            if command_config.name is None:
+                command_config.name = command_name
+
+            yield command_name, command_config
+
+    def get_channels(self) -> Iterable[Tuple[str, Channel]]:
+        """Get all channels configured for this exporter address.
+
+        This method will fill in optional configuration properties for channels.
+        """
+        if self.channels is None:
+            return []
+
+        for channel_name, channel_config in self.channels.items():
+            if channel_config is None:
+                channel_config = Channel()
+
+            if channel_config.attribute is None:
+                channel_config.attribute = channel_name
+
+            yield channel_name, channel_config
+
+
+class ExporterConfig(BaseModel):
+    """The 'exporter' section of the hardware object's YAML configuration file."""
+
+    __root__: Dict[str, Address]
+
+    def get_addresses(self) -> Iterable[Tuple[str, Address]]:
+        """Get all exporter addresses specified in this section."""
+        return list(self.__root__.items())

--- a/mxcubecore/model/protocols/tango.py
+++ b/mxcubecore/model/protocols/tango.py
@@ -1,0 +1,72 @@
+"""Models the `tango` section of YAML hardware configuration file.
+
+Provides an API to read configured tango channels and commands.
+"""
+from typing import Optional, Iterable, Tuple, Dict
+from pydantic import BaseModel
+
+
+class Command(BaseModel):
+    """Tango command configuration."""
+
+    # name of the tango device command
+    name: Optional[str]
+
+
+class Channel(BaseModel):
+    """Tango channel configuration."""
+
+    attribute: Optional[str]
+    polling_period: Optional[int]
+    timeout: Optional[int]
+
+
+class Device(BaseModel):
+    """Configuration of a tango device."""
+
+    commands: Optional[Dict[str, Optional[Command]]]
+    channels: Optional[Dict[str, Optional[Channel]]]
+
+    def get_commands(self) -> Iterable[Tuple[str, Command]]:
+        """Get all commands configured for this device.
+
+        This method will fill in optional configuration properties for commands.
+        """
+        if self.commands is None:
+            return []
+
+        for command_name, command_config in self.commands.items():
+            if command_config is None:
+                command_config = Command()
+
+            if command_config.name is None:
+                command_config.name = command_name
+
+            yield command_name, command_config
+
+    def get_channels(self) -> Iterable[Tuple[str, Channel]]:
+        """Get all channels configured for this device.
+
+        This method will fill in optional configuration properties for a channel.
+        """
+        if self.channels is None:
+            return []
+
+        for channel_name, channel_config in self.channels.items():
+            if channel_config is None:
+                channel_config = Channel()
+
+            if channel_config.attribute is None:
+                channel_config.attribute = channel_name
+
+            yield channel_name, channel_config
+
+
+class TangoConfig(BaseModel):
+    """The 'tango' section of the hardware object's YAML configuration file."""
+
+    __root__: Dict[str, Device]
+
+    def get_tango_devices(self) -> Iterable[Tuple[str, Device]]:
+        """Get all tango devices specified in this section."""
+        return list(self.__root__.items())

--- a/mxcubecore/protocols_config.py
+++ b/mxcubecore/protocols_config.py
@@ -1,0 +1,132 @@
+"""
+Provides an API to add Command and Channel objects to hardware objects,
+as specified in it's YAML configuration file.
+
+See setup_commands_channels() function for details.
+"""
+from __future__ import annotations
+from typing import Iterable, Callable
+from mxcubecore.BaseHardwareObjects import HardwareObject
+
+
+def _setup_tango_commands_channels(hwobj: HardwareObject, tango_config: dict):
+    """Set up Tango Command and Channel objects.
+
+    parameters:
+        tango: the 'tango' section of the hardware object's configuration
+    """
+    from mxcubecore.model.protocols.tango import TangoConfig, Device
+
+    def setup_tango_device(device_name: str, device_config: Device):
+        #
+        # set-up commands
+        #
+        for command_name, command_config in device_config.get_commands():
+            attrs = dict(type="tango", name=command_config.name, tangoname=device_name)
+            hwobj.add_command(attrs, command_name)
+
+        #
+        # set-up channels
+        #
+        for channel_name, channel_config in device_config.get_channels():
+            attrs = dict(type="tango", name=channel_name, tangoname=device_name)
+
+            if channel_config.polling_period:
+                attrs["polling"] = channel_config.polling_period
+
+            if channel_config.timeout:
+                attrs["timeout"] = channel_config.timeout
+
+            hwobj.add_channel(attrs, channel_config.attribute)
+
+    tango_cfg = TangoConfig.parse_obj(tango_config)
+    for device_name, device_config in tango_cfg.get_tango_devices():
+        setup_tango_device(device_name, device_config)
+
+
+def _setup_exporter_commands_channels(hwobj: HardwareObject, exporter_config: dict):
+    from mxcubecore.model.protocols.exporter import ExporterConfig, Address
+
+    def setup_address(address: str, address_config: Address):
+        #
+        # set-up commands
+        #
+        for command_name, command_config in address_config.get_commands():
+            attrs = dict(
+                type="exporter", exporter_address=address, name=command_config.name
+            )
+            hwobj.add_command(attrs, command_name)
+
+        #
+        # set-up channels
+        #
+        for channel_name, channel_config in address_config.get_channels():
+            attrs = dict(type="exporter", exporter_address=address, name=channel_name)
+            hwobj.add_channel(attrs, channel_config.attribute)
+
+    exp_cfg = ExporterConfig.parse_obj(exporter_config)
+    for address, address_config in exp_cfg.get_addresses():
+        setup_address(address, address_config)
+
+
+def _setup_epics_channels(hwobj: HardwareObject, epics_config: dict):
+    from mxcubecore.model.protocols.epics import EpicsConfig, Prefix
+
+    def setup_prefix(prefix: str, prefix_config: Prefix):
+        #
+        # set-up channels
+        #
+        for channel_name, channel_config in prefix_config.get_channels():
+            attrs = dict(type="epics", name=channel_name)
+            if channel_config.poll:
+                attrs["polling"] = channel_config.poll
+
+            pv_name = f"{prefix}{channel_config.suffix}"
+            hwobj.add_channel(attrs, pv_name)
+
+    epics_cfg = EpicsConfig.parse_obj(epics_config)
+    for prefix, prefix_config in epics_cfg.get_prefixes():
+        setup_prefix(prefix, prefix_config)
+
+
+def _protocol_handles():
+    return {
+        "tango": _setup_tango_commands_channels,
+        "exporter": _setup_exporter_commands_channels,
+        "epics": _setup_epics_channels,
+    }
+
+
+def _get_protocol_names() -> Iterable[str]:
+    """Get names of all supported protocols."""
+    return _protocol_handles().keys()
+
+
+def _get_protocol_handler(protocol_name: str) -> Callable:
+    """Get the callable that will set up commands and channels for a specific protocol."""
+    return _protocol_handles()[protocol_name]
+
+
+def _setup_protocol(hwobj: HardwareObject, config: dict, protocol: str):
+    """Add the Command and Channel objects configured in the specified protocol section.
+
+    parameters:
+        protocol: name of the protocol to handle
+    """
+    protocol_config = config.get(protocol)
+    if protocol_config is None:
+        # no configuration for this protocol
+        return
+
+    _get_protocol_handler(protocol)(hwobj, protocol_config)
+
+
+def setup_commands_channels(hwobj: HardwareObject, config: dict):
+    """Add the Command and Channel objects to a hardware object, as specified in the config.
+
+    parameters:
+        hwobj: hardware object where to add Command and Channel objects
+        config: the complete hardware object configuration, i.e. parsed YAML file as dict
+    """
+    for protocol in _get_protocol_names():
+        _setup_protocol(hwobj, config, protocol)


### PR DESCRIPTION
Adds support for configuring commands and channels using YAML. Currently it's possible to configure `Tango`, `exporter` and `EPICS` commands and channels.

This implements roughly the format discussed in: https://github.com/mxcube/mxcubecore/issues/1023
The actual format implement is documented here: https://mxcubecore--1034.org.readthedocs.build/en/1034/dev/commands_channels.html

This is still work in progress. Still on the todo list:

* write some tests
* do a bit more "manual" testing

I would like to get some feedback, before spending more time on this.