### PR TITLE
drop python 2 imports

### DIFF
--- a/mxcubecore/HardwareObjects/ESRF/ESRFMultiCollect.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFMultiCollect.py
@@ -2,24 +2,14 @@ import logging
 import math
 import os
 import time
+from http.client import HTTPConnection
+from urllib.parse import urlencode
 
 from mxcubecore import HardwareRepository as HWR
 from mxcubecore.BaseHardwareObjects import HardwareObject
 from mxcubecore.HardwareObjects.abstract.AbstractMultiCollect import *
 from mxcubecore.model.queue_model_objects import PathTemplate
 from mxcubecore.utils.conversion import string_types
-
-try:
-    from httplib import HTTPConnection
-except Exception:
-    # Python3
-    from http.client import HTTPConnection
-
-try:
-    from urllib import urlencode
-except Exception:
-    # Python3
-    from urllib.parse import urlencode
 
 
 class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):

--- a/mxcubecore/HardwareObjects/EdnaWorkflow.py
+++ b/mxcubecore/HardwareObjects/EdnaWorkflow.py
@@ -16,12 +16,6 @@ from mxcubecore.HardwareObjects.SecureXMLRpcRequestHandler import (
     SecureXMLRpcRequestHandler,
 )
 
-try:
-    from httplib import HTTPConnection
-except Exception:
-    # Python3
-    pass
-
 
 class State(object):
     """

--- a/mxcubecore/HardwareObjects/GenericDiffractometer.py
+++ b/mxcubecore/HardwareObjects/GenericDiffractometer.py
@@ -50,13 +50,6 @@ from mxcubecore.BaseHardwareObjects import HardwareObject
 from mxcubecore.HardwareObjects import sample_centring
 from mxcubecore.model import queue_model_objects
 
-try:
-    unicode
-except Exception:
-    # A quick fix for python3
-    unicode = str
-
-
 __credits__ = ["MXCuBE collaboration"]
 
 __version__ = "2.2."
@@ -1125,7 +1118,7 @@ class GenericDiffractometer(HardwareObject):
                     " Moving %s to %s" % (str(motor.name()), position)
                 )
             """
-            if isinstance(motor, (str, unicode)):
+            if isinstance(motor, str):
                 motor_role = motor
                 motor = self.motor_hwobj_dict.get(motor_role)
                 # del motor_positions[motor_role]

--- a/mxcubecore/HardwareObjects/UserTypeISPyBLims.py
+++ b/mxcubecore/HardwareObjects/UserTypeISPyBLims.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import logging
 import sys
+from urllib.error import URLError
 
 from suds import WebFault
 from suds.client import Client
@@ -9,13 +10,6 @@ from suds.sudsobject import asdict
 
 from mxcubecore.HardwareObjects.abstract.ISPyBAbstractLims import ISPyBAbstractLIMS
 from mxcubecore.model.lims_session import LimsSessionManager
-
-try:
-    from urllib2 import URLError
-    from urlparse import urljoin
-except Exception:
-    # Python3
-    from urllib.error import URLError
 
 suds_encode = str.encode
 

--- a/mxcubecore/HardwareObjects/abstract/ISPyBDataAdapter.py
+++ b/mxcubecore/HardwareObjects/abstract/ISPyBDataAdapter.py
@@ -1,35 +1,27 @@
 from __future__ import print_function
 
 import itertools
+import logging
+import sys
 import time
 from datetime import datetime
 from typing import (
     Dict,
     List,
 )
-
-from mxcubecore.HardwareObjects.abstract.ISPyBValueFactory import ISPyBValueFactory
-from mxcubecore.utils.conversion import string_types
-
-try:
-    from urllib2 import URLError
-    from urlparse import urljoin
-except Exception:
-    # Python3
-    from urllib.error import URLError
-
-import logging
-import sys
+from urllib.error import URLError
 
 from suds import WebFault
 from suds.client import Client
 from suds.sudsobject import asdict
 
+from mxcubecore.HardwareObjects.abstract.ISPyBValueFactory import ISPyBValueFactory
 from mxcubecore.model.lims_session import (
     LimsSessionManager,
     Proposal,
     Session,
 )
+from mxcubecore.utils.conversion import string_types
 
 suds_encode = str.encode
 

--- a/mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
@@ -12,12 +12,6 @@ from mxcubecore.model.lims_session import (
     Session,
 )
 
-try:
-    from urlparse import urljoin
-except Exception:
-    # Python3
-    pass
-
 # to simulate wrong loginID, use anything else than idtest
 # to simulate wrong psd, use "wrong" for password
 # to simulate ispybDown, but ldap login succeeds, use "ispybDown" for password

--- a/mxcubecore/HardwareObjects/mockup/ISPyBRestClientMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/ISPyBRestClientMockup.py
@@ -6,16 +6,10 @@ from __future__ import print_function
 
 import logging
 from datetime import datetime
+from urllib.parse import urljoin
 
 from mxcubecore import HardwareRepository as HWR
 from mxcubecore.BaseHardwareObjects import HardwareObject
-
-try:
-    from urlparse import urljoin
-except Exception:
-    # Python3
-    from urllib.parse import urljoin
-
 
 _CONNECTION_ERROR_MSG = (
     "Could not connect to ISPyB, please verify that "


### PR DESCRIPTION
Remove the imports that dealt with python2 and python3 compatibility. We don't support python 2 anymore.