### PR TITLE
ISPyB LIMS: update 'login_ok' attribute on successful user-type logins

### DIFF
--- a/mxcubecore/HardwareObjects/UserTypeISPyBLims.py
+++ b/mxcubecore/HardwareObjects/UserTypeISPyBLims.py
@@ -100,16 +100,16 @@ class UserTypeISPyBLims(ISPyBAbstractLIMS):
             logging.getLogger("HWR").debug(
                 "Starting LDAP authentication %s" % login_name
             )
-            ok = self.ldap_login(login_name, psd, ldap_connection)
+            self.login_ok = self.ldap_login(login_name, psd, ldap_connection)
             msg = loginID
             logging.getLogger("HWR").debug("User %s logged in LDAP" % login_name)
         elif self.authServerType == "ispyb":
             logging.getLogger("HWR").debug("ISPyB login")
-            ok, msg = self.ispyb_login(login_name, psd)
+            self.login_ok, msg = self.ispyb_login(login_name, psd)
         else:
             raise Exception("Authentication server type is not defined")
 
-        if not ok:
+        if not self.login_ok:
             msg = "%s." % msg.capitalize()
             # refuse Login
             logging.getLogger("HWR").error("ISPyB login not ok")


### PR DESCRIPTION
Make sure `self.login_ok` attribute is set to `True` after a successful login. The `self.login_ok` attribute attribute is consulted in `ISPyBAbstractLIMS.is_connected()` method.

The `lims.is_connected()` method is used by the rest of the system to check if LIMS sub-system is in usable state.