### PR TITLE
ISPyB client: handle boolean loginTranslate property correctly

### DIFF
--- a/mxcubecore/HardwareObjects/ISPyBClient.py
+++ b/mxcubecore/HardwareObjects/ISPyBClient.py
@@ -197,7 +197,7 @@ class ISPyBClient(HardwareObject):
             if self.ldapConnection is None:
                 logging.getLogger("HWR").debug("LDAP Server is not available")
 
-        self.loginTranslate = self.get_property("loginTranslate") or True
+        self.loginTranslate = self.get_property("loginTranslate", True)
         self.beamline_name = HWR.beamline.session.beamline_name
 
         self.ws_root = self.get_property("ws_root")


### PR DESCRIPTION
When using YAML config file for ISPyBClient hardware object, it feels natural to use YAML boolean type for `loginTranslate` property. For example a following config file:

```
  class: ISPyBClient.ISPyBClient
  configuration:
    authServerType: ispyb
    loginTranslate: false
```

This change fixes a bug where `self.loginTranslate` would be assigned True value for the config file above.