### PR TITLE
Refactoring ISPyBClientMockup for authnentication tests

### DIFF
--- a/mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
@@ -95,9 +95,9 @@ class ISPyBClientMockup(HardwareObject):
 
     def login(self, login_id, psd, ldap_connection=None, create_session=True):
         # to simulate wrong loginID
-        if login_id != "idtest0":
+        if login_id not in ("idtest0", "idtest1"):
             return {
-                "status": {"code": "error", "msg": "loginID 'wrong' does not exist!"},
+                "status": {"code": "error", "msg": f"loginID '{login_id}' does not exist!"},
                 "Proposal": None,
                 "Session": None,
             }
@@ -108,7 +108,7 @@ class ISPyBClientMockup(HardwareObject):
                 "Proposal": None,
                 "Session": None,
             }
-            # to simulate ispybDown, but login succeed
+        # to simulate ispybDown, but login succeed
         if psd == "ispybDown":
             return {
                 "status": {"code": "ispybDown", "msg": "ispyb is down"},

--- a/mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
@@ -97,7 +97,10 @@ class ISPyBClientMockup(HardwareObject):
         # to simulate wrong loginID
         if login_id not in ("idtest0", "idtest1"):
             return {
-                "status": {"code": "error", "msg": f"loginID '{login_id}' does not exist!"},
+                "status": {
+                    "code": "error",
+                    "msg": f"loginID '{login_id}' does not exist!",
+                },
                 "Proposal": None,
                 "Session": None,
             }


### PR DESCRIPTION
The [PR](https://github.com/mxcube/mxcubeweb/pull/1455) is dependent on this one.
The change provided here allows to perform correctly authentication tests that are using CREDENTIALS_1: https://github.com/mxcube/mxcubeweb/blob/develop/test/test_authn.py#L24