### PR TITLE
add AbstractShutter.is_closed property

### DIFF
--- a/mxcubecore/HardwareObjects/abstract/AbstractShutter.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractShutter.py
@@ -50,12 +50,27 @@ class AbstractShutter(AbstractNState):
     VALUES = BaseValueEnum
 
     @property
-    def is_open(self):
+    def is_open(self) -> bool:
         """Check if the shutter is open.
         Returns:
             (bool): True if open, False otherwise.
         """
         return self.get_value() == self.VALUES.OPEN
+
+    @property
+    def is_closed(self) -> bool:
+        """Check if the shutter is closed.
+
+        Note that it is not always true that ``is_closed != is_open``,
+        it takes time to open and close the shutter.
+
+        Many shutters can be in "moving" state.
+        When in that state the shutter is both "not open" and "not closed".
+
+        Returns:
+            ``True`` if closed, ``False`` otherwise.
+        """
+        return self.get_value() == self.VALUES.CLOSED
 
     def open(self, timeout=None):
         """Open the shutter.


### PR DESCRIPTION
Add a dedicated property to check if the shutter is closed. This property allows to correctly handle shutters that have a for example a `moving` state.

For example if the shutter perform the close operation by changing states via:

 `open` -> `moving` -> `closed`

The `is_closed` property allows you to check when the shutter have actually reached the `closed` state.