### PR TITLE
remove GenericDiffractometer's 'zoom' proxy attribute

### DIFF
--- a/mxcubecore/HardwareObjects/GenericDiffractometer.py
+++ b/mxcubecore/HardwareObjects/GenericDiffractometer.py
@@ -581,18 +581,6 @@ class GenericDiffractometer(HardwareObject):
         """
         return self.motor_hwobj_dict.get("phiz")
 
-    @property
-    def zoom(self):
-        """zoom motor object
-
-        NBNB HACK TODO - ocnfigure this in graphics object
-        (which now calls this property)
-
-        Returns:
-            AbstractActuator
-        """
-        return self.motor_hwobj_dict.get("zoom")
-
     def is_ready(self):
         """
         Detects if device is ready


### PR DESCRIPTION
The `zoom` attribute is now automagically set from the `objects` settings in YAML/XML configure file.

This makes it work when loading from YAML config file, otherwise the `zoom` attribute was causing issues.

