### PR TITLE
Snapshots web

### DIFF
--- a/deprecated/HardwareObjects/mockup/MultiCollectMockup.py
+++ b/deprecated/HardwareObjects/mockup/MultiCollectMockup.py
@@ -104,10 +104,6 @@ class MultiCollectMockup(AbstractMultiCollect, HardwareObject):
         self.emit("collectReady", (True,))
 
     @task
-    def take_crystal_snapshots(self, number_of_snapshots):
-        self.bl_control.diffractometer.take_snapshots(number_of_snapshots, wait=True)
-
-    @task
     def data_collection_hook(self, data_collect_parameters):
         return
 

--- a/mxcubecore/HardwareObjects/ESRF/ESRFMultiCollect.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFMultiCollect.py
@@ -47,6 +47,7 @@ class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):
 
     def init(self):
         self._detector = HWR.beamline.detector
+        self.number_of_snapshots = self.get_property("num_snapshots", 4)
 
         self.setControlObjects(
             diffractometer=self.get_object_by_role("diffractometer"),

--- a/mxcubecore/HardwareObjects/ESRF/MD2MultiCollect.py
+++ b/mxcubecore/HardwareObjects/ESRF/MD2MultiCollect.py
@@ -59,17 +59,8 @@ class MD2MultiCollect(ESRFMultiCollect):
         diffr.move_sync_motors(motor_positions_copy, wait=True, timeout=200)
 
     @task
-    def take_crystal_snapshots(self, number_of_snapshots):
-        if HWR.beamline.diffractometer.in_plate_mode():
-            if number_of_snapshots > 0:
-                number_of_snapshots = 1
-        else:
-            # this has to be done before each chage of phase
-            HWR.beamline.diffractometer.save_centring_positions()
-            # not going to centring phase if in plate mode (too long)
-            HWR.beamline.diffractometer.set_phase("Centring", wait=True, timeout=600)
-
-        HWR.beamline.diffractometer.take_snapshots(number_of_snapshots, wait=True)
+    def take_crystal_snapshots(self, number_of_snapshots, image_path_list=[]):
+        HWR.beamline.diffractometer.new_take_snapshot(image_path_list)
 
     def do_prepare_oscillation(self, *args, **kwargs):
         # set the detector cover out

--- a/mxcubecore/HardwareObjects/ESRF/MD2MultiCollect.py
+++ b/mxcubecore/HardwareObjects/ESRF/MD2MultiCollect.py
@@ -60,7 +60,7 @@ class MD2MultiCollect(ESRFMultiCollect):
 
     @task
     def take_crystal_snapshots(self, number_of_snapshots, image_path_list=[]):
-        HWR.beamline.diffractometer.new_take_snapshot(image_path_list)
+        HWR.beamline.diffractometer.take_snapshot(image_path_list)
 
     def do_prepare_oscillation(self, *args, **kwargs):
         # set the detector cover out

--- a/mxcubecore/HardwareObjects/GenericDiffractometer.py
+++ b/mxcubecore/HardwareObjects/GenericDiffractometer.py
@@ -793,9 +793,10 @@ class GenericDiffractometer(HardwareObject):
 
     def get_snapshot(self):
         """
-        Get sample_view snapshot
+        Get snapshot from sample view
 
-        :returns: bytes object of current camera image
+        Returns:
+            bytes: A bytes object of the current camera image.
         """
         if HWR.beamline.sample_view:
             return HWR.beamline.sample_view.get_snapshot()

--- a/mxcubecore/HardwareObjects/GenericDiffractometer.py
+++ b/mxcubecore/HardwareObjects/GenericDiffractometer.py
@@ -792,8 +792,13 @@ class GenericDiffractometer(HardwareObject):
     #     return self.current_positions_dict.get("phi")
 
     def get_snapshot(self):
+        """
+        Get sample_view snapshot
+
+        :returns: bytes object of current camera image
+        """
         if HWR.beamline.sample_view:
-            return HWR.beamline.sample_view.take_snapshot()
+            return HWR.beamline.sample_view.get_snapshot()
 
     def save_snapshot(self, filename):
         """ """

--- a/mxcubecore/HardwareObjects/LNLS/LNLSCollect.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSCollect.py
@@ -281,10 +281,6 @@ class LNLSCollect(AbstractMultiCollect, HardwareObject):
         )
 
     @task
-    def take_crystal_snapshots(self, number_of_snapshots):
-        self.bl_control.diffractometer.take_snapshots(number_of_snapshots, wait=True)
-
-    @task
     def data_collection_hook(self, data_collect_parameters):
         return
 

