### PR TITLE
Use types from typing for Type Hints

### DIFF
--- a/mxcubecore/HardwareObjects/EMBLFlexHarvester.py
+++ b/mxcubecore/HardwareObjects/EMBLFlexHarvester.py
@@ -29,6 +29,10 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import (
+    Any,
+    List,
+)
 
 import gevent
 
@@ -69,7 +73,7 @@ class EMBLFlexHarvester(EMBLFlexHCD):
     def mount_from_harvester(self):
         return True
 
-    def get_sample_list(self) -> list:
+    def get_sample_list(self) -> List[Any]:
         """
         Get Sample List related to the Harvester content/processing Plan
         """
@@ -262,7 +266,7 @@ class EMBLFlexHarvester(EMBLFlexHCD):
             logging.getLogger("user_level_log").exception("Could not Harvest Crystal")
             return "Could not Harvest Crystal"
 
-    def queue_list(self) -> list[str]:
+    def queue_list(self) -> List[str]:
         """
         builds a List representation of the queue based.
         """
@@ -271,7 +275,7 @@ class EMBLFlexHarvester(EMBLFlexHCD):
 
         result = []
 
-        if isinstance(node, list):
+        if isinstance(node, List):
             node_list = node
         else:
             node_list = node.get_children()

--- a/mxcubecore/HardwareObjects/Harvester.py
+++ b/mxcubecore/HardwareObjects/Harvester.py
@@ -43,7 +43,10 @@ It has some functionalities, like Harvest Sample, etc....
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import (
+    List,
+    Optional,
+)
 
 import gevent
 
@@ -235,7 +238,7 @@ class Harvester(HardwareObject):
             == "Waiting Sample Transfer"
         )
 
-    def get_samples_state(self) -> list[str]:
+    def get_samples_state(self) -> List[str]:
         """Get the Harvester Samples State
 
         Return (List):  list of crystal state "waiting_for_transfer, Running etc.."
@@ -301,7 +304,7 @@ class Harvester(HardwareObject):
             else:
                 return None
 
-    def get_crystal_uuids(self) -> list[str]:
+    def get_crystal_uuids(self) -> List[str]:
         """Get the Harvester Sample List uuid
 
         Return (List):  list of crystal by uuid from the current processing plan"
@@ -311,7 +314,7 @@ class Harvester(HardwareObject):
         )
         return harvester_crystal_list
 
-    def get_sample_names(self) -> list[str]:
+    def get_sample_names(self) -> List[str]:
         """Get the Harvester Sample List Name
 
         Return (List):  list of crystal by names from the current processing plan"
@@ -333,7 +336,7 @@ class Harvester(HardwareObject):
         )
         return crystal_images_url
 
-    def get_sample_acronyms(self) -> list[str]:
+    def get_sample_acronyms(self) -> List[str]:
         """Get the Harvester Sample List by Acronyms
 
         Return (List):  list of crystal by Acronyms from the current processing plan"

--- a/mxcubecore/HardwareObjects/TangoLimaMpegVideo.py
+++ b/mxcubecore/HardwareObjects/TangoLimaMpegVideo.py
@@ -15,7 +15,10 @@ Example configuration:
 
 import subprocess
 import uuid
-from typing import List
+from typing import (
+    List,
+    Tuple,
+)
 
 import psutil
 
@@ -51,7 +54,7 @@ class TangoLimaMpegVideo(TangoLimaVideo):
     def set_stream_size(self, w, h) -> None:
         self._current_stream_size = (int(w), int(h))
 
-    def get_stream_size(self) -> tuple[int, int, float]:
+    def get_stream_size(self) -> Tuple[int, int, float]:
         width, height = self._current_stream_size
         scale = float(width) / self.get_width()
         return (width, height, scale)
@@ -59,7 +62,7 @@ class TangoLimaMpegVideo(TangoLimaVideo):
     def get_quality_options(self) -> List[str]:
         return list(self._QUALITY_STR_TO_INT.keys())
 
-    def get_available_stream_sizes(self) -> List[tuple[int, int]]:
+    def get_available_stream_sizes(self) -> List[Tuple[int, int]]:
         try:
             w, h = self.get_width(), self.get_height()
             video_sizes = [(w, h), (int(w / 2), int(h / 2)), (int(w / 4), int(h / 4))]

--- a/mxcubecore/HardwareObjects/mockup/MDCameraMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/MDCameraMockup.py
@@ -3,7 +3,10 @@
 import logging
 import subprocess
 import time
-from typing import List
+from typing import (
+    List,
+    Tuple,
+)
 
 import gevent
 import psutil
@@ -94,11 +97,11 @@ class MDCameraMockup(BaseHardwareObjects.HardwareObject):
     def imageType(self):
         return None
 
-    def get_last_image(self) -> tuple[bytes, int, int]:
+    def get_last_image(self) -> Tuple[bytes, int, int]:
         image = Image.open(self.image)
         return image.tobytes(), image.size[0], image.size[1]
 
-    def get_available_stream_sizes(self) -> List[tuple[int, int]]:
+    def get_available_stream_sizes(self) -> List[Tuple[int, int]]:
         try:
             w, h = self.get_width(), self.get_height()
             video_sizes = [(w, h), (int(w / 2), int(h / 2)), (int(w / 4), int(h / 4))]
@@ -110,7 +113,7 @@ class MDCameraMockup(BaseHardwareObjects.HardwareObject):
     def set_stream_size(self, w, h) -> None:
         self._current_stream_size = (int(w), int(h))
 
-    def get_stream_size(self) -> tuple[int, int, float]:
+    def get_stream_size(self) -> Tuple[int, int, float]:
         width, height = self._current_stream_size
         scale = float(width) / self.get_width()
         return (width, height, scale)


### PR DESCRIPTION
In #1065, I mistakenly added Type hints that use the built-in `tuple` type, which is introduced in `Python 3.9` and hence not supported in `Python 3.8`. I replaced these and some other instances I found in the code by the corresponding types from `typing`.

This mismatch seems to be a reason for a failing test in the web version mxcube/mxcubeweb#1483