### PR TITLE
ISPyB LIMS: move get_lims_name() to parent class

### DIFF
--- a/mxcubecore/HardwareObjects/ProposalTypeISPyBLims.py
+++ b/mxcubecore/HardwareObjects/ProposalTypeISPyBLims.py
@@ -2,11 +2,9 @@ from __future__ import print_function
 
 import itertools
 import uuid
-from typing import List
 
 from mxcubecore.HardwareObjects.abstract.ISPyBAbstractLims import ISPyBAbstractLIMS
 from mxcubecore.model.lims_session import (
-    Lims,
     LimsSessionManager,
     Proposal,
     Session,
@@ -32,14 +30,6 @@ class ProposalTypeISPyBLims(ISPyBAbstractLIMS):
 
     def get_proposals_by_user(self, login_id: str):
         raise Exception("Not implemented")
-
-    def get_lims_name(self) -> List[Lims]:
-        return [
-            Lims(
-                name="ISPyB",
-                description="Information System for protein Crystalographic Beamlines",
-            )
-        ]
 
     def get_full_user_name(self):
         return self.get_user_name()

--- a/mxcubecore/HardwareObjects/abstract/ISPyBAbstractLims.py
+++ b/mxcubecore/HardwareObjects/abstract/ISPyBAbstractLims.py
@@ -2,13 +2,17 @@ from __future__ import print_function
 
 import logging
 import warnings
+from typing import List
 
 import gevent
 
 from mxcubecore import HardwareRepository as HWR
 from mxcubecore.HardwareObjects.abstract.AbstractLims import AbstractLims
 from mxcubecore.HardwareObjects.abstract.ISPyBDataAdapter import ISPyBDataAdapter
-from mxcubecore.model.lims_session import LimsSessionManager
+from mxcubecore.model.lims_session import (
+    Lims,
+    LimsSessionManager,
+)
 
 
 class ISPyBAbstractLIMS(AbstractLims):
@@ -84,6 +88,14 @@ class ISPyBAbstractLIMS(AbstractLims):
                     self._translations[code]["gui"] = proposal.gui
                 except AttributeError:
                     pass
+
+    def get_lims_name(self) -> List[Lims]:
+        return [
+            Lims(
+                name="ISPyB",
+                description="Information System for protein Crystallographic Beamlines",
+            )
+        ]
 
     def get_user_name(self):
         raise Exception("Abstract class. Not implemented")


### PR DESCRIPTION
Identical implementation of `get_lims_name()` method can be used by both `ProposalTypeISPyBLims` and `UserTypeISPyBLims` classes.

Move this method to the parent class, to make it available for `UserTypeISPyBLims` class as well.