--- a/mxcubecore/HardwareObjects/MiniDiff.py
+++ b/mxcubecore/HardwareObjects/MiniDiff.py
@@ -1034,6 +1034,10 @@ class MiniDiff(HardwareObject):
                 self.set_phase("Centring", wait=True, timeout=200)
 
         for image_path in image_path_list:
+            snapshot_index = image_path_list.index(image_path)
+            logging.getLogger("user_level_log").info(
+                f"Taking {snapshot_index + 1} sample snapshot(s)"
+            )
             HWR.beamline.sample_view.save_snapshot(path=image_path)
             self.phiMotor.set_value_relative(90, timeout=5)
 

--- a/mxcubecore/HardwareObjects/MiniDiff.py
+++ b/mxcubecore/HardwareObjects/MiniDiff.py
@@ -1024,6 +1024,19 @@ class MiniDiff(HardwareObject):
         ):
             time.sleep(0.1)
 
+    def new_take_snapshot(self, image_path_list: list) -> None:
+        if self.get_current_phase() != "Centring":
+            use_custom_snapshot_routine = self.get_property(
+                "custom_snapshot_script_dir", False
+            )
+
+            if not use_custom_snapshot_routine:
+                self.set_phase("Centring", wait=True, timeout=200)
+
+        for image_path in image_path_list:
+            HWR.beamline.sample_view.save_snapshot(path=image_path)
+            self.phiMotor.set_value_relative(90, timeout=5)
+
     def take_snapshots(self, image_count, wait=False):
         HWR.beamline.sample_view.camera.forceUpdate = True
 

--- a/mxcubecore/HardwareObjects/SampleView.py
+++ b/mxcubecore/HardwareObjects/SampleView.py
@@ -20,12 +20,13 @@
 __copyright__ = """2019 by the MXCuBE collaboration """
 __license__ = "LGPLv3+"
 
+import base64
 import copy
 from functools import reduce
-from PIL import Image
 from io import BytesIO
-import base64
+
 import numpy as np
+from PIL import Image
 
 from mxcubecore import HardwareRepository as HWR
 from mxcubecore.HardwareObjects.abstract.AbstractSampleView import AbstractSampleView

--- a/mxcubecore/HardwareObjects/TangoLimaVideo.py
+++ b/mxcubecore/HardwareObjects/TangoLimaVideo.py
@@ -21,8 +21,6 @@ import time
 import gevent
 import PyTango
 from PIL import Image
-import io
-
 from PyTango.gevent import DeviceProxy
 
 from mxcubecore import BaseHardwareObjects

--- a/mxcubecore/HardwareObjects/TangoLimaVideo.py
+++ b/mxcubecore/HardwareObjects/TangoLimaVideo.py
@@ -19,10 +19,10 @@ import struct
 import time
 
 import gevent
-import gipc
-import numpy
 import PyTango
 from PIL import Image
+import io
+
 from PyTango.gevent import DeviceProxy
 
 from mxcubecore import BaseHardwareObjects
@@ -111,7 +111,7 @@ class TangoLimaVideo(BaseHardwareObjects.HardwareObject):
         self.set_is_ready(True)
 
     def get_last_image(self):
-        return self._last_image
+        return poll_image(self.device, self.video_mode, self._FORMATS)
 
     def _do_polling(self, sleep_time):
         lima_tango_device = self.device
@@ -137,19 +137,6 @@ class TangoLimaVideo(BaseHardwareObjects.HardwareObject):
 
     def get_height(self):
         return self.device.image_height
-
-    def take_snapshot(self, path=None, bw=False):
-        data, width, height = poll_image(self.device, self.video_mode, self._FORMATS)
-
-        img = Image.frombytes("RGB", (width, height), data)
-
-        if bw:
-            img.convert("1")
-
-        if path:
-            img.save(path)
-
-        return img
 
     def set_live(self, mode):
         curr_state = self.device.video_live

--- a/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
@@ -88,6 +88,8 @@ class AbstractMultiCollect(object):
         self.mesh_range = None
         self.mesh_center = None
 
+        self.number_of_snapshots = 4
+
     def setControlObjects(self, **control_objects):
         self.bl_control = BeamlineControl(**control_objects)
 
@@ -315,6 +317,41 @@ class AbstractMultiCollect(object):
             logging.getLogger("HWR").exception("")
         else:
             pass
