### PR TITLE
[COLLECT] - flux threshold configured on flux hardware object

### DIFF
--- a/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
@@ -800,8 +800,6 @@ class AbstractMultiCollect(object):
             # if not self.safety_shutter_opened():
             self.open_safety_shutter()
 
-            flux_threshold = self.get_property("flux_threshold", 0)
-
             try:
                 HWR.beamline.flux.wait_for_beam()
                 HWR.beamline.cryo.wait_temperature()


### PR DESCRIPTION
The `flux_threshold` is now configured on the `Beam` HardwareObject. and `flux_threshold` on  `AbstractMultiCollect` is no longer used.