### PR TITLE
GPhL bug fixes and iprovements

### DIFF
--- a/mxcubecore/HardwareObjects/Gphl/CollectEmulator.py
+++ b/mxcubecore/HardwareObjects/Gphl/CollectEmulator.py
@@ -44,9 +44,6 @@ class CollectEmulator(CollectMockup):
     def __init__(self, name):
         CollectMockup.__init__(self, name)
 
-        self.instrument_data = None
-        self.segments = None
-
         self._counter = 1
 
     # def init(self):
@@ -64,32 +61,12 @@ class CollectEmulator(CollectMockup):
         # Set up and add crystal data
         result = OrderedDict()
         setup_data = result["setup_list"] = crystal_data
-
-        if self.instrument_data is None:
-            # Read instrumentation.nml and put data into mock objects
-            # NB if we are here we must be in mock mode.
-            #
-            # update with instrument data
-            # You cannot do this at init time,
-            # as GPhL_wporkflow is not yet inittialised then.
-            fp0 = HWR.beamline.gphl_workflow.file_paths.get("instrumentation_file")
-            instrument_input = f90nml.read(fp0)
-
-            self.instrument_data = instrument_input["sdcp_instrument_list"]
-            self.segments = instrument_input.get("segment_list")
+        instrument_data = HWR.beamline.gphl_workflow.instrument_data
 
         #
         # # update with instrument data
         #
-
         sweep_count = len(data_collect_parameters["oscillation_sequence"])
-
-        # Move beamstop settings to top level
-        ll0 = self.instrument_data.get("beamstop_param_names")
-        ll1 = self.instrument_data.get("beamstop_param_vals")
-        if ll0 and ll1:
-            for tag, val in zip(ll0, ll1):
-                self.instrument_data[tag.lower()] = val
 
         # Setting parameters in order (may not be necessary, but ...)
         # Missing: *mu*
@@ -118,7 +95,7 @@ class CollectEmulator(CollectMockup):
             "det_coord_def",
         )
         for tag in tags:
-            val = self.instrument_data.get(remap.get(tag, tag))
+            val = instrument_data.get(remap.get(tag, tag))
             if val is not None:
                 setup_data[tag] = val
 
@@ -127,14 +104,14 @@ class CollectEmulator(CollectMockup):
             setup_data["det_org_y"],
         ) = HWR.beamline.detector.get_beam_position()
 
-        ll0 = self.instrument_data["gonio_axis_dirs"]
-        setup_data["omega_axis"] = ll0[:3]
-        setup_data["kappa_axis"] = ll0[3:6]
-        setup_data["phi_axis"] = ll0[6:]
-        ll0 = self.instrument_data["gonio_centring_axis_dirs"]
-        setup_data["trans_x_axis"] = ll0[:3]
-        setup_data["trans_y_axis"] = ll0[3:6]
-        setup_data["trans_z_axis"] = ll0[6:]
+        ll0 = list(HWR.beamline.gphl_workflow.rotation_axes.values())
+        setup_data["omega_axis"] = ll0[0]
+        setup_data["kappa_axis"] = ll0[1]
+        setup_data["phi_axis"] = ll0[2]
+        ll0 = list(HWR.beamline.gphl_workflow.translation_axes.values())
+        setup_data["trans_x_axis"] = ll0[0]
+        setup_data["trans_y_axis"] = ll0[1]
+        setup_data["trans_z_axis"] = ll0[2]
         tags = (
             "cone_radius",
             "cone_s_height",
@@ -143,7 +120,7 @@ class CollectEmulator(CollectMockup):
             "beam_stop_s_distance",
         )
         for tag in tags:
-            val = self.instrument_data.get(remap.get(tag, tag))
+            val = instrument_data.get(remap.get(tag, tag))
             if val is not None:
                 setup_data[tag] = val
 
@@ -158,16 +135,17 @@ class CollectEmulator(CollectMockup):
         setup_data["n_sweeps"] = sweep_count
 
         # Add segments
-        if self.segments:
-            if isinstance(self.segments, dict):
+        segments = HWR.beamline.gphl_workflow.detector_segments
+        if segments:
+            if isinstance(segments, dict):
                 segment_count = 1
             else:
-                segment_count = len(self.segments)
+                segment_count = len(segments)
             setup_data["n_segments"] = segment_count
-            result["segment_list"] = self.segments
+            result["segment_list"] = segments
 
         # Adjustments
-        val = self.instrument_data.get("beam")
+        val = instrument_data.get("beam")
         if val:
             setup_data["beam"] = val
 
@@ -208,7 +186,7 @@ class CollectEmulator(CollectMockup):
             sweep["lambda"] = conversion.HC_OVER_E / energy
             sweep["res_limit"] = setup_data["res_limit_def"]
             sweep["exposure"] = osc["exposure_time"]
-            ll0 = HWR.beamline.gphl_workflow.translation_axis_roles
+            ll0 = list(HWR.beamline.gphl_workflow.translation_axes)
             sweep["trans_xyz"] = list(motors.get(x) or 0.0 for x in ll0)
             sweep["det_coord"] = detector_distance
             # NBNB hardwired for omega scan TODO

