### PR TITLE
ISPyB LIMS: store sessions in 'session_manager' for user-type logins

### DIFF
--- a/mxcubecore/HardwareObjects/UserTypeISPyBLims.py
+++ b/mxcubecore/HardwareObjects/UserTypeISPyBLims.py
@@ -116,7 +116,11 @@ class UserTypeISPyBLims(ISPyBAbstractLIMS):
             raise Exception("Error lims authentication")
 
         # login succeed, get proposal and sessions
-        self.adapter.get_sessions_by_username(loginID, self.beamline_name)
+        self.session_manager = self.adapter.get_sessions_by_username(
+            loginID, self.beamline_name
+        )
+
+        return self.session_manager
 
     def get_proposals_by_user(self, user_name):
         proposal_list = []


### PR DESCRIPTION
On successful login using user-type logins, store returned sessions in `session_manger` attribute of the `HWR.beamline.lims `object. This way session are avail later on.