### PR TITLE
Added a way for Shape to preserve user preferred state

### DIFF
--- a/mxcubecore/HardwareObjects/SampleView.py
+++ b/mxcubecore/HardwareObjects/SampleView.py
@@ -183,7 +183,12 @@ class SampleView(AbstractSampleView):
         shape.shapes_hw_object = self
 
     def add_shape_from_mpos(
-        self, mpos_list, screen_coord, t, user_state: ShapeState = "SAVED"
+        self,
+        mpos_list,
+        screen_coord,
+        t,
+        state: ShapeState = "SAVED",
+        user_state: ShapeState = "SAVED",
     ):
         """
         Adds a shape of type <t>, with motor positions from mpos_list and
@@ -203,15 +208,17 @@ class SampleView(AbstractSampleView):
 
         if _cls:
             shape = _cls(mpos_list, screen_coord)
-            # In case the shape is being recreated, we need to restore it.
-            shape.state = user_state
+            # In case the shape is being recreated, we need to restore it's state.
+            shape.state = state
             shape.user_state = user_state
 
             self.add_shape(shape)
 
         return shape
 
-    def add_shape_from_refs(self, refs, t, user_state: ShapeState = "SAVED"):
+    def add_shape_from_refs(
+        self, refs, t, state: ShapeState = "SAVED", user_state: ShapeState = "SAVED"
+    ):
         """
         Adds a shape of type <t>, taking motor positions and screen positions
         from reference points in refs.
@@ -226,7 +233,7 @@ class SampleView(AbstractSampleView):
         mpos = [self.get_shape(refid).mpos() for refid in refs]
         spos_list = [self.get_shape(refid).screen_coord for refid in refs]
         spos = reduce((lambda x, y: tuple(x) + tuple(y)), spos_list, ())
-        shape = self.add_shape_from_mpos(mpos, spos, t, user_state)
+        shape = self.add_shape_from_mpos(mpos, spos, t, state, user_state)
         shape.refs = refs
 
         return shape

--- a/mxcubecore/HardwareObjects/SampleView.py
+++ b/mxcubecore/HardwareObjects/SampleView.py
@@ -29,7 +29,10 @@ import numpy as np
 from PIL import Image
 
 from mxcubecore import HardwareRepository as HWR
-from mxcubecore.HardwareObjects.abstract.AbstractSampleView import AbstractSampleView
+from mxcubecore.HardwareObjects.abstract.AbstractSampleView import (
+    AbstractSampleView,
+    ShapeState,
+)
 from mxcubecore.model import queue_model_objects
 
 
@@ -179,7 +182,9 @@ class SampleView(AbstractSampleView):
         self.shapes[shape.id] = shape
         shape.shapes_hw_object = self
 
-    def add_shape_from_mpos(self, mpos_list, screen_coord, t):
+    def add_shape_from_mpos(
+        self, mpos_list, screen_coord, t, user_state: ShapeState = "SAVED"
+    ):
         """
         Adds a shape of type <t>, with motor positions from mpos_list and
         screen position screen_coord.
@@ -198,11 +203,15 @@ class SampleView(AbstractSampleView):
 
         if _cls:
             shape = _cls(mpos_list, screen_coord)
+            # In case the shape is being recreated, we need to restore it.
+            shape.state = user_state
+            shape.user_state = user_state
+
             self.add_shape(shape)
 
         return shape
 
-    def add_shape_from_refs(self, refs, t):
+    def add_shape_from_refs(self, refs, t, user_state: ShapeState = "SAVED"):
         """
         Adds a shape of type <t>, taking motor positions and screen positions
         from reference points in refs.
@@ -217,7 +226,7 @@ class SampleView(AbstractSampleView):
         mpos = [self.get_shape(refid).mpos() for refid in refs]
         spos_list = [self.get_shape(refid).screen_coord for refid in refs]
         spos = reduce((lambda x, y: tuple(x) + tuple(y)), spos_list, ())
-        shape = self.add_shape_from_mpos(mpos, spos, t)
+        shape = self.add_shape_from_mpos(mpos, spos, t, user_state)
         shape.refs = refs
 
         return shape
@@ -457,7 +466,10 @@ class Shape(object):
         self.id = ""
         self.cp_list = []
         self.name = ""
-        self.state = "SAVED"
+        self.state: ShapeState = "SAVED"
+        self.user_state: ShapeState = (
+            "SAVED"  # used to persist user preferences in regards wether to show or hide particular shape.
+        )
         self.label = ""
         self.screen_coord = screen_coord
         self.selected = False
@@ -621,6 +633,10 @@ class Grid(Shape):
     def update_position(self, transform):
         phi_pos = HWR.beamline.diffractometer.omega.get_value() % 360
         _d = abs((self.get_centred_position().phi % 360) - phi_pos)
+
+        if self.user_state == "HIDDEN":
+            self.state = "HIDDEN"
+            return
 
         if min(_d, 360 - _d) > self.shapes_hw_object.hide_grid_threshold:
             self.state = "HIDDEN"

--- a/mxcubecore/HardwareObjects/abstract/AbstractSampleView.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractSampleView.py
@@ -159,7 +159,12 @@ class AbstractSampleView(HardwareObject):
 
     @abc.abstractmethod
     def add_shape_from_mpos(
-        self, mpos_list, screen_cord, _type, user_state: ShapeState = "SAVED"
+        self,
+        mpos_list,
+        screen_cord,
+        _type,
+        state: ShapeState = "SAVED",
+        user_state: ShapeState = "SAVED",
     ):
         """Add a shape of type <t>, with motor positions from mpos_list and
         screen position screen_coord.

--- a/mxcubecore/HardwareObjects/abstract/AbstractSampleView.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractSampleView.py
@@ -24,9 +24,14 @@ __copyright__ = """2019 by the MXCuBE collaboration """
 __license__ = "LGPLv3+"
 
 import abc
-from typing import Union
+from typing import (
+    Literal,
+    Union,
+)
 
 from mxcubecore.BaseHardwareObjects import HardwareObject
+
+ShapeState = Literal["HIDDEN", "SAVED", "TMP"]
 
 
 class AbstractSampleView(HardwareObject):
@@ -153,13 +158,16 @@ class AbstractSampleView(HardwareObject):
         return
 
     @abc.abstractmethod
-    def add_shape_from_mpos(self, mpos_list, screen_cord, _type):
+    def add_shape_from_mpos(
+        self, mpos_list, screen_cord, _type, user_state: ShapeState = "SAVED"
+    ):
         """Add a shape of type <t>, with motor positions from mpos_list and
         screen position screen_coord.
         Args:
             mpos_list (list[mpos_list]): List of motor positions
             screen_coord (tuple(x, y): Screen cordinate for shape
             _type (str): Type str for shape, P (Point), L (Line), G (Grid)
+            user_state (ShapeState): State of the shape set by the user
         Returns:
             (Shape): Shape of type _type
         """


### PR DESCRIPTION
The PR introduces `user_state` attribute that will be set by the web app.
Previously, when the user set grid to be hidden or visible, it set `state` attribute of `Grid` class as either `HIDDEN` or `SAVED`. 
The same attribute was being changed as a result of diffractometer's motors having their state changed, like in the code below:

https://github.com/mxcube/mxcubecore/blob/d9668efbc0ea7c2d66536d9e6224beba212a4c40/mxcubecore/HardwareObjects/SampleView.py#L35C1-L56C35

The new `user_state` attribute is being intended to be able to be modified by the web app by listening to events such as `phaseChanged` or `collectOscillationFinished` in order to restore the state that user wants to see, after these operations are done.