### PR TITLE
ISPyB LIMS: make it possible to use custom ISPyB adapter object

### DIFF
--- a/mxcubecore/HardwareObjects/abstract/ISPyBAbstractLims.py
+++ b/mxcubecore/HardwareObjects/abstract/ISPyBAbstractLims.py
@@ -61,13 +61,7 @@ class ISPyBAbstractLIMS(AbstractLims):
         except AttributeError:
             pass
 
-        self.adapter = ISPyBDataAdapter(
-            self.ws_root.strip(),
-            self.proxy,
-            self.ws_username,
-            self.ws_password,
-            self.beamline_name,
-        )
+        self.adapter = self._create_data_adapter()
         logging.getLogger("HWR").debug("[ISPYB] Proxy address: %s" % self.proxy)
 
         # Add the porposal codes defined in the configuration xml file
@@ -88,6 +82,15 @@ class ISPyBAbstractLIMS(AbstractLims):
                     self._translations[code]["gui"] = proposal.gui
                 except AttributeError:
                     pass
+
+    def _create_data_adapter(self) -> ISPyBDataAdapter:
+        return ISPyBDataAdapter(
+            self.ws_root.strip(),
+            self.proxy,
+            self.ws_username,
+            self.ws_password,
+            self.beamline_name,
+        )
 
     def get_lims_name(self) -> List[Lims]:
         return [


### PR DESCRIPTION
Adds a factory method `_create_data_adapter()`, which creates an instance of data adapter. This allows to supply different implementation of the adapter objects in custom ISPyB LIMS classes.

We use a custom data adapter at MAX IV, to implement our site specific features.