### PR TITLE
Prevent mockup value to be set to exception on abort

### DIFF
--- a/mxcubecore/HardwareObjects/mockup/ActuatorMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/ActuatorMockup.py
@@ -108,7 +108,8 @@ class ActuatorMockup(AbstractActuator.AbstractActuator):
 
     def _callback(self, move_task):
         value = move_task.get()
-        self._set_value(value)
+        if not isinstance(value, gevent.GreenletExit):
+            self._set_value(value)
 
     def _set_value(self, value):
         """


### PR DESCRIPTION
This PR closes #1037.
Previously, aborting a value change would set the value of an mockup actuator to an exception, instead of a value. With these changes, the value remains the last actually set value.