### PR TITLE
change stream_size type and add type hints

### DIFF
--- a/mxcubecore/HardwareObjects/TangoLimaVideoLoopback.py
+++ b/mxcubecore/HardwareObjects/TangoLimaVideoLoopback.py
@@ -117,7 +117,7 @@ class TangoLimaVideoLoopback(TangoLimaVideo):
         super(TangoLimaVideoLoopback, self).__init__(name)
 
         self._video_stream_process = None
-        self._current_stream_size = "-1, -1"
+        self._current_stream_size = -1, -1
         self._original_stream_size = -1, -1
         self._stream_script_path = ""
         self.stream_hash = str(uuid.uuid1())
@@ -191,16 +191,16 @@ class TangoLimaVideoLoopback(TangoLimaVideo):
 
     def set_stream_size(self, w, h):
         w, h = self._encoder_friendly_size(w, h)
-        self._current_stream_size = "%s,%s" % (w, h)
+        self._current_stream_size = (int(w), int(h))
 
     def _set_stream_original_size(self, w, h):
         w, h = self._encoder_friendly_size(w, h)
         self._original_stream_size = w, h
 
     def get_stream_size(self):
-        current_size = self._current_stream_size.split(",")
-        scale = float(current_size[0]) / self._original_stream_size[0]
-        return current_size + list((scale,))
+        width, height = self._current_stream_size
+        scale = float(width) / self._original_stream_size[0]
+        return (width, height, scale)
 
     def get_available_stream_sizes(self):
         try:


### PR DESCRIPTION
As discussed in #1051, I changed the type of `_current_stream_size` to be a tuple of `int` for `TangoLimaMpegVideo`, `TangoLimaVideoLoopback` and `MDCameraMockup`. We now only convert to a string, when we start the `video_streamer`. 

On the occassion I added type hints for every function in `TangoLimaMpegVideo` and `MDCameraMockup` and removed the unused `port` parameter from the resp. `start_video_stream_process` functions and an unused import from `TangoLimaMpegVideo`.

Additionally, I was wondering if `TangoLimaVideoLoopback` is actually used? The class seems to be outdated compared to the others, it does not make use of the `video-streamer` and while it has `set` and `get` functions for the `current_stream_size`, it never uses the variable.  