### PR TITLE
Fix type hint annotation issue for Python 3.8

### DIFF
--- a/mxcubecore/HardwareObjects/abstract/AbstractCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractCollect.py
@@ -20,6 +20,8 @@
 
 """Abstract hardware object for data collection."""
 
+from __future__ import annotations
+
 import abc
 import collections
 import errno


### PR DESCRIPTION
The issue was introduced in that commit:
`4fb849824bf4bcb9b91699dc74aa670370249104`

That commit introduced type hint notations
that are not supported in Python 3.8.

With `from __future__ import annotations`,
Python 3.8 should be able to run the code anyway.