### PR TITLE
Fixed bug (for Python3.8) in type annotations

### DIFF
--- a/mxcubecore/model/lims_session.py
+++ b/mxcubecore/model/lims_session.py
@@ -3,9 +3,9 @@ from datetime import (
     timedelta,
 )
 from typing import (
+    Dict,
     List,
     Optional,
-    Dict,
 )
 
 from pydantic.v1 import (

--- a/mxcubecore/model/lims_session.py
+++ b/mxcubecore/model/lims_session.py
@@ -5,6 +5,7 @@ from datetime import (
 from typing import (
     List,
     Optional,
+    Dict,
 )
 
 from pydantic.v1 import (
@@ -77,4 +78,4 @@ class LimsUser(BaseModel):
 class LimsSessionManager(BaseModel):
     active_session: Optional[Session] = None
     sessions: Optional[List[Session]] = []
-    users: Optional[dict[str, LimsUser]] = {}
+    users: Optional[Dict[str, LimsUser]] = {}


### PR DESCRIPTION
The line
    users: Optional[dict[str, LimsUser]] = {}
raises an error in Python 3.8. Changing it to 
    users: Optional[Dict[str, LimsUser]] = {}
(and importing Dict) fixes the problem