### PR TITLE
Queue: set LIMS session ID in BaseQueueEntry class

### DIFF
--- a/mxcubecore/queue_entry/base_queue_entry.py
+++ b/mxcubecore/queue_entry/base_queue_entry.py
@@ -212,6 +212,7 @@ class BaseQueueEntry(QueueEntryContainer):
         self._checked_for_exec = False
         self.status = QUEUE_ENTRY_STATUS.NOT_EXECUTED
         self.type_str = ""
+        self._data_model.lims_session_id = HWR.beamline.session.session_id
 
     def is_failed(self):
         """Returns True if failed"""

--- a/mxcubecore/queue_entry/data_collection.py
+++ b/mxcubecore/queue_entry/data_collection.py
@@ -53,7 +53,6 @@ class DataCollectionQueueEntry(BaseQueueEntry):
         self.enable_take_snapshots = True
         self.enable_store_in_lims = True
         self.in_queue = False
-        self._data_model.lims_session_id = HWR.beamline.session.session_id
 
     def __setstate__(self, d):
         self.__dict__.update(d)


### PR DESCRIPTION
Assign LIMS session ID to data model in the `BaseQueueEntry` constructor, to make it available to all queue entry types.

As custom queue entries will typically inherit `BaseQueueEntry` class, thus they will not run the code in `DataCollectionQueueEntry`.

This change is needed for situations where custom queue entries need to call `mxcubecore.model.queue_model_objects.to_collect_dict()` function, which reads LIMS session ID from data model object.