### PR TITLE
Update Actions in `pages` GitHub workflow

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -19,14 +19,14 @@ jobs:
     steps:
 
       - name: "Checkout"
-        uses: "actions/checkout@v4"  # tested with v4.1.0
+        uses: "actions/checkout@v4"
         with:
           # With shallow clone the "Last updated" timestamp can not get computed
           # See "Caveats" at https://pypi.org/project/sphinx-last-updated-by-git
           fetch-depth: 0
 
       - name: "Set up Python 3.8"
-        uses: "actions/setup-python@v4"  # tested with v4.7.0
+        uses: "actions/setup-python@v5"
         with:
           python-version: "3.8"
 
@@ -49,7 +49,7 @@ jobs:
         # This could potentially be run only when we intend to deploy...
         # ...but it can be useful to have the artifact for debugging
         # if: "github.ref_name == github.event.repository.default_branch"
-        uses: "actions/upload-pages-artifact@v2"  # tested with v2.0.0
+        uses: "actions/upload-pages-artifact@v3"
         with:
           path: "docs/build/html"
 
@@ -73,11 +73,11 @@ jobs:
     steps:
 
       - name: "Setup GitHub Pages"
-        uses: "actions/configure-pages@v3"  # tested with v3.0.6
+        uses: "actions/configure-pages@v5"
 
       - name: "Deploy to GitHub Pages"
         id: "deployment"
-        uses: "actions/deploy-pages@v2"  # tested with 2.0.4
+        uses: "actions/deploy-pages@v4"
 
 
 ...  # EOF


### PR DESCRIPTION
In particular because of some actions being deprecated: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/