### PR TITLE
[MicrodiffAperture] - Use complete name with the "A" for label

### DIFF
--- a/mxcubecore/HardwareObjects/MicrodiffAperture.py
+++ b/mxcubecore/HardwareObjects/MicrodiffAperture.py
@@ -168,6 +168,6 @@ class MicrodiffAperture(ExporterNState):
             _nam = value.name
 
             if _nam not in ["IN", "OUT", "UNKNOWN"]:
-                values.append(_nam[1:])
+                values.append(_nam)
 
         return values


### PR DESCRIPTION
Using the complete name including the A for the label i.e "A10"