### PR TITLE
ISPyB LIMS: add a hook method for ISPyB authentication

### DIFF
--- a/mxcubecore/HardwareObjects/ProposalTypeISPyBLims.py
+++ b/mxcubecore/HardwareObjects/ProposalTypeISPyBLims.py
@@ -52,7 +52,7 @@ class ProposalTypeISPyBLims(ISPyBAbstractLIMS):
             ok = self.ldap_login(user_name, psd)
         elif self.authServerType == "ispyb":
             logging.getLogger("HWR").debug("ISPyB login")
-            ok, _ = self._ispybLogin(user_name, psd)
+            ok, _ = self.ispyb_login(user_name, psd)
         else:
             raise Exception("Authentication server type is not defined")
 

--- a/mxcubecore/HardwareObjects/UserTypeISPyBLims.py
+++ b/mxcubecore/HardwareObjects/UserTypeISPyBLims.py
@@ -105,7 +105,7 @@ class UserTypeISPyBLims(ISPyBAbstractLIMS):
             logging.getLogger("HWR").debug("User %s logged in LDAP" % login_name)
         elif self.authServerType == "ispyb":
             logging.getLogger("HWR").debug("ISPyB login")
-            ok, msg = self._ispybLogin(login_name, psd)
+            ok, msg = self.ispyb_login(login_name, psd)
         else:
             raise Exception("Authentication server type is not defined")
 

--- a/mxcubecore/HardwareObjects/abstract/ISPyBAbstractLims.py
+++ b/mxcubecore/HardwareObjects/abstract/ISPyBAbstractLims.py
@@ -98,13 +98,13 @@ class ISPyBAbstractLIMS(AbstractLims):
         ]
 
     def get_user_name(self):
-        raise Exception("Abstract class. Not implemented")
+        raise NotImplementedError
 
     def get_full_user_name(self):
-        raise Exception("Abstract class. Not implemented")
+        raise NotImplementedError
 
     def is_user_login_type(self):
-        raise Exception("Abstract class. Not implemented")
+        raise NotImplementedError
 
     def store_beamline_setup(self, session_id, bl_config):
         self.adapter.store_beamline_setup(session_id, bl_config)
@@ -142,7 +142,7 @@ class ISPyBAbstractLIMS(AbstractLims):
         return self.ldapConnection.authenticate(login_name, psd)
 
     def ispyb_login(self, login_name, psd):
-        raise Exception("Abstract class. Not implemented")
+        raise NotImplementedError
 
     def store_data_collection(self, mx_collection, bl_config=None):
         return self._store_data_collection(mx_collection, bl_config)

--- a/mxcubecore/HardwareObjects/abstract/ISPyBAbstractLims.py
+++ b/mxcubecore/HardwareObjects/abstract/ISPyBAbstractLims.py
@@ -141,6 +141,9 @@ class ISPyBAbstractLIMS(AbstractLims):
 
         return self.ldapConnection.authenticate(login_name, psd)
 
+    def ispyb_login(self, login_name, psd):
+        raise Exception("Abstract class. Not implemented")
+
     def store_data_collection(self, mx_collection, bl_config=None):
         return self._store_data_collection(mx_collection, bl_config)
 


### PR DESCRIPTION
Add an abstract method `ispyb_login()`, which is invoked when auth server is set to `ispyb`.

This allow to implement ISPyB authentication by overriding this method in your custom ISPyB lims class.