### PR TITLE
Fix project metadata URLs in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ maintainers = [
     {name = "Antonia Beteva", email = "beteva@esrf.fr"},
 ]
 readme = "README.md"
-homepage = "http://github.com/mxcube/mxcubecore"
-repository = "http://github.com/mxcube/mxcubecore"
-documentation = "https://mxcubecore.readthedocs.io/"
+urls.homepage = "https://github.com/mxcube/mxcubecore"
+urls.repository = "https://github.com/mxcube/mxcubecore"
+urls.documentation = "https://mxcubecore.readthedocs.io/"
 keywords = ["mxcube", "mxcube3", "mxcubecore"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This error was introduced in the following commit: da7bbfc8df3dd3d9a18855ff3446f6754413e5da

GitHub: related to https://github.com/mxcube/mxcubecore/pull/1138