### PR TITLE
ISPyB LIMS: add method for fetching user full name

### DIFF
--- a/mxcubecore/HardwareObjects/abstract/ISPyBDataAdapter.py
+++ b/mxcubecore/HardwareObjects/abstract/ISPyBDataAdapter.py
@@ -322,6 +322,15 @@ class ISPyBDataAdapter:
             self._exception(str(e))
             raise e
 
+    def get_person_by_username(self, username: str) -> Dict:
+        try:
+            person = self._shipping.service.findPersonByLogin(username)
+            return asdict(person)
+        except WebFault as e:
+            self._error(str(e))
+
+        return {}
+
     def get_sessions_by_username(
         self, username: str, beamline_name: str
     ) -> LimsSessionManager:


### PR DESCRIPTION
Adds a method to ISPyB data adapter for fetching information about a user.

This is useful when looking up user's full name.