--- a/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
+++ b/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
@@ -1909,6 +1909,7 @@ class GphlWorkflow(HardwareObjectYaml):
         last_orientation = ()
         maxdev = -1
         snapshotted_rotation_ids = set()
+        scan_numbers = {}
         for scan in scans:
             sweep = scan.sweep
             acq = queue_model_objects.Acquisition()
@@ -1982,6 +1983,15 @@ class GphlWorkflow(HardwareObjectYaml):
             path_template.run_number = int(ss0) if ss0 else 1
             path_template.start_num = acq_parameters.first_image
             path_template.num_files = acq_parameters.num_images
+            if (
+                path_template.suffix.endswith("h5")
+                and gphl_workflow_model.characterisation_done
+                and len(sweep.scans) > 1
+            ):
+                # Add scan number to prefix for interleaved hdf5 files (only)
+                # NBNB Temporary fix, pending solution to hdf5 interleaving problem
+                scan_numbers[prefix] = scan_no = scan_numbers.get(prefix, 0) + 1
+                prefix += "_s%s" % scan_no
             path_template.base_prefix = prefix
 
             key = (

--- a/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
+++ b/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
@@ -215,11 +215,13 @@ class GphlWorkflow(HardwareObjectYaml):
         # GoniostatTranslations generated in recentring
         self._recentrings = []
 
-        # Rotation axis role names, ordered from holder towards sample
-        self.rotation_axis_roles = []
-
-        # Translation axis role names
-        self.translation_axis_roles = []
+        # instrumentation configuration data
+        self.instrument_data = {}
+        self.detector_segments = []
+        # Rotation axes, ordered from holder towards sample
+        self.rotation_axes = OrderedDict()
+        # Translation axes
+        self.translation_axes = OrderedDict()
 
         # Switch for 'move-to-fine-zoom' message for translational calibration
         self._use_fine_zoom = False
@@ -259,12 +261,8 @@ class GphlWorkflow(HardwareObjectYaml):
         file_paths["gphl_beamline_config"] = ss0
         file_paths["transcal_file"] = os.path.join(ss0, "transcal.nml")
         file_paths["diffractcal_file"] = os.path.join(ss0, "diffractcal.nml")
-        file_paths["instrumentation_file"] = fp0 = os.path.join(
-            ss0, "instrumentation.nml"
-        )
-        instrument_data = f90nml.read(fp0)["sdcp_instrument_list"]
-        self.rotation_axis_roles = instrument_data["gonio_axis_names"]
-        self.translation_axis_roles = instrument_data["gonio_centring_axis_names"]
+        file_paths["instrumentation_file"] = os.path.join(ss0, "instrumentation.nml")
+        self.load_instrumentation_data()
 
         # Adapt configuration data - must be done after file_paths setting
         if HWR.beamline.gphl_connection.ssh_options:
@@ -299,6 +297,34 @@ class GphlWorkflow(HardwareObjectYaml):
                         )
 
         self.update_state(self.STATES.READY)
+
+    def load_instrumentation_data(self):
+        """Load instrumentation.nml file  and reformat data structures
+
+        Returns: None
+
+        """
+        instrument_input = f90nml.read(self.file_paths["instrumentation_file"])
+        self.instrument_data = instrument_data = instrument_input[
+            "sdcp_instrument_list"
+        ]
+        for ii0, tag in enumerate(instrument_data["gonio_axis_names"]):
+            ii1 = 3 * ii0
+            self.rotation_axes[tag] = instrument_data["gonio_axis_dirs"][ii1: ii1 + 3]
+        for ii0, tag in enumerate(instrument_data["gonio_centring_axis_names"]):
+            ii1 = 3 * ii0
+            self.translation_axes[tag] = instrument_data["gonio_centring_axis_dirs"][
+                ii1: ii1 + 3
+            ]
+
+        # Move beamstop settings to top level
+        ll0 = instrument_data.get("beamstop_param_names")
+        ll1 = instrument_data.get("beamstop_param_vals")
+        if ll0 and ll1:
+            for tag, val in zip(ll0, ll1):
+                instrument_data[tag.lower()] = val
+
+        self.detector_segments = instrument_input.get("segment_list")
 
     def shutdown(self):
         """Shut down workflow and connection. Triggered on program quit."""
@@ -448,6 +474,13 @@ class GphlWorkflow(HardwareObjectYaml):
             "type": "number",
             "minimum": 0,
         }
