### PR TITLE
queue models: handle omitted 'centred_pos' argument

### DIFF
--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -2702,7 +2702,9 @@ def to_collect_dict(data_collection, session, sample, centred_pos=None):
                 data_collection.experiment_type
             ],
             "skip_images": acq_params.skip_existing_images,
-            "position_name": centred_pos.get_index(),
+            "position_name": (
+                centred_pos.get_index() if centred_pos is not None else None
+            ),
             "motors": centred_pos.as_dict() if centred_pos is not None else {},
             "ispyb_group_data_collections": data_collection.ispyb_group_data_collections,
             "workflow_parameters": data_collection.workflow_parameters,


### PR DESCRIPTION
In the utility function` to_collect_dict()`, take into the account that `centred_pos` argument can be omitted.

Don't call `centred_pos.get_index()` if `centred_pos` is omitted or is None.

For background information, the call to `centred_pos.get_index()` have been recently introduced in this PR: https://github.com/mxcube/mxcubecore/pull/1056

The line in the diff: https://github.com/mxcube/mxcubecore/pull/1056/files#diff-5194ff6aa825f5865aa6953d626e6a91865a9be8ff8538f47613e62c80712f93R2705