+
+    def new_take_snapshots(self, dc_params):
+        # number_of_snapshots = dc_params.get("take_snapshots", 0)
+        snapshot_directory = dc_params["fileinfo"]["archive_directory"]
+
+        if HWR.beamline.diffractometer.in_plate_mode():
+            if number_of_snapshots > 0:
+                number_of_snapshots = 1
+
+        if not os.path.exists(snapshot_directory):
+            self.create_directories(snapshot_directory)
+
+        image_path_list = []
+
+        for snapshot_index in range(self.number_of_snapshots):
+            snapshot_filename = os.path.join(
+                snapshot_directory,
+                "%s_%s_%s.snapshot.jpeg"
+                % (
+                    dc_params["fileinfo"]["prefix"],
+                    dc_params["fileinfo"]["run_number"],
+                    (snapshot_index + 1),
+                ),
+            )
+
+            image_path_list.append(snapshot_filename)
+            dc_params["xtalSnapshotFullPath%i" % (snapshot_index + 1)] = (
+                snapshot_filename
+            )
+
+            logging.getLogger("user_level_log").info(
+                f"Taking {snapshot_index + 1} sample snapshot(s)"
+            )
+
+        HWR.beamline.diffractometer.new_take_snapshot(image_path_list)
 
     def _take_crystal_snapshots(self, number_of_snapshots):
         try:
@@ -563,11 +600,14 @@ class AbstractMultiCollect(object):
 
         # take snapshots, then assign centring status (which contains images) to
         # centring_info variable
-        take_snapshots = data_collect_parameters.get("take_snapshots", False)
+        # take_snapshots = data_collect_parameters.get("take_snapshots", False)
 
-        if take_snapshots:
-            logging.getLogger("user_level_log").info("Taking sample snapshosts")
-            self._take_crystal_snapshots(take_snapshots)
+        if self.number_of_snapshots:
+            logging.getLogger("user_level_log").info(
+                f"Taking sample ({self.number_of_snapshots}) snapshosts"
+            )
+            # self._take_crystal_snapshots(take_snapshots)
+            self.new_take_snapshots(data_collect_parameters)
         centring_info = HWR.beamline.diffractometer.get_centring_status()
         # move *again* motors, since taking snapshots may change positions
         logging.getLogger("user_level_log").info(

--- a/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
@@ -347,10 +347,6 @@ class AbstractMultiCollect(object):
                 snapshot_filename
             )
 
-            logging.getLogger("user_level_log").info(
-                f"Taking {snapshot_index + 1} sample snapshot(s)"
-            )
-
         HWR.beamline.diffractometer.new_take_snapshot(image_path_list)
 
     def _take_crystal_snapshots(self, number_of_snapshots):

--- a/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
@@ -252,10 +252,6 @@ class AbstractMultiCollect(object):
     def generate_image_jpeg(self, filename, jpeg_path, jpeg_thumbnail_path):
         pass
 
-    @task
-    def take_crystal_snapshots(self, number_of_snapshots):
-        HWR.beamline.diffractometer.take_snapshots(number_of_snapshots, wait=True)
-
     def get_sample_info_from_parameters(self, parameters):
         """Returns sample_id, sample_location and sample_code from data collection parameters"""
         sample_info = parameters.get("sample_reference")
@@ -318,7 +314,7 @@ class AbstractMultiCollect(object):
         else:
             pass
 
-    def new_take_snapshots(self, dc_params):
+    def take_snapshots(self, dc_params):
         snapshot_directory = dc_params["fileinfo"]["archive_directory"]
 
         if HWR.beamline.diffractometer.in_plate_mode():
@@ -346,20 +342,7 @@ class AbstractMultiCollect(object):
                 snapshot_filename
             )
 
-        HWR.beamline.diffractometer.new_take_snapshot(image_path_list)
-
-    def _take_crystal_snapshots(self, number_of_snapshots):
-        try:
-            if isinstance(number_of_snapshots, bool):
-                # backward compatibility, if number_of_snapshots is True|False
-                if number_of_snapshots:
-                    return self.take_crystal_snapshots(4)
-                else:
-                    return
-            if number_of_snapshots:
-                return self.take_crystal_snapshots(number_of_snapshots)
-        except Exception:
-            logging.getLogger("HWR").exception("Could not take crystal snapshots")
+        HWR.beamline.diffractometer.take_snapshot(image_path_list)
 
     @abc.abstractmethod
     def set_helical(self, helical_on):
@@ -597,8 +580,7 @@ class AbstractMultiCollect(object):
             logging.getLogger("user_level_log").info(
                 f"Taking sample ({self.number_of_snapshots}) snapshosts"
             )
