### PR TITLE
Exclude files from distribution packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,12 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 
+# Exclude some files from being added to *sdist* and * wheel* distribution packages
+exclude = [
+    "mxcubecore/configuration",
+]
+
+
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
 typing-extensions = "^4.3.0"


### PR DESCRIPTION
Exclude some files from being added to distribution packages. These files are not needed in the distribution packages and they take a lot of disk space.

GitHub: fix https://github.com/mxcube/mxcubecore/issues/1069