+        fields["crystal_thickness"] = {
+            "title": "Crystal thickness (µ)",
+            "type": "number",
+            "default": data_model.crystal_thickness or 0,
+            "minimum": 0,
+            "readOnly": True,
+        }
         fields["use_cell_for_processing"] = {
             "title": "Use for indexing",
             "type": "boolean",
@@ -566,10 +599,19 @@ class GphlWorkflow(HardwareObjectYaml):
                     "ui:order": ["cell_c", "cell_gamma"],
                 },
                 "sgroup": {
-                    "ui:order": ["input_space_group", "relative_rad_sensitivity"],
+                    "ui:order": [
+                        "input_space_group",
+                        "relative_rad_sensitivity",
+                        "crystal_thickness",
+                    ],
                     "relative_rad_sensitivity": {
                         "ui:options": {
                             "decimals": 2,
+                        }
+                    },
+                    "crystal_thickness": {
+                        "ui:options": {
+                            "decimals": 1,
                         }
                     },
                 },
@@ -632,6 +674,7 @@ class GphlWorkflow(HardwareObjectYaml):
         elif not choose_lattice:
             # Characterisation
             ui_schema["parameters"]["column1"]["ui:order"].remove("point_groups")
+            fields["crystal_thickness"]["readOnly"] = False
 
         else:
             # Acquisition
@@ -979,7 +1022,7 @@ class GphlWorkflow(HardwareObjectYaml):
         )
 
         # Make info_text and do some setting up