-            # self._take_crystal_snapshots(take_snapshots)
-            self.new_take_snapshots(data_collect_parameters)
+            self.take_snapshots(data_collect_parameters)
         centring_info = HWR.beamline.diffractometer.get_centring_status()
         # move *again* motors, since taking snapshots may change positions
         logging.getLogger("user_level_log").info(

--- a/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
@@ -319,7 +319,6 @@ class AbstractMultiCollect(object):
             pass
 
     def new_take_snapshots(self, dc_params):
-        # number_of_snapshots = dc_params.get("take_snapshots", 0)
         snapshot_directory = dc_params["fileinfo"]["archive_directory"]
 
         if HWR.beamline.diffractometer.in_plate_mode():
@@ -594,11 +593,7 @@ class AbstractMultiCollect(object):
         self.move_motors(motors_to_move_before_collect)
         HWR.beamline.diffractometer.save_centring_positions()
 
-        # take snapshots, then assign centring status (which contains images) to
-        # centring_info variable
-        # take_snapshots = data_collect_parameters.get("take_snapshots", False)
-
-        if self.number_of_snapshots:
+        if data_collect_parameters.get("take_snapshots", False):
             logging.getLogger("user_level_log").info(
                 f"Taking sample ({self.number_of_snapshots}) snapshosts"
             )

--- a/mxcubecore/HardwareObjects/abstract/AbstractSampleView.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractSampleView.py
@@ -24,9 +24,9 @@ __copyright__ = """2019 by the MXCuBE collaboration """
 __license__ = "LGPLv3+"
 
 import abc
+from typing import Union
 
 from mxcubecore.BaseHardwareObjects import HardwareObject
-from typing import Union
 
 
 class AbstractSampleView(HardwareObject):

--- a/mxcubecore/HardwareObjects/abstract/AbstractSampleView.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractSampleView.py
@@ -26,6 +26,7 @@ __license__ = "LGPLv3+"
 import abc
 
 from mxcubecore.BaseHardwareObjects import HardwareObject
+from typing import Union
 
 
 class AbstractSampleView(HardwareObject):
@@ -43,20 +44,22 @@ class AbstractSampleView(HardwareObject):
         self._shapes = None
 
     @abc.abstractmethod
-    def get_snapshot(self, overlay=True, bw=False, return_as_array=False):
+    def get_snapshot(
+        self, overlay: Union[bool, str] = True, bw=False, return_as_array=False
+    ):
         """Get snappshot(s)
         Args:
-            overlay(bool): Display shapes and other items on the snapshot
+            overlay(bool | str): Display shapes and other items on the snapshot
             bw(bool): return grayscale image
             return_as_array(bool): return as np array
         """
 
     @abc.abstractmethod
-    def save_snapshot(self, filename, overlay=True, bw=False):
+    def save_snapshot(self, filename, overlay: Union[bool, str] = True, bw=False):
         """Save a snapshot to file.
         Args:
             filename (str): The filename.
-            overlay(bool): Display shapes and other items on the snapshot.
+            overlay(bool | str): Display shapes and other items on the snapshot.
             bw(bool): Return grayscale image.
         """
 

--- a/mxcubecore/HardwareObjects/mockup/MDCameraMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/MDCameraMockup.py
@@ -6,6 +6,7 @@ import time
 
 import gevent
 import psutil
+from PIL import Image
 
 from mxcubecore import BaseHardwareObjects
 from mxcubecore import HardwareRepository as HWR
@@ -92,10 +93,9 @@ class MDCameraMockup(BaseHardwareObjects.HardwareObject):
     def imageType(self):
         return None
 
-    def takeSnapshot(self, snapshot_filename, bw=True):
-        return True
-
-    take_snapshot = takeSnapshot
+    def get_last_image(self):
+        image = Image.open(self.image)
+        return image.tobytes(), image.size[0], image.size[1]
 
     def get_available_stream_sizes(self):
         try:

--- a/mxcubecore/HardwareObjects/mockup/MultiCollectMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/MultiCollectMockup.py
@@ -105,10 +105,6 @@ class MultiCollectMockup(AbstractMultiCollect, HardwareObject):
         self.emit("collectReady", (True,))
 
     @task
-    def take_crystal_snapshots(self, number_of_snapshots):
-        self.bl_control.diffractometer.take_snapshots(number_of_snapshots, wait=True)
-
-    @task
     def data_collection_hook(self, data_collect_parameters):
         return
 


### PR DESCRIPTION
This PR includes changes to the snapshot routine, which did not work on the web version before. 
It moves the complexity of the `take_snapshots` functionality from the cameras to the `sampleview` objects. Furthermore it allows an overlay(grids/points) as input, which are put as additional layer on the latest image. Then it returns the combined image.

We further changed a few references of different snapshot calls, so that the correct ones are called (between `get_snapshot` which returns a snapshot, `take_snapshot` which is mainly used to reduce code duplication between the other two and `save_snapshot` for saving the snapshot to the disk instead of returning it).

Furthermore, the routines in `multicollect` object and `minidiff` were adjusted to utilize the new functions