### PR TITLE
[Harvester] FIx typo

### DIFF
--- a/mxcubecore/HardwareObjects/EMBLFlexHarvester.py
+++ b/mxcubecore/HardwareObjects/EMBLFlexHarvester.py
@@ -31,7 +31,7 @@ import gevent
 
 from mxcubecore.TaskUtils import task
 
-from mxcubecore.HardwareObjects import EMBLFlexHCD
+from mxcubecore.HardwareObjects.EMBLFlexHCD import EMBLFlexHCD
 
 
 class EMBLFlexHarvester(EMBLFlexHCD):

--- a/mxcubecore/HardwareObjects/Harvester.py
+++ b/mxcubecore/HardwareObjects/Harvester.py
@@ -192,7 +192,6 @@ class Harvester(HardwareObject):
             if cmd.startswith("set"):
                 ret = exp_attr.set_value(args_str)
 
-        self._wait_ready(timeout=timeout)
         return ret
 
     # ---------------------- State --------------------------------

--- a/mxcubecore/HardwareObjects/HarvesterMaintenance.py
+++ b/mxcubecore/HardwareObjects/HarvesterMaintenance.py
@@ -210,7 +210,7 @@ class HarvesterMaintenance(HardwareObject):
                 md.centringVertical.set_value_relative(sample_drift_y, None)
 
                 md.save_current_motor_position()
-                self._harvester.calibration_state(True)
+                self._harvester.set_calibration_state(True)
 
                 logging.getLogger("user_level_log").info(
                     "Pin Calibration Step 1 Succeed"


### PR DESCRIPTION
- FIx EMBLFlexHCD inheritance Object is a module, not a class Error
- remove unnecessary wait command 
- fix Typo, call set method instead