-        axis_names = self.rotation_axis_roles
+        axis_names = list(self.rotation_axes)
         if data_model.characterisation_done or data_model.wftype == "diffractcal":
             title_string = data_model.strategy_name
             lauegrp, ptgrp = crystal_symmetry.strategy_laue_group(
@@ -1605,10 +1648,8 @@ class GphlWorkflow(HardwareObjectYaml):
 
         # Get current position
         current_pos_dict = HWR.beamline.diffractometer.get_positions()
-        current_okp = tuple(current_pos_dict[role] for role in self.rotation_axis_roles)
-        current_xyz = tuple(
-            current_pos_dict[role] for role in self.translation_axis_roles
-        )
+        current_okp = tuple(current_pos_dict[role] for role in self.rotation_axes)
+        current_xyz = tuple(current_pos_dict[role] for role in self.translation_axes)
 
         # Check if sample is currently centred, and centre first sweep if not
         if (
@@ -1626,18 +1667,16 @@ class GphlWorkflow(HardwareObjectYaml):
             self._recentrings.append(translation)
             goniostatTranslations.append(translation)
             # Update current position
-            current_okp = tuple(
-                current_pos_dict[role] for role in self.rotation_axis_roles
-            )
+            current_okp = tuple(current_pos_dict[role] for role in self.rotation_axes)
             current_xyz = tuple(
-                current_pos_dict[role] for role in self.translation_axis_roles
+                current_pos_dict[role] for role in self.translation_axes
             )
             gphl_workflow_model.current_rotation_id = sweepSetting.id_
 
         elif gphl_workflow_model.characterisation_done or wftype == "diffractcal":
             # Acquisition or diffractcal; crystal is already centred
             settings = dict(sweepSetting.axisSettings)
-            okp = tuple(settings.get(x, 0) for x in self.rotation_axis_roles)
+            okp = tuple(settings.get(x, 0) for x in self.rotation_axes)
             maxdev = max(abs(okp[1] - current_okp[1]), abs(okp[2] - current_okp[2]))
 
             # Get translation setting from recentring or current (MAY be used)
@@ -1655,8 +1694,7 @@ class GphlWorkflow(HardwareObjectYaml):
                 # existing centring - take from current position
                 tol = 0.1
                 translation_settings = dict(
-                    (role, current_pos_dict.get(role))
-                    for role in self.translation_axis_roles
+                    (role, current_pos_dict.get(role)) for role in self.translation_axes
                 )
 
             if maxdev <= tol:
@@ -1692,9 +1730,7 @@ class GphlWorkflow(HardwareObjectYaml):
                     if recentring_mode == "start":
                         # We want snapshots in this mode,
                         # and the first sweepmis skipped in the loop below
-                        okp = tuple(
-                            int(settings.get(x, 0)) for x in self.rotation_axis_roles
-                        )
+                        okp = tuple(int(settings.get(x, 0)) for x in self.rotation_axes)
                         self.collect_centring_snapshots("%s_%s_%s" % okp)
 
         else:
@@ -1711,8 +1747,7 @@ class GphlWorkflow(HardwareObjectYaml):
                 rotation_settings["id_"] = orientation_id
             newRotation = GphlMessages.GoniostatRotation(**rotation_settings)
             translation_settings = dict(
-                (role, current_pos_dict.get(role))
-                for role in self.translation_axis_roles
+                (role, current_pos_dict.get(role)) for role in self.translation_axes
             )
             translation = GphlMessages.GoniostatTranslation(
                 rotation=newRotation,
@@ -1729,7 +1764,7 @@ class GphlWorkflow(HardwareObjectYaml):
             settings = dict(sweepSetting.axisSettings)
             if has_recentring_file:
                 # Update settings
-                okp = tuple(settings.get(x, 0) for x in self.rotation_axis_roles)
+                okp = tuple(settings.get(x, 0) for x in self.rotation_axes)
                 settings.update(
                     self.calculate_recentring(
                         okp, ref_xyz=current_xyz, ref_okp=current_okp
@@ -1745,7 +1780,7 @@ class GphlWorkflow(HardwareObjectYaml):
                 translation, dummy = self.execute_sample_centring(q_e, sweepSetting)
                 goniostatTranslations.append(translation)
                 gphl_workflow_model.current_rotation_id = sweepSetting.id_
-                okp = tuple(int(settings.get(x, 0)) for x in self.rotation_axis_roles)
+                okp = tuple(int(settings.get(x, 0)) for x in self.rotation_axes)
                 self.collect_centring_snapshots("%s_%s_%s" % okp)
             elif has_recentring_file and not gphl_workflow_model.characterisation_done:
                 # Not the first sweep and not gone through stratcal
@@ -1826,7 +1861,7 @@ class GphlWorkflow(HardwareObjectYaml):
             if terminated_ok:
                 if "X,Y,Z" in ss0:
                     ll0 = ss0.split()[-3:]
-                    for idx, tag in enumerate(self.translation_axis_roles):
+                    for idx, tag in enumerate(self.translation_axes):
                         result[tag] = float(ll0[idx])
                     break
 
@@ -2488,7 +2523,7 @@ class GphlWorkflow(HardwareObjectYaml):
         centring_result = centring_entry.get_data_model().get_centring_result()
         if centring_result:
             positionsDict = centring_result.as_dict()
-            dd0 = dict((x, positionsDict[x]) for x in self.translation_axis_roles)
+            dd0 = dict((x, positionsDict[x]) for x in self.translation_axes)
             return (
                 GphlMessages.GoniostatTranslation(
                     rotation=goniostatRotation,
@@ -2564,8 +2599,7 @@ class GphlWorkflow(HardwareObjectYaml):
             )
 
         translation_settings = dict(
-            (role, collect_dict["motors"].get(role))
-            for role in self.translation_axis_roles
+            (role, collect_dict["motors"].get(role)) for role in self.translation_axes
         )
         if not self._scan_id_to_translation_id or None in translation_settings.values():
             # First sweep or not first scan in sweep
@@ -2581,7 +2615,7 @@ class GphlWorkflow(HardwareObjectYaml):
             # We have recentred. Make new translation object
             translation_settings = dict(
                 (role, HWR.beamline.diffractometer.get_motor_positions().get(role))
-                for role in self.translation_axis_roles
+                for role in self.translation_axes
             )
             translation = GphlMessages.GoniostatTranslation(
                 requestedRotationId=scan.sweep.goniostatSweepSetting.id_,
@@ -2639,12 +2673,35 @@ class GphlWorkflow(HardwareObjectYaml):
         if flux:
             flux_density = flux.get_average_flux_density(transmission=100.0)
             if flux_density:
+                crystal_thickness = (
+                    HWR.beamline.gphl_workflow._queue_entry.get_data_model().crystal_thickness
+                )
+                if crystal_thickness:
+                    beam_dim = HWR.beamline.beam.get_beam_size()[
+                        HWR.beamline.gphl_workflow.rotation_axis_index()
+                    ] * 1000.
+                    # NBNB TODO beam sizes seem to come in mm. Units nowhere defined.
+                    #  FIX THIS MESS!
+                    if crystal_thickness > beam_dim:
+                        # Calculate equivalent flux density across swept crystal
+                        flux_density = flux_density * beam_dim / crystal_thickness
                 return (
                     flux_density
                     * flux.get_dose_rate_per_photon_per_mmsq(energy)
                     * 1.0e-6  # convert to MGy
                 )
         return 0
+
+    def rotation_axis_index(self):
+        """Get index of rotation axis
+
+        Rotation axis is assumed to be witehr X or Y
+        """
+        coords = list(abs(val) for val in list(self.rotation_axes.values())[0])
+        if coords[0] < coords[1]:
+            return 0
+        else:
+            return 1
 
     def get_emulation_samples(self):
         """Get list of lims_sample information dictionaries for mock/emulation

--- a/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
+++ b/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
@@ -86,6 +86,12 @@ __author__ = "Rasmus H Fogh"
 EMULATION_DATA = {
     "3n0s": {"radiationSensitivity": 0.9},
     "4j8p": {"radiationSensitivity": 1.1},
+    "4mxt":{
+        "exposureTime": 0.055,
+        "oscillationRange": 0.15,
+        "radiationSensitivity": 1.0,
+        "energy": 12.2222,
+    },
 }
 
 # Centring modes for use in centring mode pulldown.
@@ -2759,14 +2765,11 @@ class GphlWorkflow(HardwareObjectYaml):
                     # Use "Mad, "SAD", "OSC"
                     dfp = data["diffractionPlan"] = {
                         # "diffractionPlanId": 457980,
-                        "experimentKind": "Default",
-                        "numberOfPositions": 0,
-                        "observedResolution": 0.0,
-                        "preferredBeamDiameter": 0.0,
+                        # "experimentKind": "Default",
+                        "exposureTime": 0.0,
+                        "oscillationRange": 0.0,
                         "radiationSensitivity": 1.0,
-                        "requiredCompleteness": 0.0,
-                        "requiredMultiplicity": 0.0,
-                        # "requiredResolution": 0.0,
+                        "energy": 0.0,
                     }
                     dfp["aimedResolution"] = resolution
                     dfp["diffractionPlanId"] = 5000000 + serial

--- a/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
+++ b/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
@@ -89,7 +89,7 @@ EMULATION_DATA = {
     "4mxt":{
         "exposureTime": 0.055,
         "oscillationRange": 0.15,
-        "radiationSensitivity": 1.0,
+        "radiationSensitivity": 1.3,
         "energy": 12.2222,
     },
 }
@@ -676,6 +676,7 @@ class GphlWorkflow(HardwareObjectYaml):
             ):
                 fields[tag]["readOnly"] = False
             ui_schema["parameters"]["column1"]["ui:order"].remove("point_groups")
+            fields["crystal_thickness"]["readOnly"] = False
 
         elif not choose_lattice:
             # Characterisation
@@ -1112,10 +1113,7 @@ class GphlWorkflow(HardwareObjectYaml):
 
         # set starting and unchanging values of parameters
         resolution = HWR.beamline.resolution.get_value()
-        dose_budget = self.resolution2dose_budget(
-            resolution,
-            decay_limit=data_model.decay_limit,
-        )
+        dose_budget = data_model.recommended_dose_budget(resolution)
         # NB These default values are set just before this function is called
         default_image_width = data_model.image_width
         default_exposure = data_model.exposure_time
@@ -2701,10 +2699,10 @@ class GphlWorkflow(HardwareObjectYaml):
     def rotation_axis_index(self):
         """Get index of rotation axis
 
-        Rotation axis is assumed to be witehr X or Y
+        Rotation axis is assumed to be either X or Y
         """
         coords = list(abs(val) for val in list(self.rotation_axes.values())[0])
-        if coords[0] < coords[1]:
+        if coords[0] > coords[1]:
             return 0
         else:
             return 1

--- a/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
+++ b/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
@@ -86,7 +86,7 @@ __author__ = "Rasmus H Fogh"
 EMULATION_DATA = {
     "3n0s": {"radiationSensitivity": 0.9},
     "4j8p": {"radiationSensitivity": 1.1},
-    "4mxt":{
+    "4mxt": {
         "exposureTime": 0.055,
         "oscillationRange": 0.15,
         # "radiationSensitivity": 1.3,
@@ -317,11 +317,11 @@ class GphlWorkflow(HardwareObjectYaml):
         ]
         for ii0, tag in enumerate(instrument_data["gonio_axis_names"]):
             ii1 = 3 * ii0
-            self.rotation_axes[tag] = instrument_data["gonio_axis_dirs"][ii1: ii1 + 3]
+            self.rotation_axes[tag] = instrument_data["gonio_axis_dirs"][ii1 : ii1 + 3]
         for ii0, tag in enumerate(instrument_data["gonio_centring_axis_names"]):
             ii1 = 3 * ii0
             self.translation_axes[tag] = instrument_data["gonio_centring_axis_dirs"][
-                ii1: ii1 + 3
+                ii1 : ii1 + 3
             ]
 
         # Move beamstop settings to top level
@@ -2682,9 +2682,12 @@ class GphlWorkflow(HardwareObjectYaml):
                     HWR.beamline.gphl_workflow._queue_entry.get_data_model().crystal_thickness
                 )
                 if crystal_thickness:
-                    beam_dim = HWR.beamline.beam.get_beam_size()[
-                        HWR.beamline.gphl_workflow.rotation_axis_index()
-                    ] * 1000.
+                    beam_dim = (
+                        HWR.beamline.beam.get_beam_size()[
+                            HWR.beamline.gphl_workflow.rotation_axis_index()
+                        ]
+                        * 1000.0
+                    )
                     # NBNB TODO beam sizes seem to come in mm. Units nowhere defined.
                     #  FIX THIS MESS!
                     if crystal_thickness > beam_dim:

--- a/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
+++ b/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
@@ -89,8 +89,9 @@ EMULATION_DATA = {
     "4mxt":{
         "exposureTime": 0.055,
         "oscillationRange": 0.15,
-        "radiationSensitivity": 1.3,
+        # "radiationSensitivity": 1.3,
         "energy": 12.2222,
+        # "aimedResolution": 2.22,
     },
 }
 

--- a/mxcubecore/configuration/mockup/gphl/gphl-workflow.yml
+++ b/mxcubecore/configuration/mockup/gphl/gphl-workflow.yml
@@ -99,44 +99,48 @@ settings:
     # (which may override this value)
     # Any other true value reads from auto_acq_parameters below
     # automation_mode: TEST_FROM_FILE
+    # automation_mode: MASSIF1
 
-    # Default parameters for fully automated strategies
-    # Multiple acquisitions in order - characterisation then main
-    # passed to set_pre_strategy_params and set_pre_acquisition_params
-    # NB as long as we only acquire either characterisation+main or diffractcal
-    # the code will use list[0] for the first acquisition
-    # and list[-1] for the main one
-    auto_acq_parameters:
-      # For characterisation acquisition
-      - exposure_time: 0.02
-        image_width: 0.1
-        # resolution: 1.928
-        strategy: Char_4_by_10_multitrigger
-        # init_spot_dir: /directory/containing/SPOT.XDS/file/after/characterisation
-        # strategy_options: # Not currently used
-        # For acquisition or diffractcal
-        # Expectation for crystal classes - needed for indexing selection.
+  # Default parameters for fully automated strategies
+  # Multiple acquisitions in order - characterisation then main
+  # passed to set_pre_strategy_params and set_pre_acquisition_params
+  # NB as long as we only acquire either characterisation+main or diffractcal
+  # the code will use list[0] for the first acquisition
+  # and list[-1] for the main one
+  auto_acq_parameters:
+    # For characterisation acquisition
+    - exposure_time: 0.02
+      image_width: 0.1
+      # resolution: 1.928
+      strategy: Char_6_5_multitrigger
+      # init_spot_dir: /directory/containing/SPOT.XDS/file/after/characterisation
+      # strategy_options: # Not currently used
+      # For acquisition or diffractcal
+      # Expectation for crystal classes - needed for indexing selection.
 
-        # crystal_classes:
-        #   - 222P
-        #   - 222C
-        #   - 222I
-        # space_group: I222
-      - exposure_time: 0.02
-        image_width: 1.0
-        resolution: 1.5
-        snapshot_count: 2
-        wedge_width: 15.0
-        strategy: full
-        repetition_count: 1
-        # strategy_options:
-        # # Program options passed directly to stratcal - not needed normally
-        #   Override default settings
-        #   angular_tolerance, maximum_chi, and clip_kappa are defined in
-        #   settings (above) and strategy_type and variant by program
-        #   maximum_chi: 48.0
-        #   angular_tolerance: 1.0
-        #   option_name: 999.999
+      # crystal_classes:
+      #   - 222P
+      #   - 222C
+      #   - 222I
+      # space_group: I222
+    - exposure_time: 0.02
+      image_width: 1.0
+      resolution: 1.5
+      snapshot_count: 2
+      wedge_width: 15.0
+      strategy: full
+      repetition_count: 1
+#      energies:
+#        - 12.111
+#        - 12.222
+      # strategy_options:
+      # # Program options passed directly to stratcal - not needed normally
+      #   Override default settings
+      #   angular_tolerance, maximum_chi, and clip_kappa are defined in
+      #   settings (above) and strategy_type and variant by program
+      #   maximum_chi: 48.0
+      #   angular_tolerance: 1.0
+      #   option_name: 999.999
 
   # Java invocation properties - syntax is e.g. '-Dfile.encoding=UTF-8'
   invocation_properties:
@@ -316,80 +320,80 @@ workflows:
           # File name pattern for characterisation data collection
           charpattern: generic
 
-    "GΦL Diffractometer calibration":
-      wfpath: Gphl
-      wftype: diffractcal
-      requires:
-        - point
-      options:
-        # NB you must set EITHER wfprefix OR samplesubdir (or both)
-        # wfprefix is the enactment fixed file prefix
-        #        wfprefix: gphl_wf_
-        # Include sample filename prefix as subdirextory in enactment directory path
-        # Any
-        samplesubdir: null
-        # # directory paths are:
-        # wfprefix:  .../RAW_DATA/<wfprefix>_001/...
-        # samplesubdir:   .../RAW_DATA/<filenameprefix>_001/...
-        # both:   .../RAW_DATA/<filenameprefix>/<wfprefix>_001/...
+  "GΦL Diffractometer calibration":
+    wfpath: Gphl
+    wftype: diffractcal
+    requires:
+      - point
+    options:
+      # NB you must set EITHER wfprefix OR samplesubdir (or both)
+      # wfprefix is the enactment fixed file prefix
+      #        wfprefix: gphl_wf_
+      # Include sample filename prefix as subdirextory in enactment directory path
+      # Any
+      samplesubdir: null
+      # # directory paths are:
+      # wfprefix:  .../RAW_DATA/<wfprefix>_001/...
+      # samplesubdir:   .../RAW_DATA/<filenameprefix>_001/...
+      # both:   .../RAW_DATA/<filenameprefix>/<wfprefix>_001/...
 
-      strategies:
-        - title: Diffractometer calibration
-          strategy_type: diffractcal
-          wf_selection: diffractcal
-          variants:
-            - full
-            - short
-          documentation: |
-            Diffractometer calibration.
-            Designed for use by beamline personnel.
-            Calibrates axis directions, detector pane orientation,
-            and beam centre.
-            Long data collection and processing, requiring a high-quality,
-            high-symmetry crystal of precisely known cell parameters.
-            Variants:
-            full: 22 60-deg sweeps, 11 orientations
-            short: 6 60-deg sweeps, 3 orientations
-          options:
-            # wfprefix: Dcalib2_
-            # Name of strategy from library to use. Variant name is appended
-            strategy: DiffractCal_
-            # File name for diffractometer calibration output
-            calibration: diffractcal
-            # Pattern name for characterisation collections, used for all data
-            charpattern: multiorientation
-            # copy calibration result to configuration directory,
-            # moving aside previous value
-            # updateblconfig: null
-            # # Path of file to dump persisted instrumentation configuration. OPTIONAL
-            # instcfgout: gphl_diffractcal_out.nml
+    strategies:
+      - title: Diffractometer calibration
+        strategy_type: diffractcal
+        wf_selection: diffractcal
+        variants:
+          - full
+          - short
+        documentation: |
+          Diffractometer calibration.
+          Designed for use by beamline personnel.
+          Calibrates axis directions, detector pane orientation,
+          and beam centre.
+          Long data collection and processing, requiring a high-quality,
+          high-symmetry crystal of precisely known cell parameters.
+          Variants:
+          full: 22 60-deg sweeps, 11 orientations
+          short: 6 60-deg sweeps, 3 orientations
+        options:
+          # wfprefix: Dcalib2_
+          # Name of strategy from library to use. Variant name is appended
+          strategy: DiffractCal_
+          # File name for diffractometer calibration output
+          calibration: diffractcal
+          # Pattern name for characterisation collections, used for all data
+          charpattern: multiorientation
+          # copy calibration result to configuration directory,
+          # moving aside previous value
+          # updateblconfig: null
+          # # Path of file to dump persisted instrumentation configuration. OPTIONAL
+          # instcfgout: gphl_diffractcal_out.nml
 
-    "GΦL Translational Calibration":
-      wfpath: Gphl
-      wftype: transcal
-      requires:
-        - samplegrid
-      strategies:
-        - title: Translational Calibration
-          strategy_type: transcal
-          wf_selection: transcal
-          variants:
-            - full
-          documentation: |
-            Translational calibration.
-            Designed for use by beamline personnel.
-            Calibrates centring motors to allow prediction of centring positions
-            Consists of mulltiple centrings, requiring a glass or tungsten tip
-          options:
-            # file: File containing settings of rotation axes for calibration
-            # The name is the relative path from the gphl_beamline_config directory
-            # grid: Grid definition [axis_name:start:end:step],
-            #       slowest-varying to fastest varying
-            # EITHER file OR grid must be set.-->
-            # grid: grid_axes_spec
-            file: transcal_2stage.json
-            # copy calibration result to configuration directory,
-            # renaming previous result file
-            updateblconfig: null
-            # Path of file to dump persisted instrumentation configuration. OPTIONAL
-            # instcfgout: gphl_transcal_out.nml
+  "GΦL Translational Calibration":
+    wfpath: Gphl
+    wftype: transcal
+    requires:
+      - samplegrid
+    strategies:
+      - title: Translational Calibration
+        strategy_type: transcal
+        wf_selection: transcal
+        variants:
+          - full
+        documentation: |
+          Translational calibration.
+          Designed for use by beamline personnel.
+          Calibrates centring motors to allow prediction of centring positions
+          Consists of mulltiple centrings, requiring a glass or tungsten tip
+        options:
+          # file: File containing settings of rotation axes for calibration
+          # The name is the relative path from the gphl_beamline_config directory
+          # grid: Grid definition [axis_name:start:end:step],
+          #       slowest-varying to fastest varying
+          # EITHER file OR grid must be set.-->
+          # grid: grid_axes_spec
+          file: transcal_2stage.json
+          # copy calibration result to configuration directory,
+          # renaming previous result file
+          updateblconfig: null
+          # Path of file to dump persisted instrumentation configuration. OPTIONAL
+          # instcfgout: gphl_transcal_out.nml

--- a/mxcubecore/configuration/mockup/gphl/gphl-workflow.yml
+++ b/mxcubecore/configuration/mockup/gphl/gphl-workflow.yml
@@ -130,9 +130,9 @@ settings:
       wedge_width: 15.0
       strategy: full
       repetition_count: 1
-#      energies:
-#        - 12.111
-#        - 12.222
+      # energies:
+      #   - 12.111
+      #   - 12.222
       # strategy_options:
       # # Program options passed directly to stratcal - not needed normally
       #   Override default settings

--- a/mxcubecore/configuration/mockup/lims-client-mockup.xml
+++ b/mxcubecore/configuration/mockup/lims-client-mockup.xml
@@ -1,3 +1,3 @@
 <object class="ISPyBClientMockup">
    <loginType>user</loginType>
-</object> 
+</object>

--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -2297,7 +2297,12 @@ class GphlWorkflow(TaskNode):
                         )
                     )
                 self.wavelengths = tuple(wavelengths)
-            else:
+            elif not (
+                len(energies) == len(energy_tags)
+                and len(energies) == len(wavelengths)
+                and self.automation_mode
+            ):
+                # In automation mode energies and wavelengths are set together earlier
                 raise ValueError(
                     "Number of energies %s do not match remaining slots %s"
                     % (energies, energy_tags[len(self.wavelengths) :])

--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -1986,7 +1986,7 @@ class GphlWorkflow(TaskNode):
         self.space_group = str()
         self.crystal_classes = ()
         self._cell_parameters = ()
-        self.crystal_thickness = 0.0 # Minimum dimension of crystal, in micron
+        self.crystal_thickness = 0.0  # Minimum dimension of crystal, in micron
         self.detector_setting = None  # from 'resolution' parameter or defaults
         self.aimed_resolution = None  # from 'resolution' parameter or defaults
         self.wavelengths = ()  # from 'energies' parametes
@@ -2464,7 +2464,7 @@ class GphlWorkflow(TaskNode):
         else:
             energy_tag = "Characterisation"
         self.wavelengths = (
-            GphlMessages.PhasingWavelength(wavelength=wavelength,role=energy_tag),
+            GphlMessages.PhasingWavelength(wavelength=wavelength, role=energy_tag),
         )
 
     # Parameters for start of workflow

--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -1986,6 +1986,7 @@ class GphlWorkflow(TaskNode):
         self.space_group = str()
         self.crystal_classes = ()
         self._cell_parameters = ()
+        self.crystal_thickness = 0.0 # Minimum dimension of crystal, in micron
         self.detector_setting = None  # from 'resolution' parameter or defaults
         self.aimed_resolution = None  # from 'resolution' parameter or defaults
         self.wavelengths = ()  # from 'energies' parametes
@@ -2057,6 +2058,7 @@ class GphlWorkflow(TaskNode):
             "space_group",
             "crystal_classes",
             "_cell_parameters",
+            "crystal_thickness",
             "use_cell_for_processing",
             "relative_rad_sensitivity",
             "aimed_resolution",
@@ -2095,6 +2097,7 @@ class GphlWorkflow(TaskNode):
         init_spot_dir=None,
         relative_rad_sensitivity=None,
         use_cell_for_processing=None,
+        crystal_thickness=None,
         **unused,
     ):
         """
@@ -2109,6 +2112,7 @@ class GphlWorkflow(TaskNode):
         :param init_spot_dir (str):
         :param relative_rad_sensitivity (float):
         :param use_cell_for_processing (bool):
+        :param crystal_thickness (float):
         :param unused (dict):
         :return (None):
         """
@@ -2139,6 +2143,9 @@ class GphlWorkflow(TaskNode):
             )
         if cell_parameters:
             self.cell_parameters = cell_parameters
+
+        if crystal_thickness:
+            self.crystal_thickness = crystal_thickness
 
         interleave_order = self.strategy_settings.get("interleave_order")
         if interleave_order:
@@ -2342,6 +2349,7 @@ class GphlWorkflow(TaskNode):
             "decay_limit",
             "maximum_dose_budget",
             "characterisation_budget_fraction",
+            "crystal_thickness",
         ):
             value = params.get(tag)
             if value:

--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -2287,11 +2287,11 @@ class GphlWorkflow(TaskNode):
             self.snapshot_count = int(snapshot_count)
         if recentring_mode:
             self.recentring_mode = recentring_mode
+        energy_tags = (settings["default_beam_energy_tag"],)
+        if self.characterisation_done:
+            energy_tags = self.strategy_settings.get("beam_energy_tags", energy_tags)
         if energies:
             # Energies are *added* to existing list
-            energy_tags = self.strategy_settings.get(
-                "beam_energy_tags", (settings["default_beam_energy_tag"],)
-            )
             wavelengths = list(self.wavelengths)
             offset = len(wavelengths)
             if len(energies) == len(energy_tags) - offset:
@@ -2304,16 +2304,11 @@ class GphlWorkflow(TaskNode):
                         )
                     )
                 self.wavelengths = tuple(wavelengths)
-            elif not (
-                len(energies) == len(energy_tags)
-                and len(energies) == len(wavelengths)
-                and self.automation_mode
-            ):
-                # In automation mode energies and wavelengths are set together earlier
-                raise ValueError(
-                    "Number of energies %s do not match remaining slots %s"
-                    % (energies, energy_tags[len(self.wavelengths) :])
-                )
+        if len(self.wavelengths) != len(energy_tags):
+            raise ValueError(
+                "Number of energies: %s do not match slots %s"
+                % (len(self.wavelengths), energy_tags)
+            )
         if skip_collection:
             self.skip_collection = True
 


### PR DESCRIPTION
Added 'crystal thickness' input parameter, and use to calculate good transmission values also when beam is much narrower than the crystal.

Workflow now reads also energy, oscillationRange, and exposureTime from the diffractionPlan  when in automation mode.

Bug fixes for running MAD experiments in automation mode (multiple energies), for interleaved experiments with hdf5 files (temporary patch only).