### PR TITLE
Fix deprecated code for redis client

### DIFF
--- a/mxcubecore/HardwareObjects/DataPublisher.py
+++ b/mxcubecore/HardwareObjects/DataPublisher.py
@@ -100,7 +100,7 @@ class DataPublisher(HardwareObject):
         rdb = self.get_property("db", 11)
 
         self._r = redis.Redis(
-            host=rhost, port=rport, db=rdb, charset="utf-8", decode_responses=True
+            host=rhost, port=rport, db=rdb, encoding="utf-8", decode_responses=True
         )
 
         if not self._subsribe_task:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mxcubecore"
-version = "1.186.0"
+version = "1.187.0"
 license = "LGPL-3.0-or-later"
 description = "Core libraries for the MXCuBE application"
 authors = ["The MXCuBE collaboration <mxcube@esrf.fr>"]


### PR DESCRIPTION
The `charset` parameter that we use to configure our redis client in `Datapublisher` is deprecated. Changed this to `encoding`. 
![image](https://github.com/user-attachments/assets/bff98927-9805-4eb5-bc34-68e1d3db5e8f)

P.s. This was responsible for about 50 warnings in the pytest tests of the web version