### PR TITLE
Remove trailing empty spaces with pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,20 +10,7 @@ repos:
     rev: v5.0.0
     hooks:
       - id: trailing-whitespace
-        # Exclude files from trailing-whitespace checks until we get around fixing them.
-        # This way we can check that other files are trailing-whitespace clean in CI.
-        exclude: |
-            (?x)^(
-                mxcubecore/configuration/.*|
-                mxcubecore/HardwareObjects/(PlateManipulatorMaintenance|TangoMotor)\.py|
-                mxcubecore/HardwareObjects/DESY/P11(BackLight|Collect|DetectorCover|Shutter)\.py|
-                mxcubecore/HardwareObjects/LNLS/LNLS(Diffractometer|Energy|PilatusDet)\.py|
-                mxcubecore/HardwareObjects/LNLS/EPICS(Actuator|Motor|NState)\.py|
-                mxcubecore/HardwareObjects/LNLS/set_transmission_mnc.py|
-                mxcubecore/HardwareObjects/EMBL/EMBL(Energy|OnlineProcessing)\.py|
-                mxcubecore/HardwareObjects/mockup/MotorMockup\.py|
-                mxcubecore/HardwareObjects/SOLEIL/PX2/PX2Resolution\.py|
-            )$
+        exclude: \.(hkli|nml|XDS)$
       - id: end-of-file-fixer
         exclude: \.(hkli|nml)$
       - id: check-case-conflict

--- a/mxcubecore/HardwareObjects/DESY/P11BackLight.py
+++ b/mxcubecore/HardwareObjects/DESY/P11BackLight.py
@@ -114,7 +114,7 @@ class P11BackLight(AbstractNState):
             self.cmd_started = time.time()
 
     def update_light_state(self, value=None):
-        """Updates light state 
+        """Updates light state
 
         :return: light state as str
         """

--- a/mxcubecore/HardwareObjects/DESY/P11Collect.py
+++ b/mxcubecore/HardwareObjects/DESY/P11Collect.py
@@ -863,7 +863,7 @@ class P11Collect(AbstractCollect):
 
     def xdsapp_maxwell(self):
         """Starts XDSAPP auto-processing on the Maxwell cluster."""
-        
+
         if HWR.beamline.session.get_beamtime_metadata() != None:
 
             self.log.debug("==== XDSAPP AUTOPROCESSING IS STARTED ==========")
@@ -933,7 +933,7 @@ class P11Collect(AbstractCollect):
 
     def autoproc_maxwell(self):
         """Starts AutoProc auto-processing on the Maxwell cluster."""
-            
+
         if HWR.beamline.session.get_beamtime_metadata() != None:
 
             self.log.debug("==== AUTOPROC AUTOPROCESSING IS STARTED ==========")

--- a/mxcubecore/HardwareObjects/DESY/P11DetectorCover.py
+++ b/mxcubecore/HardwareObjects/DESY/P11DetectorCover.py
@@ -167,7 +167,7 @@ class P11DetectorCover(AbstractShutter):
         self.update_cover_state()
 
     def update_cover_state(self):
-        """Updates cover state 
+        """Updates cover state
 
         :return: cover state as str
         """

--- a/mxcubecore/HardwareObjects/DESY/P11Shutter.py
+++ b/mxcubecore/HardwareObjects/DESY/P11Shutter.py
@@ -159,7 +159,7 @@ class P11Shutter(AbstractShutter):
         self.log.debug("### simulated finished with exception")
 
     def update_shutter_state(self, state=None):
-        """Updates shutter state 
+        """Updates shutter state
 
         :return: shutter state as str
         """

--- a/mxcubecore/HardwareObjects/EMBL/EMBLEnergy.py
+++ b/mxcubecore/HardwareObjects/EMBL/EMBLEnergy.py
@@ -288,7 +288,7 @@ class EMBLEnergy(AbstractEnergy):
             pos = pos[0]
         value = pos / 1000
 
-        if self._nominal_value is None or abs(value - self._nominal_value) > 1e-3: 
+        if self._nominal_value is None or abs(value - self._nominal_value) > 1e-3:
             self.update_value(value)
 
     def energy_limits_changed(self, limits):

--- a/mxcubecore/HardwareObjects/EMBL/EMBLOnlineProcessing.py
+++ b/mxcubecore/HardwareObjects/EMBL/EMBLOnlineProcessing.py
@@ -492,7 +492,7 @@ class EMBLOnlineProcessing(AbstractOnlineProcessing):
            self.all_frames_dozor_is = False
            self.all_frames_batch_processed = False
            self.is_count = 0
-           self.batch_count = 0 
+           self.batch_count = 0
 
     def dozor_average_i_changed(self, average_i_value):
         if self.started:
@@ -730,7 +730,7 @@ class EMBLOnlineProcessing(AbstractOnlineProcessing):
         acq_params = self.data_collection.acquisitions[0].acquisition_parameters
 
         sample_basename   = self.params_dict["template"].split("/")[-1].split("_%d_%0")[0]
-        # stream_filename   = sample_basename + "_crystfel_xgandalf.stream" 
+        # stream_filename   = sample_basename + "_crystfel_xgandalf.stream"
         stream_filename   = sample_basename + cell_name_tag + "_crystfel.stream"
         geom_filename     = "crystfel_detector.geom"
         cell_filename     = "crystfel_cell" + cell_name_tag + ".cell"

--- a/mxcubecore/HardwareObjects/LNLS/EPICSActuator.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICSActuator.py
@@ -73,7 +73,7 @@ class EPICSActuator(AbstractActuator.AbstractActuator):
         if self.__wait_actuator_task is not None:
             self.__wait_actuator_task.kill()
         self.update_state(self.STATES.READY)
-        
+
     def _set_value(self, value):
         """ Override AbstractActuator method."""
         self.set_channel_value(self.ACTUATOR_VAL, value)

--- a/mxcubecore/HardwareObjects/LNLS/EPICSMotor.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICSMotor.py
@@ -50,7 +50,7 @@ class EPICSMotor(EPICSActuator, AbstractMotor):
         self.get_velocity()
         self.__watch_task = gevent.spawn(self._watch)
         self.update_state(self.STATES.READY)
-    
+
     def _watch(self):
         """ Watch motor current value and update it on the UI."""
         while True:
@@ -85,7 +85,7 @@ class EPICSMotor(EPICSActuator, AbstractMotor):
         if self._nominal_limits in [(0, 0), (float('-inf'), float('inf'))]:
             # Treat infinite limits
             self._nominal_limits = (None, None)
-        
+
         logging.getLogger("HWR").info('Motor %s limits: %s' % (self.motor_name, self._nominal_limits))
         return self._nominal_limits
 
@@ -97,7 +97,7 @@ class EPICSMotor(EPICSActuator, AbstractMotor):
     def set_velocity(self, value):
         """Override AbstractMotor method."""
         self.__velocity = self.set_channel_value(self.MOTOR_VELO, value)
-    
+
     def done_movement(self):
         """ Return whether motor finished movement or not."""
         dmov = self.get_channel_value(self.MOTOR_DMOV)

--- a/mxcubecore/HardwareObjects/LNLS/EPICSNState.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICSNState.py
@@ -69,7 +69,7 @@ class EPICSNState(AbstractNState, EPICSActuator):
         self.set_value(enum_val)
         self.actuatorState = self.states.get(value, "unknown")
         self.emit("actuatorStateChanged", (self.actuatorState,))
-    
+
     def actuatorIn(self, wait=True, timeout=None):
         try:
             self.state_attr = self.moves["in"]

--- a/mxcubecore/HardwareObjects/LNLS/LNLSDiffractometer.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSDiffractometer.py
@@ -358,7 +358,7 @@ class LNLSDiffractometer(GenericDiffractometer):
         if y <= (- x + 1152):
             dir_goniox = 1
         else:
-            dir_goniox = -1         
+            dir_goniox = -1
         move_goniox = dir_goniox * drx_goniox
         # mm to move
         move_goniox = move_goniox / self.pixels_per_mm_x

--- a/mxcubecore/HardwareObjects/LNLS/LNLSEnergy.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSEnergy.py
@@ -48,13 +48,13 @@ class LNLSEnergy(EPICSActuator, AbstractEnergy):
         #if abs(self._nominal_value - value) < 0.001:
         #    logging.getLogger("HWR").info("Pilatus threshold is still okay.")
         #    return value
-        
+
         threshold_ok = self.check_threshold_energy(value)
         if threshold_ok:
             self._nominal_value = value
         else:
            value = None  # Invalid energy because threshold is invalid
-        
+
         return value
 
     def check_threshold_energy(self, energy):

--- a/mxcubecore/HardwareObjects/LNLS/LNLSPilatusDet.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSPilatusDet.py
@@ -192,13 +192,13 @@ class LNLSPilatusDet(AbstractDetector):
         #        "Pilatus wavelength still okay."
         #    )
         #    return True
-        
+
         # As the set of Pilatus wavelength, det dist and beam xy is fast,
         # there is no need to compare the target value with the current one.
         logging.getLogger("HWR").info("Setting Pilatus wavelength...")
         self.set_channel_value(self.DET_WAVELENGTH, wavelength)
         time.sleep(0.6)
-        
+
         print('WAVELENGHT WAS SET: ' + str(wavelength))
         self.wavelength = self.get_wavelength()
         print('WAVELENGHT GOT: ' + str(self.wavelength))
@@ -277,7 +277,7 @@ class LNLSPilatusDet(AbstractDetector):
         """
         Set detector beam_x and returns whether it was successful or not.
 
-        Beam X value can come from different sources. The priority (from 
+        Beam X value can come from different sources. The priority (from
         high to low) is:
         * from_user
         * beam_x argument
@@ -339,7 +339,7 @@ class LNLSPilatusDet(AbstractDetector):
         """
         Set detector beam_y and returns whether it was successful or not.
 
-        Beam Y value can come from different sources. The priority (from 
+        Beam Y value can come from different sources. The priority (from
         high to low) is:
         * from_user
         * beam_y argument
@@ -380,7 +380,7 @@ class LNLSPilatusDet(AbstractDetector):
             "Error while setting Pilatus beam Y. Please, check the detector."
         )
         return False
-    
+
     def get_transmission(self):
         """
         Returns:
@@ -417,7 +417,7 @@ class LNLSPilatusDet(AbstractDetector):
             "Error while setting Pilatus transmission. Please, check the detector."
         )
         return False
-    
+
     def get_start_angle(self):
         """
         Returns:
@@ -454,7 +454,7 @@ class LNLSPilatusDet(AbstractDetector):
             "Error while setting Pilatus start angle. Please, check the detector."
         )
         return False
-    
+
     def get_angle_incr(self):
         """
         Returns:

--- a/mxcubecore/HardwareObjects/LNLS/set_transmission_mnc.py
+++ b/mxcubecore/HardwareObjects/LNLS/set_transmission_mnc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
- 
+
 """Transmission control for MANACA.
    Attenuator: ABS-300-12-C-DN-DN40 Flanges.
    Foils: #1, 8 um Al;
@@ -37,7 +37,7 @@ def read_input():
 
 def get_transmission(energy, transmission):
     transmission = transmission/100
-    # Expressions (interpolation) for calculations of MU (linear attenuation coeficient [cm^-1]) for each material in function of the beam energy. 
+    # Expressions (interpolation) for calculations of MU (linear attenuation coeficient [cm^-1]) for each material in function of the beam energy.
     # The data used to obtain the expressions (curve fitting) are from  "https://physics.nist.gov/PhysRefData/FFast/html/form.html"
     # This attenuation coeficients can be verified and optimised after experimental validation at the beamline.
     MU_Al = (78657.01011 * math.exp(-energy/0.65969)) + (6406.36151 * math.exp(-energy/1.63268)) + (492.29999 * math.exp(-energy/4.42554)) + (3.2588)
@@ -47,7 +47,7 @@ def get_transmission(energy, transmission):
     MU_Zr = (11143.28458 * math.exp(-energy/5.87029)) + (102.27474)
     MU_EMPTY = 0.0
     # Foils in ABS-attenuator. The dictionary gives the foil position and material in the key (e.g. 'F1_Al', position 1 occuped by an aluminium foil),
-    # and the thickness [um] in the value. The list gives the positions and materials, similar to the dictionary, and it is used in the combination. 
+    # and the thickness [um] in the value. The list gives the positions and materials, similar to the dictionary, and it is used in the combination.
     foils_dict = {'F0_EMPTY':0, 'F1_Al':8, 'F2_Al':10, 'F3_Al':20, 'F4_Al':80, 'F5_Al':160, 'F6_Al':320, 'F7_Al':800,
                   'F8_Al':1500, 'F9_Ti':8, 'F10_Cu':10, 'F11_Au':5, 'F12_Zr':25}
 
@@ -64,10 +64,10 @@ def get_transmission(energy, transmission):
         attenuator_position = attenuator_position[0:12]
     elif energy >= 18.5:
         attenuator_position = attenuator_position[0:13]
-    
+
     foils_comb = []
     atten_coef_sum = []
-    
+
     # calculate the all possible unique combinations
     for i in range(1, len(attenuator_position)+1):
         product = itertools.combinations(attenuator_position, i)
@@ -75,7 +75,7 @@ def get_transmission(energy, transmission):
             foils_comb.append(list(item))
     # calculate the product of MU (cm^-1) * thickness (cm) for each material (MU * d)
     # and sum the products to obtain the total (final) attenuation for each possible combination.
-    # and put the results (total attenuation) in a list. 
+    # and put the results (total attenuation) in a list.
     comb_sum = []
     for item in foils_comb:
         comb_tmp = []
@@ -114,11 +114,11 @@ def get_transmission(energy, transmission):
 
 
 def set_foils(filter_combination):
-    
+
     # declare a list with available foils and a dictionary with epics PV class (FOIL ACT, FOIL IN, FOIL OUT) for each foil
     attenuator_position = ['F1_Al', 'F2_Al', 'F3_Al', 'F4_Al', 'F5_Al', 'F6_Al', 'F7_Al', 'F8_Al',
                            'F9_Ti', 'F10_Cu', 'F11_Au', 'F12_Zr']
-    
+
     foils_pv = {'F1_Al':(PV('MNC:B:RIO01:9474C:bo0'), PV('MNC:B:RIO01:9425A:bi11'), PV('MNC:B:RIO01:9425A:bi12')),
                  'F2_Al':(PV('MNC:B:RIO01:9474C:bo1'), PV('MNC:B:RIO01:9425A:bi10'), PV('MNC:B:RIO01:9425A:bi13')),
                  'F3_Al':(PV('MNC:B:RIO01:9474C:bo2'), PV('MNC:B:RIO01:9425A:bi9'), PV('MNC:B:RIO01:9425A:bi14')),
@@ -133,9 +133,9 @@ def set_foils(filter_combination):
                  'F12_Zr':(PV('MNC:B:RIO01:9474D:bo3'), PV('MNC:B:RIO01:9425A:bi0'), PV('MNC:B:RIO01:9425A:bi23'))}
 
     # setup the foils: check foil status, put the foils in the 'filter_combination' and remove the others
-    
+
     wt = 0.1
-    
+
     # the commented lines bellow works for the attenuator expected logic (0 for foil out and 1 for foil in).
     # as the current logic is inverted (1 is foil out and 0 is foil in) use the uncommented lines.
 
@@ -166,7 +166,7 @@ def set_foils(filter_combination):
             elif foils_pv[foil][1].get() == foils_pv[foil][2].get():
                 status = 1
                 break
-    
+
     return status
 
 
@@ -176,7 +176,7 @@ def main():
     transmission_setup = get_transmission(energy, transmission)
     # transmission required by the user
     user_transmission = transmission_setup[0] * 100
-    # real transmission got with calculated foil combination 
+    # real transmission got with calculated foil combination
     actual_transmission = round(transmission_setup[1] * 100, 2)
     # calculated foil combination to get the required transmission
     filter_combination = transmission_setup[2]

--- a/mxcubecore/HardwareObjects/PlateManipulatorMaintenance.py
+++ b/mxcubecore/HardwareObjects/PlateManipulatorMaintenance.py
@@ -15,7 +15,7 @@ class PlateManipulatorMaintenance(HardwareObject):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-    
+
     def init(self):
         self._sc = self.get_object_by_role("sample_changer")
         self._scan_limits = ''
@@ -28,7 +28,7 @@ class PlateManipulatorMaintenance(HardwareObject):
         :rtype: None
         """
         return self._sc._do_abort()
-    
+
     def _move_to_crystal_position(self, args):
         """
         command to move MD head to x, y crystal position
@@ -38,7 +38,7 @@ class PlateManipulatorMaintenance(HardwareObject):
         :rtype: None
         """
         return self._sc.move_to_crystal_position(args)
-    
+
 
     def _do_change_mode(self, args):
         self._sc._do_change_mode(args)
@@ -66,7 +66,7 @@ class PlateManipulatorMaintenance(HardwareObject):
     def _update_global_state(self):
         state_dict, cmd_state, message = self.get_global_state()
         self.emit("globalStateChanged", (state_dict, cmd_state, message))
-    
+
     def get_global_state(self):
         """
         """
@@ -90,7 +90,7 @@ class PlateManipulatorMaintenance(HardwareObject):
 
         return state_dict, cmd_state, message
 
-    
+
 
     def get_cmd_info(self):
         """ return information about existing commands for this object
@@ -121,5 +121,5 @@ class PlateManipulatorMaintenance(HardwareObject):
         if cmdname == "setPlateBarcode":
             self.set_plate_barcode(args)
         # if cmdname == "change_mode":
-        #     self._do_change_mode(args)      
+        #     self._do_change_mode(args)
         return True

--- a/mxcubecore/HardwareObjects/SOLEIL/PX2/PX2Resolution.py
+++ b/mxcubecore/HardwareObjects/SOLEIL/PX2/PX2Resolution.py
@@ -12,7 +12,7 @@ class PX2Resolution(AbstractResolution):
         super(PX2Resolution, self).__init__(name)
         self.resolution_motor = resolution()
         self.beam_center = beam_center()
-        
+
     def connect_notify(self, signal):
         if signal == "stateChanged":
             self.update_state(self.get_state())
@@ -20,7 +20,7 @@ class PX2Resolution(AbstractResolution):
     def get_value(self):
         self._nominal_value = self.resolution_motor.get_resolution()
         return self._nominal_value
-    
+
     def _set_value(self, value):
         self.resolution_motor.set_resolution(value)
 

--- a/mxcubecore/HardwareObjects/TangoMotor.py
+++ b/mxcubecore/HardwareObjects/TangoMotor.py
@@ -224,12 +224,12 @@ class TangoMotor(AbstractMotor):
         motor_state = self.chan_state.get_value()
         self.log.debug(" reading motor state for %s is %s" % (self.name(), str(motor_state)))
         self.motor_state_changed(motor_state)
-            
+
     def update_value(self, value=None):
         """Updates motor position"""
         if value is None:
             value = self.get_value()
-        self.latest_value = value 
+        self.latest_value = value
         super(TangoMotor, self).update_value(value)
 
     def get_motor_mnemonic(self):

--- a/mxcubecore/HardwareObjects/mockup/MotorMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/MotorMockup.py
@@ -121,6 +121,6 @@ class MotorMockup(ActuatorMockup, AbstractMotor):
             self.update_specific_state(None)
 
         return value
-    
+
     def is_moving(self):
         return ( (self.get_state() == self.STATES.BUSY ) or (self.get_state() == self.SPECIFIC_STATES.MOVING))

--- a/mxcubecore/configuration/alba_xaloc13/auto-processing.xml
+++ b/mxcubecore/configuration/alba_xaloc13/auto-processing.xml
@@ -2,5 +2,5 @@
 
   <template_dir>/beamlines/bl13/commissioning/templates</template_dir>
   <variables_ds>bl13/ct/variables</variables_ds>
-  
+
 </object>

--- a/mxcubecore/configuration/alba_xaloc13/beam-info.xml
+++ b/mxcubecore/configuration/alba_xaloc13/beam-info.xml
@@ -1,11 +1,11 @@
 <object class="ALBABeamInfo">
     <taurusname>bl13/ct/variables</taurusname>
-  
+
     <channel type="sardana" name="BeamPositionHorizontal">ImageCenterX</channel>
     <channel type="sardana" name="BeamPositionVertical">ImageCenterY</channel>
     <channel type="sardana" name="BeamWidth">BeamWidth</channel>
     <channel type="sardana" name="BeamHeight">BeamHeight</channel>
-    
+
     <beam_divergence_horizontal>230.0</beam_divergence_horizontal>
     <beam_divergence_vertical>150.0</beam_divergence_vertical>
 </object>

--- a/mxcubecore/configuration/alba_xaloc13/beamline-setup.xml
+++ b/mxcubecore/configuration/alba_xaloc13/beamline-setup.xml
@@ -9,7 +9,7 @@
   <object href="/omega" role="omega_axis"/>
   <object href="/kappa" role="kappa_axis"/>
   <!-- object href="/kappaphi" role="kappa_phi_axis"/ -->
-  <object href="/cats" role="sample_changer"/>    
+  <object href="/cats" role="sample_changer"/>
   <!-- object href="/plate-manipulator" role="plate_manipulator"/ -->
   <object href="/resolution" role="resolution"/>
   <object href="/energy" role="energy"/>
@@ -19,7 +19,7 @@
   <object href="/dbconnection" role="lims_client"/>
   <object href="/data-analysis" role="data_analysis"/>
   <!--<object href="/workflow-mockup" role="workflow"/> -->
- 
+
   <!-- Procedures and routines -->
   <object href="/energyscan-mockup" role="energyscan"/>
   <object href="/mxcollect" role="collect"/>

--- a/mxcubecore/configuration/alba_xaloc13/cats.xml
+++ b/mxcubecore/configuration/alba_xaloc13/cats.xml
@@ -1,7 +1,7 @@
 <object class = "ALBACats">
 
   <username>Cats</username>
-  <tangoname>bl13/eh/cats</tangoname>    
+  <tangoname>bl13/eh/cats</tangoname>
 
   <!-- specify the number of lids here to support different models-->
   <no_of_lids>3</no_of_lids>
@@ -11,7 +11,7 @@
   <useUpdateTimer>False</useUpdateTimer>
 
   <unipuck_tool>5</unipuck_tool> <!-- can be unipuck: 1   or double/gripper:  5 -->
- 
+
   <auto_prepare_diff>True</auto_prepare_diff>
 
   <channel type="tango" tangoname="bl13/eh/diff" name="shifts">MountingPosition</channel>

--- a/mxcubecore/configuration/alba_xaloc13/catsmaint.xml
+++ b/mxcubecore/configuration/alba_xaloc13/catsmaint.xml
@@ -1,7 +1,7 @@
 <object class = "ALBACatsMaint">
   <username>CatsMaint</username>
-  <tangoname>bl13/eh/cats</tangoname>    
-  
+  <tangoname>bl13/eh/cats</tangoname>
+
   <!--  COMMANDS -->
 
   <channel type="tango" tangoname="bl13/eh/diff" name="shifts">MountingPosition</channel>

--- a/mxcubecore/configuration/alba_xaloc13/data-analysis.xml
+++ b/mxcubecore/configuration/alba_xaloc13/data-analysis.xml
@@ -10,5 +10,5 @@
 
   <template_dir>/beamlines/bl13/commissioning/templates</template_dir>
   <variables_ds>bl13/ct/variables</variables_ds>
-  
+
 </object>

--- a/mxcubecore/configuration/alba_xaloc13/gphl_beamline_config/filenametemplates.xml
+++ b/mxcubecore/configuration/alba_xaloc13/gphl_beamline_config/filenametemplates.xml
@@ -10,33 +10,33 @@ Refer to the TemplateElementTypes class diagram.
 The following restrictions must be adhered to:
 
   (1) The root element MUST be
-     
+
        <xml-fragment xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ...>
-     
+
       It MUST be called "xml-fragment" and it MUST assign the prefix "xsi" to
       the standard XML Schema instance namespace. It also must also declare namespaces
       for all the types that are used: those take the form of the relative path
       in the data model only. The prefix "tag:globalphasing.com,YYYY-MM-DD:schemata:"
       will be added when this file is read.
-     
+
   (2) XML elements within the top-level elements MUST follow the order of their
       declaration in the UML data model (elements corresponding to inherited
       properties come before locally-defined ones). XML elements whose values
       are absent (allowed where the property's lower bound is 0) should be
       omitted, not given null or empty values.
-      
+
   (3) Each <element> contained within a <filenamePattern> element MUST contain
       a "xsi:type" attribute. The localname of the value of this attribute MUST
       be the unqualified name of one of the non-abstract subtypes of
       Types::TemplateElementTypes::NameTemplateElement.
-      
+
   (4) Elements that are direct children of the document root:
-  
+
         (i) MUST contain the appropriate xsi:type attribute
         (ii) may be called anything, but the recommended name is the
         same as the value of the xsi:type attribute with the first letter
         of the local part lower cased.
-        
+
         In the future, a proper XSD type for the root element of this
         file may be defined: when this happens the xsi:type attribute
         will become unnecessary, and the element name will be used for
@@ -53,23 +53,23 @@ The following restrictions must be adhered to:
 
     <c:filenamePattern xsi:type="c:FilenamePattern">
         <exid>GDA</exid>
-        
+
         <element xsi:type="tet:Parameter">
         <maxWidth>43</maxWidth>
         <name>prefix</name>
         <type>string</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
-        
+
         <element xsi:type="tet:Parameter">
             <maxWidth>2</maxWidth>
             <name>run</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
@@ -152,7 +152,7 @@ The following restrictions must be adhered to:
             <name>beam_setting_index</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
@@ -162,7 +162,7 @@ The following restrictions must be adhered to:
             <name>run_number</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
@@ -211,7 +211,7 @@ The following restrictions must be adhered to:
             <name>beam_setting_index</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Parameter">
             <maxWidth>1</maxWidth>
             <name>inverse_beam_component_sign</name>
@@ -227,7 +227,7 @@ The following restrictions must be adhered to:
             <name>run_number</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
@@ -281,7 +281,7 @@ The following restrictions must be adhered to:
             <name>run_number</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
@@ -299,79 +299,79 @@ The following restrictions must be adhered to:
 
 
     <c:filenamePatternMapping xsi:type="c:FilenamePatternMapping">
-    
+
         <entry>
             <tgtName>prefix</tgtName>
             <srcRange>0</srcRange>
             <srcRange>6</srcRange>
         </entry>
-        
+
         <entry>
             <tgtName>run</tgtName>
             <srcRange>7</srcRange>
             <srcRange>8</srcRange>
         </entry>
-        
+
         <mapsFrom>interleaved</mapsFrom>
         <mapsTo>GDA</mapsTo>
-        
+
     </c:filenamePatternMapping>
 
     <c:filenamePatternMapping xsi:type="c:FilenamePatternMapping">
-    
+
         <entry>
             <tgtName>prefix</tgtName>
             <srcRange>0</srcRange>
             <srcRange>7</srcRange>
         </entry>
-        
+
         <entry>
             <tgtName>run</tgtName>
             <srcRange>8</srcRange>
             <srcRange>9</srcRange>
         </entry>
-        
+
         <mapsFrom>ib_interleaved</mapsFrom>
         <mapsTo>GDA</mapsTo>
-        
+
     </c:filenamePatternMapping>
 
     <c:filenamePatternMapping xsi:type="c:FilenamePatternMapping">
-    
+
         <entry>
             <tgtName>prefix</tgtName>
             <srcRange>0</srcRange>
             <srcRange>1</srcRange>
         </entry>
-        
+
         <entry>
             <tgtName>run</tgtName>
             <srcRange>2</srcRange>
             <srcRange>3</srcRange>
         </entry>
-        
+
         <mapsFrom>generic</mapsFrom>
         <mapsTo>GDA</mapsTo>
-        
+
     </c:filenamePatternMapping>
 
     <c:filenamePatternMapping xsi:type="c:FilenamePatternMapping">
-    
+
         <entry>
             <tgtName>prefix</tgtName>
             <srcRange>0</srcRange>
             <srcRange>4</srcRange>
         </entry>
-        
+
         <entry>
             <tgtName>run</tgtName>
             <srcRange>5</srcRange>
             <srcRange>6</srcRange>
         </entry>
-        
+
         <mapsFrom>multiorientation</mapsFrom>
         <mapsTo>GDA</mapsTo>
-        
+
     </c:filenamePatternMapping>
 
 

--- a/mxcubecore/configuration/alba_xaloc13/gphl_beamline_config/transcal_2stage.json
+++ b/mxcubecore/configuration/alba_xaloc13/gphl_beamline_config/transcal_2stage.json
@@ -1,5 +1,5 @@
 [
-    { 
+    {
       "#": "Settings for running TransCal on a mini-Kappa (short protocol, without SOC)",
       "settings": [
         0,   0,       0,
@@ -13,10 +13,10 @@
       "noRefineSOC": true,
       "useRecen": false
     },
-    
+
     {
       "#": "Settings for running TransCal on a mini-Kappa (medium-length protocol)",
-    
+
       "settings": [
         0.00,     0.00,   -90.00,
         0.00,     0.00,   -45.00,

--- a/mxcubecore/configuration/alba_xaloc13/limavideo.xml
+++ b/mxcubecore/configuration/alba_xaloc13/limavideo.xml
@@ -6,7 +6,7 @@
    <!--address>84.89.227.6</address-->
 
    <address>84.89.227.72</address>
-   <tangoname>bl13/eh/basler_oav</tangoname> 
+   <tangoname>bl13/eh/basler_oav</tangoname>
 
    <gain>0.24</gain>
    <scale>1</scale>

--- a/mxcubecore/configuration/alba_xaloc13/mini-diff.xml
+++ b/mxcubecore/configuration/alba_xaloc13/mini-diff.xml
@@ -1,5 +1,5 @@
 <object class="ALBAMiniDiff">
- 
+
   <taurusname>bl13/eh/diff</taurusname>
 
   <!-- Specific for Xaloc -->
@@ -27,7 +27,7 @@
   <object href="/supervisor" role="beamline-supervisor"/>
 
   <object href="/beam-info" role="beam_info"/>
-  
+
   <sample_centring>True</sample_centring>
 
   <!--object href="/minikappa-correction" role="minikappa_correction"/-->

--- a/mxcubecore/configuration/alba_xaloc13/queue-model.xml
+++ b/mxcubecore/configuration/alba_xaloc13/queue-model.xml
@@ -1,7 +1,7 @@
 <object class="QueueModel" role="QueueModel">
-  <object href="/queue" role="queue"/>    
-  
-  <!-- 
+  <object href="/queue" role="queue"/>
+
+  <!--
   <load_on_start_enabled>True</load_on_start_enabled>
   <load_on_start_filename>/tmp/mxcube/queue.dat</load_on_start_filename>
   -->

--- a/mxcubecore/configuration/alba_xaloc13/session.xml
+++ b/mxcubecore/configuration/alba_xaloc13/session.xml
@@ -1,4 +1,4 @@
-<object class = "ALBASession" role = "session">  
+<object class = "ALBASession" role = "session">
   <!-- ATTENTION . base data directories are overwritten in ALBA -->
   <!--   the value in ldap homeDirectory is used for the three base directories -->
   <!--      base_directory, base_process_directory, base_archive_directory -->

--- a/mxcubecore/configuration/alba_xaloc13/xml-rpc-server.xml
+++ b/mxcubecore/configuration/alba_xaloc13/xml-rpc-server.xml
@@ -3,7 +3,7 @@
   <!-- Should XML-RPC server listen on all interfaces?
        False (the default) means listen only on the interface given
        by socket.gethostname()-->
-  <all_interfaces> 
+  <all_interfaces>
     True
   </all_interfaces>
   <port>

--- a/mxcubecore/configuration/desy_p11/Qt4_graphics-manager.xml
+++ b/mxcubecore/configuration/desy_p11/Qt4_graphics-manager.xml
@@ -3,7 +3,7 @@
    <object href="/beam-info" role="beam_info"/>
    <object href="/mjpg-stream-video" role="camera"/>
 
-   <!-- Enable move sample buttons 
+   <!-- Enable move sample buttons
         TODO: implement this feature
    <enable_move_buttons>False</enable_move_buttons> -->
 
@@ -12,7 +12,7 @@
 
    <!-- Scale incomming video frame -->
    <!-- <default_image_scale>1</default_image_scale> -->
-   <image_scale_list>(1, 1.5, 2, 2.5, 3, 4, 5)</image_scale_list> 
+   <image_scale_list>(1, 1.5, 2, 2.5, 3, 4, 5)</image_scale_list>
 
    <!-- Scale all graphics view -->
    <!-- <view_scale>1.3</view_scale> -->

--- a/mxcubecore/configuration/desy_p11/_Qt4_video-mockup.xml
+++ b/mxcubecore/configuration/desy_p11/_Qt4_video-mockup.xml
@@ -1,3 +1,3 @@
-<object class="Qt4_VideoMockup"> 
-   <interval>1</interval>	
+<object class="Qt4_VideoMockup">
+   <interval>1</interval>
 </object>

--- a/mxcubecore/configuration/desy_p11/auto-processing-mockup.xml
+++ b/mxcubecore/configuration/desy_p11/auto-processing-mockup.xml
@@ -3,7 +3,7 @@
     Each autoprocessing program is executable script.
     Script is stored and executed when the event is called
 
-    remove Break to run actual script      
+    remove Break to run actual script
     -->
     <programs>
     <program>

--- a/mxcubecore/configuration/desy_p11/beamline-setup.xml
+++ b/mxcubecore/configuration/desy_p11/beamline-setup.xml
@@ -6,7 +6,7 @@
   <object href="/diff-omega-mockup" role="omega_axis"/>
   <object href="/diff-kappa-mockup" role="kappa_axis"/>
   <object href="/diff-kappaphi-mockup" role="kappa_phi_axis"/>
-  <object href="/sc-mockup" role="sample_changer"/>    
+  <object href="/sc-mockup" role="sample_changer"/>
   <object href="/plate-manipulator" role="plate_manipulator"/>
   <object href="/resolution-mockup" role="resolution"/>
   <object href="/energy-mockup" role="energy"/>
@@ -23,7 +23,7 @@
   <!--<object href="/workflow-mockup" role="workflow"/> -->
   <object href="/gphl_beamline_config/gphl-workflow" role="gphl_workflows"/>
   <object href="/gphl_beamline_config/gphl-connection" role="gphl_connection"/>
- 
+
   <!-- Procedures and routines -->
   <object href="/energyscan-mockup" role="energyscan"/>
   <object href="/mxcollect" role="collect"/>

--- a/mxcubecore/configuration/desy_p11/beamline-test.xml
+++ b/mxcubecore/configuration/desy_p11/beamline-test.xml
@@ -1,5 +1,5 @@
 <object class="BeamlineTestMockup">
-    <object href="/beamline-setup" role="beamline_setup"/> 
+    <object href="/beamline-setup" role="beamline_setup"/>
 
     <available_tests>["example_one", "example_two"]</available_tests>
     <startup_tests>["example_one"]</startup_tests>

--- a/mxcubecore/configuration/desy_p11/cats.xml
+++ b/mxcubecore/configuration/desy_p11/cats.xml
@@ -1,11 +1,11 @@
 <object class = "sample_changer.Cats90">
   <username>Cats</username>
-  <tangoname>bl141/cats/1</tangoname>    
+  <tangoname>bl141/cats/1</tangoname>
   <!-- specify the number of lids here to support different models-->
   <no_of_lids>3</no_of_lids>
- 
+
   <channel type="tango" name="_chnState" polling="events">State</channel>
-  
+
   <command type="tango" name="_cmdAbort">abort</command>
 
   <channel type="tango" name="_chnBasket1State" polling="events">di_Cassette1Presence</channel>

--- a/mxcubecore/configuration/desy_p11/catsmaint.xml
+++ b/mxcubecore/configuration/desy_p11/catsmaint.xml
@@ -1,7 +1,7 @@
 <object class = "sample_changer.CatsMaint">
   <username>CatsMaint</username>
-  <tangoname>bl141/cats/1</tangoname>    
-  
+  <tangoname>bl141/cats/1</tangoname>
+
   <command type="tango" name="_cmdReset">reset</command>
   <command type="tango" name="_cmdBack">back</command>
   <command type="tango" name="_cmdSafe">safe</command>

--- a/mxcubecore/configuration/desy_p11/centring-math.xml
+++ b/mxcubecore/configuration/desy_p11/centring-math.xml
@@ -1,13 +1,13 @@
 <procedure class="CentringMath">
   <!--
   Gonio axes are in a real physical order
-  --> 
+  -->
   <gonioAxes>
      <axis>
         <motorname>phiy</motorname>
         <direction>[0, 1, 0]</direction>
 	<type>translation</type>
-	<motorHO>/eh1/diff-phiy</motorHO> 
+	<motorHO>/eh1/diff-phiy</motorHO>
      </axis>
 
      <!-- removing this axis (normal to Omega) will fix Omega position -->
@@ -15,7 +15,7 @@
         <motorname>phiz</motorname>
         <direction>[1, 0, 0]</direction>
         <type>translation</type>
-        <motorHO>/eh1/diff-phiz</motorHO> 
+        <motorHO>/eh1/diff-phiz</motorHO>
      </axis>
 
      <!-- e.g. robodiff chi axis
@@ -32,22 +32,22 @@
         <!-- direction of omega at Chi==0 -->
         <direction>[0, -1, 0]</direction>
         <type>rotation</type>
-        <motorHO>/eh1/diff-omega</motorHO> 
+        <motorHO>/eh1/diff-omega</motorHO>
      </axis>
 
      <axis>
-        <!-- direction of sampx at Chi==0 and Omega == 0 --> 
+        <!-- direction of sampx at Chi==0 and Omega == 0 -->
         <motorname>sampx</motorname>
         <direction>[-0.281085,  0, 0.959683]</direction>
         <type>translation</type>
-        <motorHO>/eh1/diff-sampx</motorHO> 
+        <motorHO>/eh1/diff-sampx</motorHO>
      </axis>
 
      <axis>
         <motorname>sampy</motorname>
         <direction>[0.959683,  0, 0.281085 ]</direction>
         <type>translation</type>
-        <motorHO>/eh1/diff-sampy</motorHO> 
+        <motorHO>/eh1/diff-sampy</motorHO>
      </axis>
   </gonioAxes>
   <cameraAxes>

--- a/mxcubecore/configuration/desy_p11/lims-client-mockup.xml
+++ b/mxcubecore/configuration/desy_p11/lims-client-mockup.xml
@@ -1,4 +1,4 @@
 <object class="ISPyBClientMockup">
    <object href="/session" role="session"/>
    <loginType>user</loginType>
-</object> 
+</object>

--- a/mxcubecore/configuration/desy_p11/mjpg-stream-video.xml
+++ b/mxcubecore/configuration/desy_p11/mjpg-stream-video.xml
@@ -1,4 +1,4 @@
-<object class="MjpgStreamVideo"> 
+<object class="MjpgStreamVideo">
     <interval>10</interval>
     <host>haspp11camsrv</host>
     <port>8081</port>

--- a/mxcubecore/configuration/desy_p11/queue-model.xml
+++ b/mxcubecore/configuration/desy_p11/queue-model.xml
@@ -1,7 +1,7 @@
 <object class="QueueModel" role="QueueModel">
-  <object href="/queue" role="queue"/>    
-  
-  <!-- 
+  <object href="/queue" role="queue"/>
+
+  <!--
   <load_on_start_enabled>True</load_on_start_enabled>
   <load_on_start_filename>/tmp/mxcube/queue.dat</load_on_start_filename>
   -->

--- a/mxcubecore/configuration/desy_p11/redis.xml
+++ b/mxcubecore/configuration/desy_p11/redis.xml
@@ -1,4 +1,4 @@
 <object class="RedisClient">
    <object href="/beamline-setup" role="beamline_setup"/>
-   <object href="/queue-model" role="queue_model"/>   
+   <object href="/queue-model" role="queue_model"/>
 </object>

--- a/mxcubecore/configuration/desy_p11/sc-generic.xml
+++ b/mxcubecore/configuration/desy_p11/sc-generic.xml
@@ -1,7 +1,7 @@
 <object class = "sample_changer.SC3">
 <!--PMSC  or SC3-->
   <username>Sample Changer / Test</username>
-  <exporter_address></exporter_address>    
+  <exporter_address></exporter_address>
   <channel type="exporter" name="_state">State</channel>
   <channel type="exporter" name="_selected_basket">SelectedBasketLocation</channel>
   <channel type="exporter" name="_selected_sample">SelectedSampleLocation</channel>
@@ -21,18 +21,18 @@
 
   <!--
   <channel_type>exporter</channel_type>
-  <exporter_address>pc445.embl.fr:9001</exporter_address>    
-  
+  <exporter_address>pc445.embl.fr:9001</exporter_address>
+
   <channel_state>State</channel_state>
   <channel_image>ImageJPG</channel_image>
-  <channel_phase>CurrentPhase</channel_phase>  
-  <channel_task_info>LastTaskInfo</channel_task_info>    
-  
+  <channel_phase>CurrentPhase</channel_phase>
+  <channel_task_info>LastTaskInfo</channel_task_info>
+
   <command_scan>startScan</command_scan>
   <command_set_phase>startSetPhase</command_set_phase>
-  <command_abort>abort</command_abort>  
+  <command_abort>abort</command_abort>
   <command_reset>restart</command_reset>
-  <command_load_sample>startMovePlateToShelf</command_load_sample>  
+  <command_load_sample>startMovePlateToShelf</command_load_sample>
   <command_select_sample>startMovePlateToShelf</command_select_sample>
 -->
 </object>

--- a/mxcubecore/configuration/desy_p11/slits-mockup.xml
+++ b/mxcubecore/configuration/desy_p11/slits-mockup.xml
@@ -10,5 +10,5 @@
        <minGap>0.005</minGap>
        <maxGap>0.300</maxGap>
        <updateTolerance>0.0005</updateTolerance>
-    </gapV>  
+    </gapV>
 </object>

--- a/mxcubecore/configuration/desy_p11/video-mockup.xml
+++ b/mxcubecore/configuration/desy_p11/video-mockup.xml
@@ -1,3 +1,3 @@
-<object class="VideoMockup"> 
-   <interval>2000</interval>	
+<object class="VideoMockup">
+   <interval>2000</interval>
 </object>

--- a/mxcubecore/configuration/desy_p11/xml-rpc-server.xml
+++ b/mxcubecore/configuration/desy_p11/xml-rpc-server.xml
@@ -3,7 +3,7 @@
   <!-- Should XML-RPC server listen on all interfaces?
        False (the default) means listen only on the interface given
        by socket.gethostname()-->
-  <all_interfaces> 
+  <all_interfaces>
     True
   </all_interfaces>
   <port>

--- a/mxcubecore/configuration/embl_hh_p13/beam-centering.xml
+++ b/mxcubecore/configuration/embl_hh_p13/beam-centering.xml
@@ -14,7 +14,7 @@
     <command type="tine" name="cmdStartPitchScan" tinename="/P13/p13mono.cdi/StartPitchScan">SEND</command>
     <command type="tine" name="cmdSetVMaxPitch" tinename="/p13/p13mono.cdi/SetVMaxPitch">SEND</command>
     <command type="tine" name="cmdQBPMRangeSet" tinename="/P13/QBPM1/Device0">CurrentRange.set</command>
-  
+
     <scale_hor>-0.020</scale_hor>
     <scale_ver>-0.020</scale_ver>
 </object>

--- a/mxcubecore/configuration/embl_hh_p13/beam-info.xml
+++ b/mxcubecore/configuration/embl_hh_p13/beam-info.xml
@@ -3,12 +3,12 @@
 
     <exporter_address>p13md201.embl-hamburg.de:9001</exporter_address>
     <!--channel type="exporter" name="BeamPositionHorizontal">BeamPositionHorizontal</channel>
-    <channel type="exporter" name="BeamPositionVertical">BeamPositionVertical</channel--> 
+    <channel type="exporter" name="BeamPositionVertical">BeamPositionVertical</channel-->
 
     <channel type="tine" name="BeamPositionHorizontal" tinename="/P13/MD/MD_0" timeout="100">BeamPositionHorizontal</channel>
-    <channel type="tine" name="BeamPositionVertical" tinename="/P13/MD/MD_0" timeout="100">BeamPositionVertical</channel> 
+    <channel type="tine" name="BeamPositionVertical" tinename="/P13/MD/MD_0" timeout="100">BeamPositionVertical</channel>
     <channel type="exporter" name="BeamSizeMicrons">BeamSizeMicrons</channel>
-    <channel type="exporter" name="BeamShapeEllipse">BeamShapeEllipse</channel> 
+    <channel type="exporter" name="BeamShapeEllipse">BeamShapeEllipse</channel>
 
     <defaultBeamDivergence>(230.0, 150.0)</defaultBeamDivergence>
 </object>

--- a/mxcubecore/configuration/embl_hh_p13/beam.xml
+++ b/mxcubecore/configuration/embl_hh_p13/beam.xml
@@ -3,12 +3,12 @@
 
     <exporter_address>p13md201.embl-hamburg.de:9001</exporter_address>
     <!--channel type="exporter" name="BeamPositionHorizontal">BeamPositionHorizontal</channel>
-    <channel type="exporter" name="BeamPositionVertical">BeamPositionVertical</channel--> 
+    <channel type="exporter" name="BeamPositionVertical">BeamPositionVertical</channel-->
 
     <channel type="tine" name="BeamPositionHorizontal" tinename="/P13/MD/MD_0" timeout="100">BeamPositionHorizontal</channel>
-    <channel type="tine" name="BeamPositionVertical" tinename="/P13/MD/MD_0" timeout="100">BeamPositionVertical</channel> 
+    <channel type="tine" name="BeamPositionVertical" tinename="/P13/MD/MD_0" timeout="100">BeamPositionVertical</channel>
     <channel type="exporter" name="BeamSizeMicrons">BeamSizeMicrons</channel>
-    <channel type="exporter" name="BeamShapeEllipse">BeamShapeEllipse</channel> 
+    <channel type="exporter" name="BeamShapeEllipse">BeamShapeEllipse</channel>
 
     <defaultBeamDivergence>(230.0, 150.0)</defaultBeamDivergence>
 </object>

--- a/mxcubecore/configuration/embl_hh_p13/beamline-test.xml
+++ b/mxcubecore/configuration/embl_hh_p13/beamline-test.xml
@@ -7,8 +7,8 @@
     <channel type="tine" name="intensRange" tinename="/P13/BCUIntensity/Device0">CurrentRange.set</channel-->
 
     <channel type="tine" name="chanPitchScanStatus" tinename="/P13/p13mono.cdi/PitchScanStat" attach="datachange">PitchScanStat</channel>
- 
-    <!-- 
+
+    <!--
     <channel type="tine" name="chanQBPMAr" tinename="/P13/p13mono.cdi/QBPMAr">RECV</channel>
     <channel type="tine" name="chanPitchPositionAr" tinename="/P13/p13mono.cdi/VPitchAr">RECV</channel>
     <channel type="tine" name="chanEncAr" tinename="/P13/p13mono.cdi/EncAr">RECV</channel>
@@ -20,10 +20,10 @@
     <command type="tine" name="cmdStartPitchScan" tinename="/P13/p13mono.cdi/StartPitchScan">SEND</command>
     <command type="tine" name="cmdSetVMaxPitch" tinename="/p13/p13mono.cdi/SetVMaxPitch">SEND</command>
     <command type="tine" name="cmdQBPMRangeSet" tinename="/P13/QBPM1/Device0">CurrentRange.set</command>
-  
+
 
     <!-- available_tests is a list of selected tests:
- 
+
         "summary": "Beamline summary",
         "com": "Communication with beamline devices",
         "ppu": "PPU control",
@@ -37,7 +37,7 @@
         "graph": "Graph"}
     <available_tests>["ppu", "autocentring", "com", "sc_stats"]</available_tests>
     -->
-    
+
     <startup_tests>["measure_intensity"]</startup_tests>
     <scale_hor>-0.020</scale_hor>
     <scale_ver>-0.020</scale_ver>

--- a/mxcubecore/configuration/embl_hh_p13/beamline-tools.xml
+++ b/mxcubecore/configuration/embl_hh_p13/beamline-tools.xml
@@ -7,7 +7,7 @@
        <display>Center beam</display>
        <method>center_beam_report</method>
        <icon>QuickRealign</icon>
-     </tool> 
+     </tool>
      <tool>
        <hwobj>flux</hwobj>
        <display>Measure flux</display>

--- a/mxcubecore/configuration/embl_hh_p13/centring-math.xml
+++ b/mxcubecore/configuration/embl_hh_p13/centring-math.xml
@@ -1,13 +1,13 @@
 <procedure class="CentringMath">
   <!--
   Gonio axes are in a real physical order
-  --> 
+  -->
   <gonioAxes>
      <axis>
         <motorname>phiy</motorname>
         <direction>[1, 0, 0]</direction>
 	<type>translation</type>
-	<motorHO>/eh1/diff-phiy</motorHO> 
+	<motorHO>/eh1/diff-phiy</motorHO>
      </axis>
 
      <!-- removing this axis (normal to Omega) will fix Omega position -->
@@ -15,23 +15,23 @@
         <motorname>phiz</motorname>
         <direction>[0,-1, 0]</direction>
         <type>translation</type>
-        <motorHO>/eh1/diff-phiz</motorHO> 
+        <motorHO>/eh1/diff-phiz</motorHO>
      </axis>
 
      <axis>
         <motorname>phi</motorname>
         <direction>[-1, 0, 0]</direction>
         <type>rotation</type>
-        <motorHO>/eh1/diff-omega</motorHO> 
+        <motorHO>/eh1/diff-omega</motorHO>
      </axis>
 
      <axis>
-        <!-- direction of sampx at Omega == 0 --> 
+        <!-- direction of sampx at Omega == 0 -->
         <motorname>sampx</motorname>
         <!--  THIS WAS ORIGINAL OMEGA REFERENCE  direction>[0,  -0.998939, 0.0460604]</direction-->
         <direction>[0, 0, 1]</direction>
         <type>translation</type>
-        <motorHO>/eh1/diff-sampx</motorHO> 
+        <motorHO>/eh1/diff-sampx</motorHO>
      </axis>
 
      <axis>
@@ -39,7 +39,7 @@
         <!-- THIS WAS ORIGINAL OMEGA REFERENCE direction>[0, 0.0460604,-0.998939]</direction-->
         <direction>[0, -1, 0]</direction>
         <type>translation</type>
-        <motorHO>/eh1/diff-sampy</motorHO> 
+        <motorHO>/eh1/diff-sampy</motorHO>
      </axis>
   </gonioAxes>
   <cameraAxes>

--- a/mxcubecore/configuration/embl_hh_p13/diffractometer.xml
+++ b/mxcubecore/configuration/embl_hh_p13/diffractometer.xml
@@ -27,7 +27,7 @@
   <object href="/centring-math" role="centring"/>
   <object href="/minikappa-correction" role="minikappa_correction"/>
 
-  <use_sample_changer>True</use_sample_changer> 
+  <use_sample_changer>True</use_sample_changer>
   <zoom_centre>{"x": 605,"y": 652}</zoom_centre>
 
   <!-- Alignment Z -->

--- a/mxcubecore/configuration/embl_hh_p13/eh1/detector-eiger16m.xml
+++ b/mxcubecore/configuration/embl_hh_p13/eh1/detector-eiger16m.xml
@@ -5,12 +5,12 @@
   <channel type="tine" name="chanStatus" tinename="/P13/detector/eiger16m">status</channel>
   <channel type="tine" name="chanRoiMode" tinename="/P13/detector/eiger16m" attach="datachange">detector-mode</channel>
   <channel type="tine" name="chanFrameRate" tinename="/P13/detector/eiger16m">frame-rate</channel>
-  <channel type="tine" name="chanBeamXY" tinename="/P13/detector/eiger16m">beam-xy</channel> 
+  <channel type="tine" name="chanBeamXY" tinename="/P13/detector/eiger16m">beam-xy</channel>
   <channel type="tine" name="chanActualFrameRate" tinename="/P13/rideau/tioga">average-speed</channel>
 
   <channel type="tine" name="chanCoverState" tinename="P13/P13DetTrans.CDI/GuillCmd" size="2">RECV</channel>
   <command type="tine" name="cmdCloseCover"  tinename="P13/P13DetTrans.CDI/GuillCmd">GuillCmd</command>
-  
+
   <command type="tine" name="cmdRestartDaq" tinename="/P13/detector/eiger16m">initialize</command>
 
   <type>Eiger</type>

--- a/mxcubecore/configuration/embl_hh_p13/eh1/detector-pilatus6m.xml
+++ b/mxcubecore/configuration/embl_hh_p13/eh1/detector-pilatus6m.xml
@@ -10,7 +10,7 @@
   <channel type="tine" name="chanHumidity" tinename="/P13/detector/pilatus6m">humidity</channel>
   <channel type="tine" name="chanStatus" tinename="/P13/detector/pilatus6m">status</channel>
   <channel type="tine" name="chanRoiMode" tinename="/P13/detector/pilatus6m">detector-mode</channel>
-  <channel type="tine" name="chanFrameRate" tinename="/P13/detector/pilatus6m">frame-rate</channel> 
+  <channel type="tine" name="chanFrameRate" tinename="/P13/detector/pilatus6m">frame-rate</channel>
   <channel type="tine" name="chanBeamXY" tinename="/P13/detector/pilatus6m">beam-xy</channel>
 
   <channel type="tine" name="chanCoverState" tinename="/P13/P13DetTrans.CDI/GuillCmd" size="2">RECV</channel>

--- a/mxcubecore/configuration/embl_hh_p13/eh1/diff-beamstop.xml
+++ b/mxcubecore/configuration/embl_hh_p13/eh1/diff-beamstop.xml
@@ -1,5 +1,5 @@
 <object class="EMBLBeamstop">
-  <exporter_address>p13md201.embl-hamburg.de:9001</exporter_address>  
+  <exporter_address>p13md201.embl-hamburg.de:9001</exporter_address>
 
   <defaultBeamstopSize>1.5</defaultBeamstopSize>
   <defaultBeamstopDistance>15.0</defaultBeamstopDistance>

--- a/mxcubecore/configuration/embl_hh_p13/eh1/diff-focus.xml
+++ b/mxcubecore/configuration/embl_hh_p13/eh1/diff-focus.xml
@@ -1,4 +1,4 @@
 <object class="ExporterMotor">
   <exporter_address>p13md201.embl-hamburg.de:9001</exporter_address>
   <actuator_name>CentringTableFocus</actuator_name>
-</object> 
+</object>

--- a/mxcubecore/configuration/embl_hh_p13/eh1/energy.xml
+++ b/mxcubecore/configuration/embl_hh_p13/eh1/energy.xml
@@ -2,7 +2,7 @@
   <command type="tine" name="cmdSetEnergy" tinename="/P13/Energy/P13Energy">TgtEnergy</command>
   <channel type="tine" name="chanEnergy" tinename="/P13/Energy/P13Energy">Energy</channel>
   <!-- <channel type="tine" name="chanLimitLow" tinename="/P13/Energy/P13Energy">ELimitLow</channel>
-  <channel type="tine" name="chanLimitHigh" tinename="/P13/Energy/P13Energy">ELimitHigh</channel> --> 
+  <channel type="tine" name="chanLimitHigh" tinename="/P13/Energy/P13Energy">ELimitHigh</channel> -->
   <channel type="tine" name="chanStatus" tinename="/P13/Energy/P13Energy">Status</channel>
   <channel type="tine" name="chanUndulatorGap" tinename="/P13/Energy/P13Energy">Gap</channel>
 

--- a/mxcubecore/configuration/embl_hh_p13/eh1/resolution.xml
+++ b/mxcubecore/configuration/embl_hh_p13/eh1/resolution.xml
@@ -3,7 +3,7 @@
   <command type="tine" name="stopAxis" tinename="/P13/collection/resolution">stop</command>
   <channel type="tine" name="axisState" tinename="/P13/collection/resolution">state2</channel>
   <channel type="tine" name="axisPosition" tinename="/P13/collection/resolution">position</channel>
-  <channel type="tine" name="axisLimits" tinename="/P13/collection/resolution">limits</channel> 
+  <channel type="tine" name="axisLimits" tinename="/P13/collection/resolution">limits</channel>
 <!-->
   <moveHOSignals>{'Door_Interlock':'DoorInterlockStateChanged'}</moveHOSignals>
   <moveConditions>{'Door_Interlock.doorIsInterlocked()':True}</moveConditions>

--- a/mxcubecore/configuration/embl_hh_p13/eh1/transmission.xml
+++ b/mxcubecore/configuration/embl_hh_p13/eh1/transmission.xml
@@ -2,7 +2,7 @@
   <channel type="tine" name="axisLimits" tinename="/P13/transmission/attenuator">limits</channel>
   <channel type="tine" name="axisPosition" tinename="/P13/transmission/attenuator">transmission</channel>
   <channel type="tine" name="axisState" tinename="/P13/transmission/attenuator">status</channel>
-  
+
   <username>Transmission</username>
   <actuator_name>Transmission</actuator_name>
 </object>

--- a/mxcubecore/configuration/embl_hh_p13/energy.xml
+++ b/mxcubecore/configuration/embl_hh_p13/energy.xml
@@ -1,6 +1,6 @@
 <object class = "EMBLEnergy">
   <command type="tine" name="cmdSetEnergy" tinename="/P13/Energy/P13Energy" timeout="10000">TgtEnergy</command>
-  <channel type="tine" name="chanEnergy" tinename="/P13/Energy/P13Energy">Energy</channel>    
+  <channel type="tine" name="chanEnergy" tinename="/P13/Energy/P13Energy">Energy</channel>
   <!-- <channel type="tine" name="chanLimitLow" tinename="/P13/Energy/P13Energy">ELimitLow</channel>
   <channel type="tine" name="chanLimitHigh" tinename="/P13/Energy/P13Energy">ELimitHigh</channel>  -->
   <channel type="tine" name="chanStatus" tinename="/P13/Energy/P13Energy">Status</channel>
@@ -9,7 +9,7 @@
 
   <command type="tine" name="cmdEnergyCtrlByte" tinename="/P13/Energy/P13Energy" timeout="5000">EnergyCtrlByte</command>
   <command type="tine" name="cmdReleaseBreakBragg" tinename="/P13/MonoBragg/Device 0">ReleaseBreakBragg</command>
-  <command type="tine" name="cmdSetBreakBragg" tinename="/P13/MonoBragg/Device 0">SetBreakBragg</command>  
+  <command type="tine" name="cmdSetBreakBragg" tinename="/P13/MonoBragg/Device 0">SetBreakBragg</command>
   <command type="tine" name="cmdResetPerp" tinename="/P13/p13mono/perp">reset</command>
 
 

--- a/mxcubecore/configuration/embl_hh_p13/energyscan.xml
+++ b/mxcubecore/configuration/embl_hh_p13/energyscan.xml
@@ -1,6 +1,6 @@
 <object class="EMBLEnergyScan">
   <channel type="tine" name="energyScanStart" tinename="/P13/fluorescence-scan/fls-scan" attach="event">start</channel>
-  <channel type="tine" name="energyScanStatus" tinename="/P13/fluorescence-scan/fls-scan" attach="event">status</channel>	
+  <channel type="tine" name="energyScanStatus" tinename="/P13/fluorescence-scan/fls-scan" attach="event">status</channel>
   <channel type="tine" name="energyScanError" tinename="/P13/fluorescence-scan/fls-scan" attach="datachange">error</channel>
   <command type="tine" name="energyScanAbort" tinename="/P13/fluorescence-scan/fls-scan">abort</command>
 
@@ -8,7 +8,7 @@
   <command type="tine" name="cmdSetMaxTransmission" tinename="/P13/fluorescence-scan/fls-scan">max-transmission</command>
 
   <chooch_command>/opt/embl-hh/bin/runchooch.py</chooch_command>
-  
+
   <theoritical_edge_threshold>5</theoritical_edge_threshold>
   <numPoints>60</numPoints>
 
@@ -93,7 +93,7 @@
       <symbol>Mo</symbol>
       <energy>K</energy>
     </element>
-    
+
     <element>
       <symbol>Ag</symbol>
       <energy>L</energy>

--- a/mxcubecore/configuration/embl_hh_p13/fast-shutter.xml
+++ b/mxcubecore/configuration/embl_hh_p13/fast-shutter.xml
@@ -1,5 +1,5 @@
 <object class="MDFastShutter">
   <exporter_address>p13md201.embl-hamburg.de:9001</exporter_address>
   <channel type="exporter" name="chanShutterIsOpen">FastShutterIsOpen</channel>
-  <channel type="exporter" name="chanCurrentPhase">CurrentPhase</channel> 
+  <channel type="exporter" name="chanCurrentPhase">CurrentPhase</channel>
 </object>

--- a/mxcubecore/configuration/embl_hh_p13/flux.xml
+++ b/mxcubecore/configuration/embl_hh_p13/flux.xml
@@ -4,7 +4,7 @@
    <channel type="tine" name="fluxStatus" tinename="/P13/flux-history/flux-record">status</channel>
    <channel type="tine" name="fluxMessage" tinename="/P13/flux-history/flux-record" attach="datachange">error</channel>
    <channel type="tine" name="fluxTransmission" tinename="/P13/flux-history/flux-record">transmission</channel>
-   <command type="tine" name="fluxRecord" tinename="/P13/flux-history/flux-record">intensity</command> 
-   
+   <command type="tine" name="fluxRecord" tinename="/P13/flux-history/flux-record">intensity</command>
+
    <intensity_offset>-1.864e-5</intensity_offset>
 </object>

--- a/mxcubecore/configuration/embl_hh_p13/machine-info.xml
+++ b/mxcubecore/configuration/embl_hh_p13/machine-info.xml
@@ -1,13 +1,13 @@
 <object class="EMBLMachineInfo">
     <defaultFlux>2.3e+12</defaultFlux>
-    <updateIntervalS>60</updateIntervalS>		
+    <updateIntervalS>60</updateIntervalS>
     <limits>{'current':75, 'temp': 25, 'hum': 60, 'intens': 5e-8}</limits>
     <hutchTempAddress>G47cS9:K:KL:P13EH1RaTIW_ai</hutchTempAddress>
     <hutchHumAddress>G47cS9:K:KL:P13EH1RaF_ai</hutchHumAddress>
 
     <channel type="tine" name="machStateText" tinename="/PETRA/ARCHIVER/keyword">MachineStateText</channel>
     <channel type="tine" name="machCurrent" tinename="/PETRA/ARCHIVER/keyword">curDC</channel>
-    <channel type="tine" name="machEnergy" tinename="/PETRA/ARCHIVER/keyword">Energy</channel> 
+    <channel type="tine" name="machEnergy" tinename="/PETRA/ARCHIVER/keyword">Energy</channel>
     <channel type="tine" name="machBunchCount" tinename="/PETRA/ARCHIVER/keyword">NBunches</channel>
     <channel type="tine" name="cryojetIn" tinename="/P13/P13Cryojet.CDI/CryojetIn">RECV</channel>
     <channel type="tine" name="scLowLevelAlarm" tinename="/P13/P13Cryojet.CDI/LowLevelAlarm">RECV</channel>

--- a/mxcubecore/configuration/embl_hh_p13/mxcollect.xml
+++ b/mxcubecore/configuration/embl_hh_p13/mxcollect.xml
@@ -2,7 +2,7 @@
   <channel type="tine" name="collectFrame" tinename="/P13/collection/mx-standard" attach="event">frame</channel>
   <channel type="tine" name="collectStatus" tinename="/P13/collection/mx-standard" attach="event">status</channel>
   <channel type="tine" name="collectError" tinename="/P13/collection/mx-standard" attach="event">Error</channel>
-  <channel type="tine" name="guillotineState" tinename="P13/P13DetTrans.CDI/GuillCmd" size="2">RECV</channel> 
+  <channel type="tine" name="guillotineState" tinename="P13/P13DetTrans.CDI/GuillCmd" size="2">RECV</channel>
 
   <command type="tine" name="collectCompression" tinename="/P13/collection/mx-standard">compression</command>
   <command type="tine" name="collectDescription" tinename="/P13/collection/mx-standard">description</command>
@@ -11,7 +11,7 @@
   <command type="tine" name="collectEnergy" tinename="/P13/collection/mx-standard">energy</command>
   <command type="tine" name="collectExposureTime" tinename="/P13/collection/mx-standard">exposure-time</command>
   <command type="tine" name="collectHelicalPosition" tinename="/P13/collection/mx-standard">helical-position</command>
-  <command type="tine" name="collectInQueue" tinename="/P13/collection/mx-standard">in-queue</command> 
+  <command type="tine" name="collectInQueue" tinename="/P13/collection/mx-standard">in-queue</command>
   <command type="tine" name="collectNumImages" tinename="/P13/collection/mx-standard">num-images</command>
   <command type="tine" name="collectOverlap" tinename="/P13/collection/mx-standard">overlap</command>
   <command type="tine" name="collectProcessing" tinename="/P13/collection/mx-standard">processing</command>

--- a/mxcubecore/configuration/embl_hh_p13/offline-processing.xml
+++ b/mxcubecore/configuration/embl_hh_p13/offline-processing.xml
@@ -3,7 +3,7 @@
     <program>
       <executable>ssh bcrunch srun /mx-beta/edna-cluster-scripts/edna_proc.csh</executable>
       <event>after</event>
-    </program> 
+    </program>
     <program>
       <executable>ssh bcrunch srun /mx-beta/edna-cluster-scripts/edna_autoPROC.csh</executable>
       <event>after</event>

--- a/mxcubecore/configuration/embl_hh_p13/oh1/motor-pitch-hfm.xml
+++ b/mxcubecore/configuration/embl_hh_p13/oh1/motor-pitch-hfm.xml
@@ -1,8 +1,8 @@
 <object class = "TINEMotor">
   <channel type="tine" name="axisPosition" tinename="/P13/P13Kb.CDI/HFMTgtPos">RECV</channel>
-  <command type="tine" name="setPosition" tinename="/P13/P13Kb.CDI/HFMTgtPos">SEND</command> 
+  <command type="tine" name="setPosition" tinename="/P13/P13Kb.CDI/HFMTgtPos">SEND</command>
 
-  <!-- 
+  <!--
   <channel type="tine" name="axisPosition" tinename="/P13/P13Kb/HFMPitchUp">position</channel>
   <channel type="tine" name="axisState" tinename="/P13/P13Kb/HFMPitchUp">state</channel>
   <command type="tine" name="setPosition" tinename="/P13/P13Kb/HFMPitchUp">MOVE.Start</command> -->

--- a/mxcubecore/configuration/embl_hh_p13/oh1/motor-pitch-vfm.xml
+++ b/mxcubecore/configuration/embl_hh_p13/oh1/motor-pitch-vfm.xml
@@ -1,8 +1,8 @@
 <object class = "TINEMotor">
   <channel type="tine" name="axisPosition" tinename="/P13/P13Kb.CDI/VFMTgtPos">RECV</channel>
-  <command type="tine" name="setPosition" tinename="/P13/P13Kb.CDI/VFMTgtPos">SEND</command> 
+  <command type="tine" name="setPosition" tinename="/P13/P13Kb.CDI/VFMTgtPos">SEND</command>
 
-  <!-- 
+  <!--
   <channel type="tine" name="axisPosition" tinename="/P13/P13Kb/VHMPitchHDn">position</channel>
   <channel type="tine" name="axisState" tinename="/P13/P13Kb/VHMPitchHDn">state</channel>
   <command type="tine" name="setPosition" tinename="/P13/P13Kb/VHMPitchHDn">MOVE.Start</command> -->

--- a/mxcubecore/configuration/embl_hh_p13/online-processing.xml
+++ b/mxcubecore/configuration/embl_hh_p13/online-processing.xml
@@ -1,5 +1,5 @@
 <object class="EMBLOnlineProcessing">
-  <channel type="tine" name="chanStatus" tinename="/P13/rideau/tioga" attach="datachange">status</channel>	
+  <channel type="tine" name="chanStatus" tinename="/P13/rideau/tioga" attach="datachange">status</channel>
   <channel type="tine" name="chanDozorPass" tinename="/P13/rideau/tioga" attach="event">dozor-pass</channel>
   <channel type="tine" name="chanFrameCount" tinename="/P13/rideau/tioga" attach="timer">frame-count</channel>
   <channel type="tine" name="chanDozorIS" tinename="/P13/rideau/tioga" attach="event">dozor-pass-IS</channel>

--- a/mxcubecore/configuration/embl_hh_p13/queue-model.xml
+++ b/mxcubecore/configuration/embl_hh_p13/queue-model.xml
@@ -1,3 +1,3 @@
 <object class="QueueModel" role="QueueModel">
-  <object href="/queue" role="queue"/>    
+  <object href="/queue" role="queue"/>
 </object>

--- a/mxcubecore/configuration/embl_hh_p13/resolution.xml
+++ b/mxcubecore/configuration/embl_hh_p13/resolution.xml
@@ -3,7 +3,7 @@
   <command type="tine" name="stopAxis" tinename="/P13/collection/resolution">stop</command>
   <channel type="tine" name="axisState" tinename="/P13/collection/resolution">state2</channel>
   <channel type="tine" name="axisPosition" tinename="/P13/collection/resolution">position</channel>
-  <channel type="tine" name="axisLimits" tinename="/P13/collection/resolution">limits</channel> 
+  <channel type="tine" name="axisLimits" tinename="/P13/collection/resolution">limits</channel>
 <!-->
   <moveHOSignals>{'Door_Interlock':'DoorInterlockStateChanged'}</moveHOSignals>
   <moveConditions>{'Door_Interlock.doorIsInterlocked()':True}</moveConditions>

--- a/mxcubecore/configuration/embl_hh_p13/safety-shutter.xml
+++ b/mxcubecore/configuration/embl_hh_p13/safety-shutter.xml
@@ -5,13 +5,13 @@
   <channel type="tine" name="chanStateOpenPermission" tinename="/P13/ics/shutter-secondary" attach="event">state-open-permission</channel>
 
   <channel type="tine" name="chanIcsError" tinename="/P13/ics/state" attach="datachange" timeout="100">error</channel>
-  
+
   <command type="tine" name="cmdClose" tinename="/P13/ics/shutter-secondary" timeout="2000">close</command>
   <command type="tine" name="cmdOpen" tinename="/P13/ics/shutter-secondary" timeout="2000">open</command>
 
   <channel type="tine" name="chanCmdCloseError" tinename="/P13/ics/shutter-secondary" attach="datachange" timeout="100">close</channel>
   <channel type="tine" name="chanCmdOpenError" tinename="/P13/ics/shutter-secondary" attach="datachange" timeout="100">open</channel>
 
-  
+
   <useShutter>True</useShutter>
 </object>

--- a/mxcubecore/configuration/embl_hh_p13/sample-changer.xml
+++ b/mxcubecore/configuration/embl_hh_p13/sample-changer.xml
@@ -3,9 +3,9 @@
    <channel type="tine" name="chanStatusList" tinename="/P13/P13SC/P13Marvin">MarvinStatus</channel>
    <channel type="tine" name="chanPuckSwitches" tinename="/P13/P13SC/P13Marvin">PuckSwitches</channel>
    <channel type="tine" name="chanMountedSamplePuck" tinename="/P13/P13SC/P13Marvin">StsSmplMnted</channel>
-   <channel type="tine" name="chanVeto" tinename="/P13/P13DetTrans.CDI/VetoActive">RECV</channel> 
+   <channel type="tine" name="chanVeto" tinename="/P13/P13DetTrans.CDI/VetoActive">RECV</channel>
 
-   <command type="tine" name="cmdMountSample" tinename="/P13/P13SC/P13Marvin" timeout="5000">Mount</command> 
+   <command type="tine" name="cmdMountSample" tinename="/P13/P13SC/P13Marvin" timeout="5000">Mount</command>
    <command type="tine" name="cmdUnmountSample" tinename="/P13/P13SC/P13Marvin" timeout="5000">DismountSample</command>
 
    <useUpdateTimer>False</useUpdateTimer>

--- a/mxcubecore/configuration/embl_hh_p13/session.xml
+++ b/mxcubecore/configuration/embl_hh_p13/session.xml
@@ -1,4 +1,4 @@
-<object class = "EMBLSession" role = "session">  
+<object class = "EMBLSession" role = "session">
   <synchrotron_name>EMBL-HH</synchrotron_name>
   <endstation_name>p13eh1</endstation_name>
   <beamline_name>P13</beamline_name>

--- a/mxcubecore/configuration/embl_hh_p14/beam.xml
+++ b/mxcubecore/configuration/embl_hh_p14/beam.xml
@@ -7,8 +7,8 @@
     <channel type="exporter" name="BeamPositionVertical">BeamPositionVertical</channel> -->
 
     <channel type="tine" name="BeamPositionHorizontal" tinename="/P14/MD3/MD3_0" timeout="100">BeamPositionHorizontal</channel>
-    <channel type="tine" name="BeamPositionVertical" tinename="/P14/MD3/MD3_0" timeout="100">BeamPositionVertical</channel>  
+    <channel type="tine" name="BeamPositionVertical" tinename="/P14/MD3/MD3_0" timeout="100">BeamPositionVertical</channel>
     <channel type="exporter" name="BeamSizeMicrons">BeamSizeMicrons</channel>
-    <channel type="exporter" name="BeamShapeEllipse">BeamShapeEllipse</channel> 
+    <channel type="exporter" name="BeamShapeEllipse">BeamShapeEllipse</channel>
     <defaultBeamDivergence>(12.0, 5.0)</defaultBeamDivergence>
 </object>

--- a/mxcubecore/configuration/embl_hh_p14/centring-math.xml
+++ b/mxcubecore/configuration/embl_hh_p14/centring-math.xml
@@ -1,13 +1,13 @@
 <object class="CentringMath">
   <!--
   Gonio axes are in a real physical order
-  --> 
+  -->
   <gonioAxes>
      <axis>
         <motorname>phiy</motorname>
         <direction>[0, 1, 0]</direction>
 	<type>translation</type>
-	<motorHO>/eh1/diff-phiy</motorHO> 
+	<motorHO>/eh1/diff-phiy</motorHO>
      </axis>
 
      <!-- removing this axis (normal to Omega) will fix Omega position -->
@@ -15,7 +15,7 @@
         <motorname>phiz</motorname>
         <direction>[1, 0, 0]</direction>
         <type>translation</type>
-        <motorHO>/eh1/diff-phiz</motorHO> 
+        <motorHO>/eh1/diff-phiz</motorHO>
      </axis>
 
      <!-- e.g. robodiff chi axis
@@ -32,16 +32,16 @@
         <!-- direction of omega at Chi==0 -->
         <direction>[0, -1, 0]</direction>
         <type>rotation</type>
-        <motorHO>/eh1/diff-omega</motorHO> 
+        <motorHO>/eh1/diff-omega</motorHO>
      </axis>
 
      <axis>
-        <!-- direction of sampx at Chi==0 and Omega == 0 --> 
+        <!-- direction of sampx at Chi==0 and Omega == 0 -->
         <motorname>sampx</motorname>
         <!--direction>[-0.281085,  0, 0.959683]</direction-->
         <direction>[-0.9999505209310272, 0, 0.00994764744888108]</direction>
         <type>translation</type>
-        <motorHO>/eh1/diff-sampx</motorHO> 
+        <motorHO>/eh1/diff-sampx</motorHO>
      </axis>
 
      <axis>
@@ -49,7 +49,7 @@
         <!--direction>[0.959683,  0, 0.281085 ]</direction-->
         <direction>[0.00994764744888108, 0, 0.9999505209310272]</direction>
         <type>translation</type>
-        <motorHO>/eh1/diff-sampy</motorHO> 
+        <motorHO>/eh1/diff-sampy</motorHO>
      </axis>
   </gonioAxes>
   <cameraAxes>

--- a/mxcubecore/configuration/embl_hh_p14/characterisation.xml
+++ b/mxcubecore/configuration/embl_hh_p14/characterisation.xml
@@ -1,5 +1,5 @@
 <object class="EDNACharacterisation">
-  <object href="/eh1/diff-beamstop" role="beamstop"/> 
+  <object href="/eh1/diff-beamstop" role="beamstop"/>
   <edna_command>ssh bcrunch srun /mx-beta/edna-cluster-scripts/edna_characterisation.csh</edna_command>
   <edna_default_file>edna-defaults.xml</edna_default_file>
 </object>

--- a/mxcubecore/configuration/embl_hh_p14/crl.xml
+++ b/mxcubecore/configuration/embl_hh_p14/crl.xml
@@ -1,6 +1,6 @@
 <object class="EMBLCRL">
   <command type="tine" name="cmdSetLenses" tinename="/P14/p14CRLs.CDI/LensOut">SEND</command>
-  <command type="tine" name="cmdSetTrans" tinename="/P14/p14CRLs.CDI/SetTrans">SEND</command> 
+  <command type="tine" name="cmdSetTrans" tinename="/P14/p14CRLs.CDI/SetTrans">SEND</command>
   <channel type="tine" name="chanCrlValue" tinename="/P14/P14CRLs.CDI/LensInBeamLimit" size="8">RECV</channel>
   <object hwrid="/energy" role="energy"/>
   <object hwrid="/eh1/beamFocusing" role="beam_focusing"/>

--- a/mxcubecore/configuration/embl_hh_p14/diffractometer.xml
+++ b/mxcubecore/configuration/embl_hh_p14/diffractometer.xml
@@ -1,17 +1,17 @@
 <object class="EMBLMiniDiff">
   <exporter_address>p14md302.embl-hamburg.de:9001</exporter_address>
-  <channel type="exporter" name="CoaxCamScaleX">CoaxCamScaleX</channel>  
-  <channel type="exporter" name="CoaxCamScaleY">CoaxCamScaleY</channel> 
-  <channel type="exporter" name="HeadType">HeadType</channel> 
+  <channel type="exporter" name="CoaxCamScaleX">CoaxCamScaleX</channel>
+  <channel type="exporter" name="CoaxCamScaleY">CoaxCamScaleY</channel>
+  <channel type="exporter" name="HeadType">HeadType</channel>
   <channel type="exporter" name="CurrentPhase">CurrentPhase</channel>
-  <channel type="exporter" name="FastShutterIsOpen">FastShutterIsOpen</channel> 
+  <channel type="exporter" name="FastShutterIsOpen">FastShutterIsOpen</channel>
   <channel type="exporter" name="ScintillatorPosition">ScintillatorPosition</channel>
   <channel type="exporter" name="CapillaryPosition">CapillaryPosition</channel>
   <channel type="exporter" name="State">State</channel>
   <channel type="exporter" name="Status">Status</channel>
 
   <command type="exporter" name="startSetPhase">startSetPhase</command>
-  <command type="exporter" name="startAutoFocus">startAutoFocus</command>  
+  <command type="exporter" name="startAutoFocus">startAutoFocus</command>
   <command type="exporter" name="saveCentringPositions">saveCentringPositions</command>
   <command type="exporter" name="getOmegaMotorDynamicScanLimits">getOmegaMotorDynamicScanLimits</command>
   <object href="/eh1/diff-omega" role="phi"/>
@@ -24,7 +24,7 @@
   <object href="/eh1/diff-sampy" role="sampy"/>
   <object href="/eh1/diff-kappa" role="kappa"/>
   <object href="/eh1/diff-kappaphi" role="kappa_phi"/>
-  
+
   <object href="/centring-math" role="centring"/>
   <object href="/imaging-centring-math" role="imaging-centring"/>
 

--- a/mxcubecore/configuration/embl_hh_p14/eh1/attocubeMotors/attoGroup.xml
+++ b/mxcubecore/configuration/embl_hh_p14/eh1/attocubeMotors/attoGroup.xml
@@ -1,9 +1,9 @@
 <object class="MotorsGroup">
-    <username>attocubeMotors</username>	
+    <username>attocubeMotors</username>
     <serverAddr>/P14/P14Atto</serverAddr>
     <groupAddr>/Sl4Out</groupAddr>
     <positionAddr>Position</positionAddr>
-    <statusAddr>status</statusAddr>			
+    <statusAddr>status</statusAddr>
     <motors>
 	<motor>
           <motorName>Out</motorName>

--- a/mxcubecore/configuration/embl_hh_p14/eh1/beamAttocube.xml
+++ b/mxcubecore/configuration/embl_hh_p14/eh1/beamAttocube.xml
@@ -1,7 +1,7 @@
 <object class="BeamSlitBox">
-    <focModeEq>/eh1/beamFocusing</focModeEq>	
+    <focModeEq>/eh1/beamFocusing</focModeEq>
     <shape>rectangle</shape>
-    <focModes>['Unfocused', 'Horizontal', 'Vertical', 'Double']</focModes>	
+    <focModes>['Unfocused', 'Horizontal', 'Vertical', 'Double']</focModes>
     <gapH>
        <modesAllowed>['Unfocused', 'Vertical']</modesAllowed>
        <stepSize>0.0050</stepSize>
@@ -17,7 +17,7 @@
           <motor>
  	    <motorName>In</motorName>
             <motorsGroup>attocubeMotors</motorsGroup>
-	    <reference>-749599</reference>	          
+	    <reference>-749599</reference>
 	  </motor>
        </motors>
     </gapH>
@@ -35,10 +35,10 @@
 	  </motor>
 	  <motor>
  	    <motorName>But</motorName>
-            <motorsGroup>attocubeMotors</motorsGroup>	          
+            <motorsGroup>attocubeMotors</motorsGroup>
             <reference>16260</reference>
 	  </motor>
        </motors>
-    </gapV>  
-    <object hwrid="/eh1/attocubeMotors/attoGroup" role="attocubeMotors"/> 
+    </gapV>
+    <object hwrid="/eh1/attocubeMotors/attoGroup" role="attocubeMotors"/>
 </object>

--- a/mxcubecore/configuration/embl_hh_p14/eh1/beamFocusing.xml
+++ b/mxcubecore/configuration/embl_hh_p14/eh1/beamFocusing.xml
@@ -16,7 +16,7 @@
            <size>(0.007, 0.003)</size>
            <divergence>(999, 500)</divergence>
            <message>'Double microfocued mode. \nCrystal life time will be ~0.080 sec.\n Beam size will be 0.007x0.02 mm.'</message>
-           <aperture>150</aperture> 
+           <aperture>150</aperture>
         </focusMode>
         <focusMode>
            <modeName>Imaging</modeName>
@@ -42,11 +42,10 @@
     <object hwrid="/eh1/beamFocusingMotors/P14ExpTbl" role="P14ExpTbl"/>
     <object hwrid="/eh1/beamFocusingMotors/P14KB" role="P14KB"/>
     <object hwrid="/eh1/beamFocusingMotors/P14BCU" role="P14BCU"/>
-    <object hwrid="/eh1/beamFocusingMotors/P14DetTrans" role="P14DetTrans"/> 
-    <object hwrid="/eh1/slitsMotors/slitsGroup" role="slitsMotors"/> 	 
-    <object hwrid="/eh1/diff-aperture" role="aperture"/> 
+    <object hwrid="/eh1/beamFocusingMotors/P14DetTrans" role="P14DetTrans"/>
+    <object hwrid="/eh1/slitsMotors/slitsGroup" role="slitsMotors"/>
+    <object hwrid="/eh1/diff-aperture" role="aperture"/>
 
     <command type="tine" name="cmdSetCalibrationName"   tinename="/P14/collection/distance">calibration</command>
     <setPhaseCmd>{"address": "/P14/MD3/MD3_0", "property": "startSetPhase", "argument": "BeamLocation"}</setPhaseCmd>
 </object>
-	  

--- a/mxcubecore/configuration/embl_hh_p14/eh1/detector-eiger16m-cdte.xml
+++ b/mxcubecore/configuration/embl_hh_p14/eh1/detector-eiger16m-cdte.xml
@@ -6,7 +6,7 @@
   <channel type="tine" name="chanStatus" tinename="/P14/detector/eiger16m-cdte">status</channel>
   <channel type="tine" name="chanRoiMode" tinename="/P14/detector/eiger16m-cdte" attach="datachange">detector-mode</channel>
   <channel type="tine" name="chanFrameRate" tinename="/P14/detector/eiger16m-cdte">frame-rate</channel>
-  <channel type="tine" name="chanBeamXY" tinename="/P14/detector/eiger16m-cdte">beam-xy</channel> 
+  <channel type="tine" name="chanBeamXY" tinename="/P14/detector/eiger16m-cdte">beam-xy</channel>
   <channel type="tine" name="chanActualFrameRate" tinename="/P14/rideau/tioga">average-speed</channel>
 
   <channel type="tine" name="chanCoverState" tinename="/P14/P14DetTrans.CDI/GuillCmd" size="2">RECV</channel>
@@ -25,7 +25,7 @@
   <hasShutterless>True</hasShutterless>
   <fileSuffix>cbf</fileSuffix>
   <bindingMode>Unbinned</bindingMode>
-  <defaultDistance>0</defaultDistance> 
+  <defaultDistance>0</defaultDistance>
   <px_min>0</px_min>
   <px_max>64000</px_max>
 

--- a/mxcubecore/configuration/embl_hh_p14/eh1/detector-eiger16m.xml
+++ b/mxcubecore/configuration/embl_hh_p14/eh1/detector-eiger16m.xml
@@ -21,7 +21,7 @@
   <channel type="tine" name="chanStatus" tinename="/P14/detector/eiger16m">status</channel>
   <channel type="tine" name="chanRoiMode" tinename="/P14/detector/eiger16m" attach="datachange">detector-mode</channel>
   <channel type="tine" name="chanFrameRate" tinename="/P14/detector/eiger16m">frame-rate</channel>
-  <channel type="tine" name="chanBeamXY" tinename="/P14/detector/eiger16m">beam-xy</channel> 
+  <channel type="tine" name="chanBeamXY" tinename="/P14/detector/eiger16m">beam-xy</channel>
   <channel type="tine" name="chanActualFrameRate" tinename="/P14/tioga/tioga">average-speed</channel>
 
   <channel type="tine" name="chanCoverState" tinename="/P14/P14DetTrans.CDI/GuillCmd" size="2">RECV</channel>
@@ -43,7 +43,7 @@
   <collectName>pilatus6m</collectName>
   <roiModes>("0", "C18", "C2")</roiModes-->
 
-  
+
   <type>Eiger</type>
   <model>16M</model>
   <collectName>eiger16m</collectName>
@@ -55,7 +55,7 @@
   <hasShutterless>True</hasShutterless>
   <fileSuffix>cbf</fileSuffix>
   <bindingMode>Unbinned</bindingMode>
-  <defaultDistance>0</defaultDistance> 
+  <defaultDistance>0</defaultDistance>
   <px_min>0</px_min>
   <px_max>64000</px_max>
 

--- a/mxcubecore/configuration/embl_hh_p14/eh1/detector-eiger4m-cdte.xml
+++ b/mxcubecore/configuration/embl_hh_p14/eh1/detector-eiger4m-cdte.xml
@@ -21,7 +21,7 @@
   <channel type="tine" name="chanStatus" tinename="/P14/detector/eiger4m-cdte">status</channel>
   <channel type="tine" name="chanRoiMode" tinename="/P14/detector/eiger4m-cdte" attach="datachange">detector-mode</channel>
   <channel type="tine" name="chanFrameRate" tinename="/P14/detector/eiger4m-cdte">frame-rate</channel>
-  <channel type="tine" name="chanBeamXY" tinename="/P14/detector/eiger4m-cdte">beam-xy</channel> 
+  <channel type="tine" name="chanBeamXY" tinename="/P14/detector/eiger4m-cdte">beam-xy</channel>
   <channel type="tine" name="chanActualFrameRate" tinename="/P14/tioga/tioga">average-speed</channel>
 
   <channel type="tine" name="chanCoverState" tinename="P14/P14DetTrans.CDI/GuillCmd" size="2">RECV</channel>
@@ -43,7 +43,7 @@
   <collectName>pilatus6m</collectName>
   <roiModes>("0", "C18", "C2")</roiModes-->
 
-  
+
   <type>Eiger</type>
   <model>4M</model>
   <collectName>eiger4m-cdte</collectName>
@@ -55,7 +55,7 @@
   <hasShutterless>True</hasShutterless>
   <fileSuffix>cbf</fileSuffix>
   <bindingMode>Unbinned</bindingMode>
-  <defaultDistance>0</defaultDistance> 
+  <defaultDistance>0</defaultDistance>
   <px_min>0</px_min>
   <px_max>64000</px_max>
 

--- a/mxcubecore/configuration/embl_hh_p14/eh1/diff-focus.xml
+++ b/mxcubecore/configuration/embl_hh_p14/eh1/diff-focus.xml
@@ -1,4 +1,4 @@
 <object class="ExporterMotor">
   <exporter_address>p14md302.embl-hamburg.de:9001</exporter_address>
   <actuator_name>CentringTableFocus</actuator_name>
-</object> 
+</object>

--- a/mxcubecore/configuration/embl_hh_p14/eh1/diff-front-light.xml
+++ b/mxcubecore/configuration/embl_hh_p14/eh1/diff-front-light.xml
@@ -1,6 +1,6 @@
 <object class="MicrodiffLight">
   <exporter_address>p14md302.embl-hamburg.de:9001</exporter_address>
-  <channel type="exporter" name="chanLightValue">FrontLightLevel</channel> 
+  <channel type="exporter" name="chanLightValue">FrontLightLevel</channel>
   <channel type="exporter" name="chanLightIsOn">FrontLightIsOn</channel>
 
   <!--<channel type="tine" name="chanLightValue" tinename="/P14/MD3/MD3_0">FrontLightLevel</channel> -->

--- a/mxcubecore/configuration/embl_hh_p14/eh1/diff-frontLight.xml
+++ b/mxcubecore/configuration/embl_hh_p14/eh1/diff-frontLight.xml
@@ -1,6 +1,6 @@
 <object class="MicrodiffLight">
   <exporter_address>p14md301.embl-hamburg.de:9001</exporter_address>
-  <channel type="exporter" name="chanLightValue">FrontLightLevel</channel> 
+  <channel type="exporter" name="chanLightValue">FrontLightLevel</channel>
   <channel type="exporter" name="chanLightIsOn">FrontLightIsOn</channel>
 
   <!--<channel type="tine" name="chanLightValue" tinename="/P14/MD3/MD3_0">FrontLightLevel</channel> -->

--- a/mxcubecore/configuration/embl_hh_p14/eh1/energy.xml
+++ b/mxcubecore/configuration/embl_hh_p14/eh1/energy.xml
@@ -3,7 +3,7 @@
 
   <channel type="tine" name="chanEnergy" tinename="/P14/Energy/P14Energy">Energy</channel>
   <channel type="tine" name="chanLimitLow" tinename="/P14/Energy/P14Energy">ELimitLow</channel>
-  <channel type="tine" name="chanLimitHigh" tinename="/P14/Energy/P14Energy">ELimitHigh</channel>   
+  <channel type="tine" name="chanLimitHigh" tinename="/P14/Energy/P14Energy">ELimitHigh</channel>
   <channel type="tine" name="chanStatus" tinename="/P14/Energy/P14Energy">Status</channel>
   <tunableEnergy>True</tunableEnergy>
 </object>

--- a/mxcubecore/configuration/embl_hh_p14/eh1/slits.xml
+++ b/mxcubecore/configuration/embl_hh_p14/eh1/slits.xml
@@ -1,6 +1,6 @@
 <object class="EMBLSlitBox">
     <shape>rectangle</shape>
-    <focModes>['Collimated', 'Horizontal', 'Vertical', 'Double']</focModes>	
+    <focModes>['Collimated', 'Horizontal', 'Vertical', 'Double']</focModes>
     <gapH>
        <modesAllowed>['Collimated', 'Vertical']</modesAllowed>
        <stepSize>0.0050</stepSize>
@@ -16,7 +16,7 @@
           <motor>
  	    <motorName>In</motorName>
             <motorsGroup>slitsMotors</motorsGroup>
-            <reference>1230240</reference>	          
+            <reference>1230240</reference>
 	  </motor>
        </motors>
     </gapH>
@@ -38,7 +38,7 @@
             <reference>-372780</reference>
 	  </motor>
        </motors>
-    </gapV>  
-    <object hwrid="/eh1/slitsMotors/slitsGroup" role="slitsMotors"/> 
+    </gapV>
+    <object hwrid="/eh1/slitsMotors/slitsGroup" role="slitsMotors"/>
     <object hwrid="/eh1/beamFocusing" role="focusing"/>
 </object>

--- a/mxcubecore/configuration/embl_hh_p14/eh1/slitsGroup.xml
+++ b/mxcubecore/configuration/embl_hh_p14/eh1/slitsGroup.xml
@@ -1,9 +1,9 @@
 <object class="EMBLMotorsGroup">
-    <username>slitsMotors</username>	
+    <username>slitsMotors</username>
     <serverAddr>/P14/P14Atto</serverAddr>
     <groupAddr>/Sl4Out</groupAddr>
     <positionAddr>Position</positionAddr>
-    <statusAddr>status</statusAddr>			
+    <statusAddr>status</statusAddr>
     <motors>
 	<motor>
           <motorName>Out</motorName>

--- a/mxcubecore/configuration/embl_hh_p14/eh1/slitsMotors/slits.xml
+++ b/mxcubecore/configuration/embl_hh_p14/eh1/slitsMotors/slits.xml
@@ -1,6 +1,6 @@
 <object class="EMBLSlitBox">
     <shape>rectangle</shape>
-    <focModes>['Collimated', 'Horizontal', 'Vertical', 'Double']</focModes>	
+    <focModes>['Collimated', 'Horizontal', 'Vertical', 'Double']</focModes>
     <gapH>
        <modesAllowed>['Collimated', 'Vertical']</modesAllowed>
        <stepSize>0.0050</stepSize>
@@ -16,7 +16,7 @@
           <motor>
  	    <motorName>In</motorName>
             <motorsGroup>slitsMotors</motorsGroup>
-	    <reference>309310</reference>	          
+	    <reference>309310</reference>
 	  </motor>
        </motors>
     </gapH>
@@ -34,11 +34,11 @@
 	  </motor>
 	  <motor>
  	    <motorName>But</motorName>
-            <motorsGroup>slitsMotors</motorsGroup>	          
+            <motorsGroup>slitsMotors</motorsGroup>
             <reference>-245700</reference>
 	  </motor>
        </motors>
-    </gapV>  
-    <object hwrid="/eh1/slitsMotors/slitsGroup" role="slitsMotors"/> 
+    </gapV>
+    <object hwrid="/eh1/slitsMotors/slitsGroup" role="slitsMotors"/>
     <object hwrid="/eh1/beamFocusing" role="focusing"/>
 </object>

--- a/mxcubecore/configuration/embl_hh_p14/energy.xml
+++ b/mxcubecore/configuration/embl_hh_p14/energy.xml
@@ -7,7 +7,7 @@
 
   <command type="tine" name="cmdEnergyCtrlByte" tinename="/P14/Energy/P14Energy">EnergyCtrlByte</command>
   <command type="tine" name="cmdReleaseBreakBragg" tinename="/P14/Mono/Device 0">ReleaseBreakBragg</command>
-  <command type="tine" name="cmdSetBreakBragg" tinename="/P14/Mono/Device 0">SetBreakBragg</command> 
+  <command type="tine" name="cmdSetBreakBragg" tinename="/P14/Mono/Device 0">SetBreakBragg</command>
 
   <command type="tine" name="cmdResetPerp" tinename="/P14/p14MonoMotor/perp">reset</command>
 
@@ -15,7 +15,7 @@
   <!-- Configuration with undulators was 15 for all, 7 for all apart roll2 -->
   <ctrlBytes>(5, 15)</ctrlBytes>
 
-  <!-- 
+  <!--
   if change > 0.1 keV ctrlByte[1]
   else ctrlByte[0]
 

--- a/mxcubecore/configuration/embl_hh_p14/energyscan.xml
+++ b/mxcubecore/configuration/embl_hh_p14/energyscan.xml
@@ -2,7 +2,7 @@
   <channel type="tine" name="energyScanStart" tinename="/P14/fluorescence-scan/fls-scan" attach="event">start</channel>
   <channel type="tine" name="energyScanStatus" tinename="/P14/fluorescence-scan/fls-scan" attach="event">status</channel>
   <channel type="tine" name="energyScanError" tinename="/P14/fluorescence-scan/fls-scan" attach="datachange">error</channel>
-	
+
   <command type="tine" name="energyScanAbort" tinename="/P14/fluorescence-scan/fls-scan">abort</command>
   <command type="tine" name="cmdAdjustTransmission" tinename="/P14/fluorescence-scan/fls-scan">attenuate-state</command>
   <command type="tine" name="cmdSetMaxTransmission" tinename="/P14/fluorescence-scan/fls-scan">max-transmission</command>
@@ -10,7 +10,7 @@
   <energy2WavelengthConstant>12.3980</energy2WavelengthConstant>
   <defaultWavelength>0.976</defaultWavelength>
   <theoritical_edge_threshold>5</theoritical_edge_threshold>
-  <numPoints>60</numPoints> 
+  <numPoints>60</numPoints>
 
   <chooch_command>/opt/embl-hh/bin/runchooch.py</chooch_command>
 

--- a/mxcubecore/configuration/embl_hh_p14/flux.xml
+++ b/mxcubecore/configuration/embl_hh_p14/flux.xml
@@ -8,6 +8,6 @@
    <channel type="tine" name="fluxMessage" tinename="/P14/flux-history/flux-record" attach="datachange">error</channel>
 
    <command type="tine" name="fluxRecord" tinename="/P14/flux-history/flux-record">intensity</command>
-   <command type="tine" name="slitsRecord" tinename="/P14/flux-history/flux-record">beam-size</command>  
-   <intensity_offset>6.65-e7</intensity_offset> 
+   <command type="tine" name="slitsRecord" tinename="/P14/flux-history/flux-record">beam-size</command>
+   <intensity_offset>6.65-e7</intensity_offset>
 </object>

--- a/mxcubecore/configuration/embl_hh_p14/gphl_beamline_config/filenametemplates.xml
+++ b/mxcubecore/configuration/embl_hh_p14/gphl_beamline_config/filenametemplates.xml
@@ -158,7 +158,7 @@ Element names are tied to the beamline or workflow and cannot be modified
             <name>beam_setting_index</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
@@ -167,7 +167,7 @@ Element names are tied to the beamline or workflow and cannot be modified
             <name>run_number</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
@@ -213,7 +213,7 @@ Element names are tied to the beamline or workflow and cannot be modified
             <name>beam_setting_index</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Parameter">
             <name>inverse_beam_component_sign</name>
             <type>string</type>
@@ -227,7 +227,7 @@ Element names are tied to the beamline or workflow and cannot be modified
             <name>run_number</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
@@ -279,7 +279,7 @@ Element names are tied to the beamline or workflow and cannot be modified
             <name>run_number</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
@@ -381,6 +381,6 @@ Element names are tied to the beamline or workflow and cannot be modified
         <mapsTo>Beamline</mapsTo>
 
     </c:filenamePatternMapping>
-    
+
 
 </xml-fragment>

--- a/mxcubecore/configuration/embl_hh_p14/gphl_beamline_config/transcal_2stage.json
+++ b/mxcubecore/configuration/embl_hh_p14/gphl_beamline_config/transcal_2stage.json
@@ -1,5 +1,5 @@
 [
-    { 
+    {
       "#": "Settings (omega, kappa, phi) for running TransCal on a mini-Kappa (short protocol, without SOC)",
       "settings": [
         0,   0,       0,
@@ -14,10 +14,10 @@
       "nameSuffix": "pre",
       "useRecen": false
     },
-    
+
     {
       "#": "Settings(omega, kappa, phi) for running TransCal on a mini-Kappa (medium-length protocol)",
-    
+
       "settings": [
         0.00,     0.00,   -90.00,
         0.00,     0.00,   -45.00,

--- a/mxcubecore/configuration/embl_hh_p14/imaging-centring-math.xml
+++ b/mxcubecore/configuration/embl_hh_p14/imaging-centring-math.xml
@@ -1,13 +1,13 @@
 <object class="CentringMath">
   <!--
   Gonio axes are in a real physical order
-  --> 
+  -->
   <gonioAxes>
      <axis>
         <motorname>phiy</motorname>
         <direction>[0, 1, 0]</direction>
 	<type>translation</type>
-	<motorHO>/eh1/diff-phiy</motorHO> 
+	<motorHO>/eh1/diff-phiy</motorHO>
      </axis>
 
      <!-- removing this axis (normal to Omega) will fix Omega position -->
@@ -15,7 +15,7 @@
         <motorname>phiz</motorname>
         <direction>[1, 0, 0]</direction>
         <type>translation</type>
-        <motorHO>/eh1/diff-phiz</motorHO> 
+        <motorHO>/eh1/diff-phiz</motorHO>
      </axis>
 
      <!-- e.g. robodiff chi axis
@@ -32,16 +32,16 @@
         <!-- direction of omega at Chi==0 -->
         <direction>[0, -1, 0]</direction>
         <type>rotation</type>
-        <motorHO>/eh1/diff-omega</motorHO> 
+        <motorHO>/eh1/diff-omega</motorHO>
      </axis>
 
      <axis>
-        <!-- direction of sampx at Chi==0 and Omega == 0 --> 
+        <!-- direction of sampx at Chi==0 and Omega == 0 -->
         <motorname>sampx</motorname>
         <!--direction>[-0.281085,  0, 0.959683]</direction-->
         <direction>[-0.9999505209310272, 0, 0.00994764744888108]</direction>
         <type>translation</type>
-        <motorHO>/eh1/diff-sampx</motorHO> 
+        <motorHO>/eh1/diff-sampx</motorHO>
      </axis>
 
      <axis>
@@ -49,7 +49,7 @@
         <!--direction>[0.959683,  0, 0.281085 ]</direction-->
         <direction>[0.00994764744888108, 0, 0.9999505209310272]</direction>
         <type>translation</type>
-        <motorHO>/eh1/diff-sampy</motorHO> 
+        <motorHO>/eh1/diff-sampy</motorHO>
      </axis>
   </gonioAxes>
   <cameraAxes>

--- a/mxcubecore/configuration/embl_hh_p14/machine-info.xml
+++ b/mxcubecore/configuration/embl_hh_p14/machine-info.xml
@@ -1,5 +1,5 @@
 <object class="EMBLMachineInfo">
-    <updateIntervalS>120</updateIntervalS>		
+    <updateIntervalS>120</updateIntervalS>
     <limits>{'current':75, 'temp': 25, 'hum': 60, 'intens': 5e-8}</limits>
     <hutchTempAddress>G47cS9:K:KL:P14EH1RaTIW_ai</hutchTempAddress>
     <hutchHumAddress>G47cS9:K:KL:P14EH1RaF_ai</hutchHumAddress>

--- a/mxcubecore/configuration/embl_hh_p14/mxcollect.xml
+++ b/mxcubecore/configuration/embl_hh_p14/mxcollect.xml
@@ -2,7 +2,7 @@
   <channel type="tine" name="collectFrame" tinename="/P14/collection/mx-standard" attach="event">frame</channel>
   <channel type="tine" name="collectStatus" tinename="/P14/collection/mx-standard" attach="event">status</channel>
   <channel type="tine" name="collectError" tinename="/P14/collection/mx-standard" attach="event">Error</channel>
-  <channel type="tine" name="guillotineState" tinename="P14/P14ExpTbl.CDI/GuillCmd" size="2">RECV</channel> 
+  <channel type="tine" name="guillotineState" tinename="P14/P14ExpTbl.CDI/GuillCmd" size="2">RECV</channel>
 
   <command type="tine" name="collectCompression" tinename="/P14/collection/mx-standard">compression</command>
   <command type="tine" name="collectDescription" tinename="/P14/collection/mx-standard">description</command>
@@ -11,7 +11,7 @@
   <command type="tine" name="collectEnergy" tinename="/P14/collection/mx-standard">energy</command>
   <command type="tine" name="collectExposureTime" tinename="/P14/collection/mx-standard">exposure-time</command>
   <command type="tine" name="collectHelicalPosition" tinename="/P14/collection/mx-standard">helical-position</command>
-  <command type="tine" name="collectInQueue" tinename="/P14/collection/mx-standard">in-queue</command> 
+  <command type="tine" name="collectInQueue" tinename="/P14/collection/mx-standard">in-queue</command>
   <command type="tine" name="collectNumImages" tinename="/P14/collection/mx-standard">num-images</command>
   <command type="tine" name="collectOverlap" tinename="/P14/collection/mx-standard">overlap</command>
   <command type="tine" name="collectProcessing" tinename="/P14/collection/mx-standard">processing</command>

--- a/mxcubecore/configuration/embl_hh_p14/oav-camera.xml
+++ b/mxcubecore/configuration/embl_hh_p14/oav-camera.xml
@@ -1,5 +1,5 @@
 <object class="VimbaVideo">
-   <mirror>(True, False)</mirror> 
+   <mirror>(True, False)</mirror>
    <interval>40</interval>
    <camera_name>DEV_000F3101F813</camera_name>
 </object>

--- a/mxcubecore/configuration/embl_hh_p14/offline-processing.xml
+++ b/mxcubecore/configuration/embl_hh_p14/offline-processing.xml
@@ -3,7 +3,7 @@
     <program>
       <executable>ssh bcrunch srun /mx-beta/edna-cluster-scripts/edna_proc.csh</executable>
       <event>after</event>
-    </program> 
+    </program>
     <program>
       <executable>ssh bcrunch srun /mx-beta/edna-cluster-scripts/edna_autoPROC.csh</executable>
       <event>after</event>

--- a/mxcubecore/configuration/embl_hh_p14/plate-manipulator.xml
+++ b/mxcubecore/configuration/embl_hh_p14/plate-manipulator.xml
@@ -3,7 +3,7 @@
    <command type="exporter" name="startMovePlateToLocation">startMovePlateToLocation</command>
    <channel type="exporter" name="PlateLocation">PlateLocation</channel>
    <channel type="exporter" name="State">State</channel>
-   <channel type="exporter" name="CurrentPhase">CurrentPhase</channel> 
+   <channel type="exporter" name="CurrentPhase">CurrentPhase</channel>
 
    <!-- Comment next line if kappa is used -->
    <!-- <channel type="tine" name="PlateLocation" tinename="/P14/MD3/MD3_0">PlateLocation</channel> -->

--- a/mxcubecore/configuration/embl_hh_p14/ppu-control.xml
+++ b/mxcubecore/configuration/embl_hh_p14/ppu-control.xml
@@ -1,9 +1,9 @@
 <object class="EMBLPPUControl">
   <channel type="tine" name="chanAllStatus" tinename="/P14/ppu/ppu-cmd" attach="datachange" timeout="100">all-status-running</channel>
-  <channel type="tine" name="chanAllRestart" tinename="/P14/ppu/ppu-cmd" attach="datachange">all-restart-running</channel> 
+  <channel type="tine" name="chanAllRestart" tinename="/P14/ppu/ppu-cmd" attach="datachange">all-restart-running</channel>
 
-  <command type="tine" name="cmdAllStatus" tinename="/P14/ppu/ppu-cmd">all-status</command> 
-  <command type="tine" name="cmdAllRestart" tinename="/P14/ppu/ppu-cmd">all-restart-self</command> 
+  <command type="tine" name="cmdAllStatus" tinename="/P14/ppu/ppu-cmd">all-status</command>
+  <command type="tine" name="cmdAllRestart" tinename="/P14/ppu/ppu-cmd">all-restart-self</command>
   <command type="tine" name="cmdFurkaRestart" tinename="/P14/ppu/ppu-cmd">furka-restart-self</command>
   <executionState>Execution in progress</executionState>
   <errorState>ERROR</errorState>

--- a/mxcubecore/configuration/embl_hh_p14/redis.xml
+++ b/mxcubecore/configuration/embl_hh_p14/redis.xml
@@ -1,4 +1,4 @@
 <object class="RedisClient">
    <object href="/beamline-setup" role="beamline_setup"/>
-   <object href="/queue-model" role="queue_model"/>   
+   <object href="/queue-model" role="queue_model"/>
 </object>

--- a/mxcubecore/configuration/embl_hh_p14/safety-shutter.xml
+++ b/mxcubecore/configuration/embl_hh_p14/safety-shutter.xml
@@ -6,7 +6,7 @@
   <channel type="tine" name="chanIcsError" tinename="/P14/ics/state" attach="datachange" timeout="100">error</channel>
   <channel type="tine" name="chanCmdCloseError" tinename="/P14/ics/shutter-secondary" attach="datachange" timeout="100">close</channel>
   <channel type="tine" name="chanCmdOpenError" tinename="/P14/ics/shutter-secondary" attach="datachange" timeout="100">open</channel>
-  
+
   <command type="tine" name="cmdClose" tinename="/P14/ics/shutter-secondary" timeout="2000">close</command>
   <command type="tine" name="cmdOpen" tinename="/P14/ics/shutter-secondary" timeout="2000">open</command>
 

--- a/mxcubecore/configuration/embl_hh_p14/sample-changer.xml
+++ b/mxcubecore/configuration/embl_hh_p14/sample-changer.xml
@@ -11,14 +11,14 @@
    <channel type="tine" name="chanErrors" tinename="/P14/P14SC/P14Marvin" attach="datachange">Errors</channel>
    <channel type="tine" name="chanDeviceBusy" tinename="/P14/P14SC/P14Marvin" attach="datachange">Marvin.MountStat</channel>
 
-   <command type="tine" name="cmdMountSample" tinename="/P14/P14SC/P14Marvin" timeout="2000">MountSample</command> 
+   <command type="tine" name="cmdMountSample" tinename="/P14/P14SC/P14Marvin" timeout="2000">MountSample</command>
    <command type="tine" name="cmdUnmountSample" tinename="/P14/P14SC/P14Marvin" timeout="2000">DismountSample</command>
    <command type="tine" name="cmdOpenLid" tinename="/P14/P14SC/P14Marvin">Dewar.OpenLid</command>
    <command type="tine" name="cmdCloseLid" tinename="/P14/P14SC/P14Marvin">Dewar.CloseLid</command>
    <command type="tine" name="cmdBaseToCenter" tinename="/P14/P14SC/P14Marvin">BaseToCenter</command>
    <command type="tine" name="cmdCenterToBase" tinename="/P14/P14SC/P14Marvin">CenterToBase</command>
    <command type="tine" name="cmdDryGripper" tinename="/P14/P14SC/P14Marvin">DryGripper</command>
-   <command type="tine" name="cmdCloseGuillotine"   tinename="/P14/collection/shutter">close</command> 
+   <command type="tine" name="cmdCloseGuillotine"   tinename="/P14/collection/shutter">close</command>
    <command type="tine" name="cmdResetError" tinename="/P14/P14SC/P14Marvin">ResetError</command>
 
    <object href="/eh1/beamFocusing" role="beam_focusing"/>

--- a/mxcubecore/configuration/embl_hh_p14/sample-view.xml
+++ b/mxcubecore/configuration/embl_hh_p14/sample-view.xml
@@ -1,6 +1,6 @@
 <object class="QtGraphicsManager">
    <object href="/diffractometer" role="diffractometer"/>
-   <object href="/oav-camera" role="camera"/> 
+   <object href="/oav-camera" role="camera"/>
    <image_scale_list>[0.5, 1, 1.5, 2]</image_scale_list>
    <auto_grid_size_mm>(0.2, 0.2)</auto_grid_size_mm>
    <!-- <store_graphics_config>True</store_graphics_config> -->

--- a/mxcubecore/configuration/embl_hh_p14/session.xml
+++ b/mxcubecore/configuration/embl_hh_p14/session.xml
@@ -1,5 +1,5 @@
-<object class = "EMBLSession" role = "session">  
-  <synchrotron_name>EMBL-HH</synchrotron_name>	
+<object class = "EMBLSession" role = "session">
+  <synchrotron_name>EMBL-HH</synchrotron_name>
   <endstation_name>p14eh1</endstation_name>
   <beamline_name>P14</beamline_name>
   <file_info>

--- a/mxcubecore/configuration/embl_hh_p14/xray-imaging.xml
+++ b/mxcubecore/configuration/embl_hh_p14/xray-imaging.xml
@@ -1,5 +1,5 @@
 <object class="EMBLXrayImaging">
-  <!-- <channel type="tine" name="chanFrame" tinename="/P14/arapaho/arapaho" attach="event">frame</channel> 
+  <!-- <channel type="tine" name="chanFrame" tinename="/P14/arapaho/arapaho" attach="event">frame</channel>
 
   <channel type="tine" name="chanFrameCount" tinename="/P14/arapaho/arapaho" attach="datachange" timeout="100">frame-count</channel>
   <channel type="tine" name="chanFFSSIM" tinename="/P14/arapaho/arapaho" attach="event">ff-ssim</channel>
@@ -43,4 +43,4 @@
   <!--reference_angle>-0.003530541</reference_angle-->
   <!--reference_angle>-0.0031490</reference_angle at 0.5  to 1.0 m -->
   <!--reference_angle>0.003482</reference_angle through the mirrors-->
-</object>     
+</object>

--- a/mxcubecore/configuration/embl_hh_pe2/attenuators.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/attenuators.xml
@@ -2,4 +2,4 @@
   <channel type="tine" name="chanAttValue" tinename="/P14/transmission/attenuator" attach="event">transmission</channel>
   <channel type="tine" name="chanAttState" tinename="/P14/transmission/attenuator" attach="event">status</channel>
   <channel type="tine" name="chanAttLimits" tinename="/P14/transmission/attenuator" attach="event">limits</channel>
-</object> 
+</object>

--- a/mxcubecore/configuration/embl_hh_pe2/beam-info.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/beam-info.xml
@@ -4,8 +4,8 @@
     <!-- <channel type="exporter" name="BeamPositionHorizontal">BeamPositionHorizontal</channel>
     <channel type="exporter" name="BeamPositionVertical">BeamPositionVertical</channel> -->
     <channel type="tine" name="BeamPositionHorizontal" tinename="/PE2/BSD/BSD_0" timeout="100">BeamPositionHorizontal</channel>
-    <channel type="tine" name="BeamPositionVertical" tinename="/PE2/BSD/BSD_0" timeout="100">BeamPositionVertical</channel>  
+    <channel type="tine" name="BeamPositionVertical" tinename="/PE2/BSD/BSD_0" timeout="100">BeamPositionVertical</channel>
     <channel type="exporter" name="BeamSizeMicrons">BeamSizeMicrons</channel>
-    <channel type="exporter" name="BeamShapeEllipse">BeamShapeEllipse</channel> 
+    <channel type="exporter" name="BeamShapeEllipse">BeamShapeEllipse</channel>
     <defaultBeamDivergence>(12.0, 5.0)</defaultBeamDivergence>
 </object>

--- a/mxcubecore/configuration/embl_hh_pe2/beamline-setup.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/beamline-setup.xml
@@ -24,7 +24,7 @@
 
   <object href="/dbconnection" role="lims_client"/>
 <!--  <object href="/image-tracking" role="image_tracking"/>-->
-  <object href="/parallel-processing" role="parallel_processing"/> 
+  <object href="/parallel-processing" role="parallel_processing"/>
   <object href="/auto-processing" role="auto_processing"/>
 
 

--- a/mxcubecore/configuration/embl_hh_pe2/camera.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/camera.xml
@@ -1,4 +1,4 @@
-<object class="VimbaVideo"> 
+<object class="VimbaVideo">
    <interval>40</interval>
    <camera_index>0</camera_index>
 </object>

--- a/mxcubecore/configuration/embl_hh_pe2/data-analysis.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/data-analysis.xml
@@ -1,6 +1,6 @@
 <object class="EDNACharacterisation">
   <object href="/mxcollect" role="collect"/>
-  <object href="/eh2/diff-beamstop" role="beamstop"/> 
+  <object href="/eh2/diff-beamstop" role="beamstop"/>
   <edna_command>/opt/embl-hh/bin/edna_characterisation.sh</edna_command>
   <edna_default_file>edna-defaults.xml</edna_default_file>
 </object>

--- a/mxcubecore/configuration/embl_hh_pe2/eh2/detector.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/eh2/detector.xml
@@ -2,13 +2,13 @@
   <object hwrid="/eh2/detector-distance" role="detector_distance"/>
 
 
-  <!-- 
+  <!--
   <channel type="tine" name="chanTemperature" tinename="/PE2/detector/eiger4m">temperature</channel>
   <channel type="tine" name="chanHumidity" tinename="/PE2/detector/eiger4m">humidity</channel>
   <channel type="tine" name="chanStatus" tinename="/PE2/detector/eiger4m">status</channel>
   <channel type="tine" name="chanRoiMode" tinename="/PE2/detector/eiger4m" attach="datachange">detector-mode</channel>
   <channel type="tine" name="chanFrameRate" tinename="/PE2/detector/eiger4m">frame-rate</channel>
-  <channel type="tine" name="chanBeamXY" tinename="/PE2/detector/eiger4m">beam-xy</channel> 
+  <channel type="tine" name="chanBeamXY" tinename="/PE2/detector/eiger4m">beam-xy</channel>
   <channel type="tine" name="chanActualFrameRate" tinename="/PE2/tioga/tioga">average-speed</channel>
   <command type="tine" name="cmdRestartDaq" tinename="/PE2/detector/eiger4m">initialize</command>
 
@@ -33,7 +33,7 @@
   <channel type="tine" name="chanStatus" tinename="/PE2/detector/pilatus2m">status</channel>
   <channel type="tine" name="chanRoiMode" tinename="/PE2/detector/pilatus2m" attach="datachange">detector-mode</channel>
   <channel type="tine" name="chanFrameRate" tinename="/PE2/detector/pilatus2m">frame-rate</channel>
-  <channel type="tine" name="chanBeamXY" tinename="/PE2/detector/pilatus2m">beam-xy</channel> 
+  <channel type="tine" name="chanBeamXY" tinename="/PE2/detector/pilatus2m">beam-xy</channel>
   <command type="tine" name="cmdRestartDaq" tinename="/PE2/detector/pilatus2m">initialize</command>
 
   <type>pilatus</type>

--- a/mxcubecore/configuration/embl_hh_pe2/eh2/diff-frontLight.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/eh2/diff-frontLight.xml
@@ -1,6 +1,6 @@
 <object class="MicrodiffLight">
   <exporter_address>pe2bsd01.embl-hamburg.de:9001</exporter_address>
-  <channel type="exporter" name="chanLightValue">FrontLightFactor</channel> 
+  <channel type="exporter" name="chanLightValue">FrontLightFactor</channel>
   <channel type="exporter" name="chanLightIsOn">FrontLightIsOn</channel>
 
   <!--<channel type="tine" name="chanLightValue" tinename="/P14/MD3/MD3_0">FrontLightLevel</channel> -->

--- a/mxcubecore/configuration/embl_hh_pe2/eh2/table_hor.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/eh2/table_hor.xml
@@ -1,3 +1,3 @@
 <object class="EMBLTableMotor">
-  <direction>horizontal</direction>  
+  <direction>horizontal</direction>
 </object>

--- a/mxcubecore/configuration/embl_hh_pe2/energy.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/energy.xml
@@ -7,13 +7,13 @@
 
   <command type="tine" name="cmdEnergyCtrlByte" tinename="/P14/Energy/P14Energy">EnergyCtrlByte</command>
   <command type="tine" name="cmdReleaseBreakBragg" tinename="/P14/Mono/Device 0">ReleaseBreakBragg</command>
-  <command type="tine" name="cmdSetBreakBragg" tinename="/P14/Mono/Device 0">SetBreakBragg</command> 
+  <command type="tine" name="cmdSetBreakBragg" tinename="/P14/Mono/Device 0">SetBreakBragg</command>
 
   <tunableEnergy>True</tunableEnergy>
   <!-- Configuration with undulators -->
   <ctrlBytes>(5, 15)</ctrlBytes>
 
-  <!-- 
+  <!--
   if change > 0.1 keV ctrlByte[1]
   else ctrlByte[0]
 

--- a/mxcubecore/configuration/embl_hh_pe2/graphics.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/graphics.xml
@@ -1,6 +1,6 @@
 <object class="QtGraphicsManager">
 <!--   <object href="/mini-diff" role="diffractometer"/>-->
-   <object href="/camera" role="camera"/> 
+   <object href="/camera" role="camera"/>
    <object href="/beam-info" role="beam_info"/>
    <imageScaleList>[0.5, 1, 1.5, 2]</imageScaleList>
    <auto_grid_size_mm>(0.2, 0.2)</auto_grid_size_mm>

--- a/mxcubecore/configuration/embl_hh_pe2/mach-info.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/mach-info.xml
@@ -1,7 +1,7 @@
 <object class="EMBLMachineInfo">
     <object href="/session" role="session"/>
     <object href="/safshut" role="shutter"/>
- 
+
     <channel type="tine" name="machStateText" tinename="/PETRA/ARCHIVER/keyword" attach="datachange">MachineStateText</channel>
     <channel type="tine" name="machCurrent" tinename="/PETRA/ARCHIVER/keyword" >curDC</channel>
     <channel type="tine" name="machEnergy" tinename="/PETRA/ARCHIVER/keyword" attach="datachange">Energy</channel>

--- a/mxcubecore/configuration/embl_hh_pe2/mini-diff.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/mini-diff.xml
@@ -1,18 +1,18 @@
 <object class="EMBLBSD">
   <exporter_address>pe2bsd01.embl-hamburg.de:9001</exporter_address>
-  <channel type="exporter" name="CoaxCamScaleX">CoaxCamScaleX</channel>  
-  <channel type="exporter" name="CoaxCamScaleY">CoaxCamScaleY</channel> 
+  <channel type="exporter" name="CoaxCamScaleX">CoaxCamScaleX</channel>
+  <channel type="exporter" name="CoaxCamScaleY">CoaxCamScaleY</channel>
   <channel type="exporter" name="CurrentPhase">CurrentPhase</channel>
   <channel type="exporter" name="ScintillatorPosition">ScintillatorPosition</channel>
   <channel type="exporter" name="CapillaryPosition">CapillaryPosition</channel>
   <channel type="exporter" name="State">State</channel>
   <channel type="exporter" name="Status">Status</channel>
   <channel type="exporter" name="BeamstopPosition">BeamstopPosition</channel>
-  <channel type="tine" name="FastShutterIsOpen" tinename="/P14/MD3/MD3_0" attach="event">FastShutterIsOpen</channel>  
+  <channel type="tine" name="FastShutterIsOpen" tinename="/P14/MD3/MD3_0" attach="event">FastShutterIsOpen</channel>
 
   <command type="exporter" name="startSetPhase">startSetPhase</command>
-  <command type="exporter" name="startAutoFocus">startAutoFocus</command>  
-  
+  <command type="exporter" name="startAutoFocus">startAutoFocus</command>
+
   <object href="/eh2/diff-omega" role="phi"/>
   <object href="/eh2/diff-phiz" role="phiz"/>
   <object href="/eh2/diff-phiy" role="phiy"/>
@@ -21,9 +21,9 @@
   <object href="/eh2/diff-sampx" role="sampx"/>
   <object href="/eh2/diff-sampy" role="sampy"/>
   <object href="/eh2/detector-distance" role="detector_distance"/>
-  
+
   <object href="/camera" role="camera"/>
-  <object href="/beam-info" role="beam_info"/> 
+  <object href="/beam-info" role="beam_info"/>
 
   <phase_list>("Transfer", "Centring", "DataCollection", "BeamLocation")</phase_list>
 </object>

--- a/mxcubecore/configuration/embl_hh_pe2/mxcollect.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/mxcollect.xml
@@ -25,7 +25,7 @@
   <command type="tine" name="collectExposureTime" tinename="/PE2/collection/mx-standard">exposure-time</command>
   <command type="tine" name="collectHelicalPosition" tinename="/PE2/collection/mx-standard">helical-position</command>
   <command type="tine" name="collectImagesPerTrigger" tinename="/PE2/collection/mx-standard">nexp-frame</command>
-  <command type="tine" name="collectInQueue" tinename="/PE2/collection/mx-standard">in-queue</command> 
+  <command type="tine" name="collectInQueue" tinename="/PE2/collection/mx-standard">in-queue</command>
   <command type="tine" name="collectNumImages" tinename="/PE2/collection/mx-standard">num-images</command>
   <command type="tine" name="collectOverlap" tinename="/PE2/collection/mx-standard">overlap</command>
   <command type="tine" name="collectProcessing" tinename="/PE2/collection/mx-standard">processing</command>

--- a/mxcubecore/configuration/embl_hh_pe2/primary-crl.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/primary-crl.xml
@@ -1,6 +1,6 @@
 <object class="EMBLCRL">
   <command type="tine" name="cmdSetLenses" tinename="/P14/p14CRLs.CDI/LensOut">SEND</command>
-  <command type="tine" name="cmdSetTrans" tinename="/P14/p14CRLs.CDI/SetTrans">SEND</command> 
+  <command type="tine" name="cmdSetTrans" tinename="/P14/p14CRLs.CDI/SetTrans">SEND</command>
   <channel type="tine" name="chanCrlValue" tinename="/P14/P14CRLs.CDI/LensInBeamLimit" size="6">RECV</channel>
   <object hwrid="/energy" role="energy"/>
   <focal_length>28.0</focal_length>

--- a/mxcubecore/configuration/embl_hh_pe2/queue-model.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/queue-model.xml
@@ -1,3 +1,3 @@
 <object class="QueueModel" role="QueueModel">
-  <object href="/queue" role="queue"/>    
+  <object href="/queue" role="queue"/>
 </object>

--- a/mxcubecore/configuration/embl_hh_pe2/safshut.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/safshut.xml
@@ -6,7 +6,7 @@
   <channel type="tine" name="chanIcsError" tinename="/P14/ics/state" attach="datachange" timeout="100">error</channel>
   <channel type="tine" name="chanCmdCloseError" tinename="/P14/ics/shutter-PE2" attach="datachange" timeout="100">close</channel>
   <channel type="tine" name="chanCmdOpenError" tinename="/P14/ics/shutter-PE2" attach="datachange" timeout="100">open</channel>
-  
+
   <command type="tine" name="cmdClose" tinename="/P14/ics/shutter-PE2" timeout="2000">close</command>
   <command type="tine" name="cmdOpen" tinename="/P14/ics/shutter-PE2" timeout="2000">open</command>
   <useShutter>True</useShutter>

--- a/mxcubecore/configuration/embl_hh_pe2/session.xml
+++ b/mxcubecore/configuration/embl_hh_pe2/session.xml
@@ -1,5 +1,5 @@
-<object class = "EMBLSession" role = "session">  
-  <synchrotron_name>EMBL-HH</synchrotron_name>	
+<object class = "EMBLSession" role = "session">
+  <synchrotron_name>EMBL-HH</synchrotron_name>
   <endstation_name>p14eh2</endstation_name>
   <beamline_name>PE2</beamline_name>
   <file_info>

--- a/mxcubecore/configuration/esrf_id13/graphics.xml
+++ b/mxcubecore/configuration/esrf_id13/graphics.xml
@@ -3,7 +3,7 @@
    <object href="/beam-info" role="beam_info"/>
    <object href="/id13Camera" role="camera"/>
 
-   <!-- Enable move sample buttons 
+   <!-- Enable move sample buttons
         TODO: implement this feature
    <enable_move_buttons>False</enable_move_buttons> -->
 
@@ -12,7 +12,7 @@
 
    <!-- Scale incomming video frame -->
    <!-- <default_image_scale>1</default_image_scale> -->
-   <image_scale_list>(1, 1.5, 2, 2.5, 3, 4, 5)</image_scale_list> 
+   <image_scale_list>(1, 1.5, 2, 2.5, 3, 4, 5)</image_scale_list>
 
    <!-- Scale all graphics view -->
    <!-- <view_scale>1.3</view_scale> -->

--- a/mxcubecore/configuration/esrf_id231/attenuators.xml
+++ b/mxcubecore/configuration/esrf_id231/attenuators.xml
@@ -5,51 +5,51 @@
   <command type="spec" name="setTransmission">transmission</command>
   <channel type="spec" name="attstate">MATT_STATE</channel>
   <channel type="spec" name="attfactor">ATT_FACTOR</channel>
-  <atte> 
+  <atte>
      <label>PyroC 0.1</label>
      <bits>2048</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>PyroC 0.2</label>
      <bits>1024</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>PyroC 0.5</label>
      <bits>512</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>PyroC 0.8</label>
      <bits>256</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>PyroC 1.8</label>
      <bits>128</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>PyroC 3.5</label>
      <bits>64</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>Alum 0.1</label>
      <bits>32</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>Alum 0.25</label>
      <bits>16</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>Alum 0.5</label>
      <bits>8</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>Alum 1</label>
      <bits>4</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>Alum 2</label>
      <bits>2</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>Alum 4</label>
      <bits>1</bits>
   </atte>

--- a/mxcubecore/configuration/esrf_id231/beamline-setup.xml
+++ b/mxcubecore/configuration/esrf_id231/beamline-setup.xml
@@ -1,7 +1,7 @@
 <object class="BeamlineSetup" role="BeamlineSetup">
   <object href="/attenuators" role="transmission"/>
   <object href="/minidiff" role="diffractometer"/>
-  <object href="/sc" role="sample_changer"/>    
+  <object href="/sc" role="sample_changer"/>
   <object href="/eh1/res" role="resolution"/>
   <object href="/eh1/horizontal_motors" role="horizontal_motors"/>
   <object href="/eh1/vertical_motors" role="vertical_motors"/>
@@ -12,7 +12,7 @@
   <object href="/dbconnection" role="lims_client"/>
   <object href="/data-analysis" role="data_analysis"/>
   <object href="/ednaparams" role="workflow"/>
- 
+
   <object href="/mxcollect" role="collect"/>
   <object href="/energyscan" role="energy"/>
 

--- a/mxcubecore/configuration/esrf_id231/dnaconnection.xml
+++ b/mxcubecore/configuration/esrf_id231/dnaconnection.xml
@@ -2,7 +2,7 @@
   <port>2222</port>
   <dnahost>mx231</dnahost>
   <dnaname>id23eh1</dnaname>
-  <dnaport>1112</dnaport> 
+  <dnaport>1112</dnaport>
   <collect>/mxcollect</collect>
   <samplechanger>/sc</samplechanger>
 </procedure>

--- a/mxcubecore/configuration/esrf_id231/ednaparams.xml
+++ b/mxcubecore/configuration/esrf_id231/ednaparams.xml
@@ -10,6 +10,6 @@
   <command type="tango" name="set_values_map">SetScalarValuesMap</command>
   <command type="tango" name="get_values_map">GetScalarValuesMap</command>
   <command type="tango" name="get_available_workflows">GetAvailableWorkflows</command>
-  <channel type="tango" name="state" polling="500">StateAttribute</channel> 
-  <channel type="tango" name="current_actor" polling="500">RunningActorName</channel> 
+  <channel type="tango" name="state" polling="500">StateAttribute</channel>
+  <channel type="tango" name="current_actor" polling="500">RunningActorName</channel>
 </object>

--- a/mxcubecore/configuration/esrf_id231/exptable.xml
+++ b/mxcubecore/configuration/esrf_id231/exptable.xml
@@ -4,17 +4,17 @@
   <real>
       <object hwrid="/eh1/tz1"/>
       <object hwrid="/eh1/tz2"/>
-      <object hwrid="/eh1/tz3"/>  
-      <object hwrid="/eh1/ttf"/>  
-      <object hwrid="/eh1/ttb"/>  
+      <object hwrid="/eh1/tz3"/>
+      <object hwrid="/eh1/ttf"/>
+      <object hwrid="/eh1/ttb"/>
   </real>
   <pseudo>
       <object hwrid="/eh1/thgt" role="height"/>
-      <object hwrid="/eh1/txtilt" role="roll"/>  
-      <object hwrid="/eh1/tytilt" role="ytilt"/>  
-      <object hwrid="/eh1/ttr" role="translation"/>  
-      <object hwrid="/eh1/tztilt"/>  
-      <object hwrid="/eh1/tftilt"/>  
+      <object hwrid="/eh1/txtilt" role="roll"/>
+      <object hwrid="/eh1/tytilt" role="ytilt"/>
+      <object hwrid="/eh1/ttr" role="translation"/>
+      <object hwrid="/eh1/tztilt"/>
+      <object hwrid="/eh1/tftilt"/>
   </pseudo>
   </motors>
   <procedures>

--- a/mxcubecore/configuration/esrf_id231/filters.xml
+++ b/mxcubecore/configuration/esrf_id231/filters.xml
@@ -1,21 +1,21 @@
 <object class = "Filters">
   <username>OH1 Filters</username>
-  <axis> 
+  <axis>
      <object hwrid="/filters/mbv2"/>
   </axis>
-  <axis> 
+  <axis>
      <object hwrid="/filters/dm2"/>
   </axis>
-  <axis> 
+  <axis>
      <object hwrid="/filters/mbv1"/>
   </axis>
-  <axis> 
+  <axis>
      <object hwrid="/filters/wbv"/>
   </axis>
-  <axis> 
+  <axis>
      <object hwrid="/filters/att2"/>
   </axis>
-  <axis> 
+  <axis>
      <object hwrid="/filters/att1"/>
   </axis>
 </object>

--- a/mxcubecore/configuration/esrf_id231/filters/wbv.xml
+++ b/mxcubecore/configuration/esrf_id231/filters/wbv.xml
@@ -5,25 +5,25 @@
    <filter>
      <username>PyroC 0.5</username>
      <offset>0</offset>
-   </filter> 
+   </filter>
      <filter>
      <username>Diamond</username>
      <offset>1</offset>
-   </filter> 
+   </filter>
    <filter>
      <username>Empty</username>
      <offset>2</offset>
-   </filter> 
+   </filter>
    <filter>
      <username>Al 5</username>
      <offset>3</offset>
-   </filter> 
+   </filter>
    <filter>
      <username>PyroC 5</username>
      <offset>4</offset>
-   </filter> 
+   </filter>
    <filter>
      <username>PyroC 8</username>
      <offset>5</offset>
-   </filter> 
+   </filter>
 </object>

--- a/mxcubecore/configuration/esrf_id231/flux.xml
+++ b/mxcubecore/configuration/esrf_id231/flux.xml
@@ -8,4 +8,4 @@
   <channel type="spec" name="flag" version="lid232:eh1">FLUX_CALCULATION_FLAG</channel>
   <object role="shutter" href="/safshut"/>
   <object role="energy" href="/oh1/energy"/>
-</object> 
+</object>

--- a/mxcubecore/configuration/esrf_id231/minidiff-user.xml
+++ b/mxcubecore/configuration/esrf_id231/minidiff-user.xml
@@ -5,7 +5,7 @@
   <motors>
   <phi-shutter>
       <object hwrid="/eh1/phi"    role="phi"/>
-      <object hwrid="/eh1/phiz"   role="phiz"/>  
+      <object hwrid="/eh1/phiz"   role="phiz"/>
       <object hwrid="/eh1/shuty"/>
       <object hwrid="/eh1/shutz"/>
       <object hwrid="/eh1/shut"/>
@@ -14,14 +14,14 @@
       <object hwrid="/eh1/zoom"  role="zoom"/>
       <object hwrid="/eh1/light" role="light"/>
       <object hwrid="/eh1/focus" role="focus"/>
-      <object hwrid="/eh1/length" role="phiy"/> 
+      <object hwrid="/eh1/length" role="phiy"/>
       <object hwrid="/eh1/sampx" role="sampx"/>
       <object hwrid="/eh1/sampy" role="sampy"/>
   </sample>
   <others>
       <object hwrid="/eh1/bstopy"/>
-      <object hwrid="/eh1/bstopz"/>  
-      <object hwrid="/eh1/DtoX"/>  
+      <object hwrid="/eh1/bstopz"/>
+      <object hwrid="/eh1/DtoX"/>
       <object hwrid="/eh1/camx"/>
       <object hwrid="/eh1/camz"/>
   </others>

--- a/mxcubecore/configuration/esrf_id231/minidiff.xml
+++ b/mxcubecore/configuration/esrf_id231/minidiff.xml
@@ -10,15 +10,15 @@
     <archiveFolder>/data/pyarch/id23eh1/C3D/archive_images</archiveFolder>
     <outputFolder>/users/blissadm/applications/c3d/output</outputFolder>
     <statsFile>/users/blissadm/log/Mxautocentring_stats.log</statsFile>
-    
-    
+
+
     <calibrationMacro>minidiff_take_backgrounds</calibrationMacro>
     <maxhmove>1.3</maxhmove>
-    <maxvmove>1.3</maxvmove> 
+    <maxvmove>1.3</maxvmove>
     <maxNoise>50</maxNoise>
     <maxBackgroundDrift>8</maxBackgroundDrift>
-    <cryoShadowMargin>80</cryoShadowMargin> 
-    <ringMargin>35</ringMargin> 
+    <cryoShadowMargin>80</cryoShadowMargin>
+    <ringMargin>35</ringMargin>
     <phiyDirection>1</phiyDirection>
     <beamline>id23eh1</beamline>
     <allowPlayback>1</allowPlayback>
@@ -70,7 +70,7 @@
   <motors>
   <phi-shutter>
       <object role="phi" hwrid="/eh1/phi"></object>
-      <object role="phiz" hwrid="/eh1/phiz"></object>  
+      <object role="phiz" hwrid="/eh1/phiz"></object>
       <object hwrid="/eh1/shuty"></object>
       <object hwrid="/eh1/shutz"></object>
       <object hwrid="/eh1/shut"></object>
@@ -80,7 +80,7 @@
       <object role="light" hwrid="/eh1/light"></object>
       <object role="flight" hwrid="/eh1/flight"></object>
       <object role="focus" hwrid="/eh1/focus"></object>
-      <object role="phiy" hwrid="/eh1/length"></object>  
+      <object role="phiy" hwrid="/eh1/length"></object>
       <object role="sampx" hwrid="/eh1/sampx"></object>
       <object role="sampy" hwrid="/eh1/sampy"></object>
       <object role="kappa" hwrid="/eh1/kap1"></object>
@@ -88,8 +88,8 @@
   </sample>
   <others>
       <object hwrid="/eh1/bstopy"></object>
-      <object role="bstopz" hwrid="/eh1/bstopz"></object>  
-      <object hwrid="/eh1/DtoX"></object>  
+      <object role="bstopz" hwrid="/eh1/bstopz"></object>
+      <object hwrid="/eh1/DtoX"></object>
   </others>
   </motors>
   <aperture>/apzy</aperture>

--- a/mxcubecore/configuration/esrf_id231/minidiff_motors.xml
+++ b/mxcubecore/configuration/esrf_id231/minidiff_motors.xml
@@ -4,7 +4,7 @@
   <motors>
   <phi-shutter>
       <object role="phi" hwrid="/eh1/phi"></object>
-      <object role="phiz" hwrid="/eh1/phiz"></object>  
+      <object role="phiz" hwrid="/eh1/phiz"></object>
       <object hwrid="/eh1/shuty"></object>
       <object hwrid="/eh1/shutz"></object>
       <object hwrid="/eh1/shut"></object>
@@ -13,14 +13,14 @@
       <object role="zoom" hwrid="/eh1/zoom"></object>
       <object role="light" hwrid="/eh1/light"></object>
       <object role="focus" hwrid="/eh1/focus"></object>
-      <object role="phiy" hwrid="/eh1/length"></object>  
+      <object role="phiy" hwrid="/eh1/length"></object>
       <object role="sampx" hwrid="/eh1/sampx"></object>
       <object role="sampy" hwrid="/eh1/sampy"></object>
   </sample>
   <others>
       <object hwrid="/eh1/bstopy"></object>
-      <object role="bstopz" hwrid="/eh1/bstopz"></object>  
-      <object hwrid="/eh1/DtoX"></object>  
+      <object role="bstopz" hwrid="/eh1/bstopz"></object>
+      <object hwrid="/eh1/DtoX"></object>
   </others>
   </motors>
 </object>

--- a/mxcubecore/configuration/esrf_id231/mono.xml
+++ b/mxcubecore/configuration/esrf_id231/mono.xml
@@ -8,7 +8,7 @@
   </pseudo>
   <real>
       <object hwrid="/oh1/mono"/>
-      <object hwrid="/oh1/push111"/>  
+      <object hwrid="/oh1/push111"/>
   </real>
   </motors>
   <specname>basil:oh1</specname>

--- a/mxcubecore/configuration/esrf_id231/mxPowderCalibration.xml
+++ b/mxcubecore/configuration/esrf_id231/mxPowderCalibration.xml
@@ -2,7 +2,7 @@
 -->
 <mxPowderCalibration>
     <numberOfInputImagesAsked>   13</numberOfInputImagesAsked>
-    <numberOfInputImagesRead>    13</numberOfInputImagesRead> 
+    <numberOfInputImagesRead>    13</numberOfInputImagesRead>
     <percentageOfIndexedSpots>    83.10</percentageOfIndexedSpots>
     <rmsd>  0.000939</rmsd>
     <refinedBeamCentreCalibration>

--- a/mxcubecore/configuration/esrf_id231/mxcollect.xml
+++ b/mxcubecore/configuration/esrf_id231/mxcollect.xml
@@ -1,7 +1,7 @@
-<object class="ID231MultiCollect">	
+<object class="ID231MultiCollect">
   <object href="/dbconnection" role="dbserver"/>
-  <object href="/safshut" role="safety_shutter"/>	
-  <object href="/sc" role="sample_changer"/>	
+  <object href="/safshut" role="safety_shutter"/>
+  <object href="/sc" role="sample_changer"/>
   <object href="/minidiff" role="diffractometer"/>
   <object href="/energyscan" role="energy"/>
   <object href="/mxlocal" role="beamline_configuration"/>
@@ -47,7 +47,7 @@
   <channel type="spec" version="lid232:eh1" name="helical_pars">HELICAL_PARS</channel>
 
   <directory_prefix>id23eh1</directory_prefix>
-  
+
   <input_files_server>localhost:5698</input_files_server>
 
   <auto_processing>
@@ -58,6 +58,6 @@
     <program>
       <executable>/users/blissadm/bin/autoproc-launcher.py</executable>
       <event>before</event>
-    </program> 
+    </program>
   </auto_processing>
 </object>

--- a/mxcubecore/configuration/esrf_id231/mxlocal.xml
+++ b/mxcubecore/configuration/esrf_id231/mxlocal.xml
@@ -48,7 +48,7 @@
     <undulator>
       <type>u35</type>
       <device_uri>//aries/id/id/23</device_uri>
-      <gap_index>0</gap_index> 
+      <gap_index>0</gap_index>
     </undulator>
     <undulator>
       <type>u20</type>
@@ -105,7 +105,7 @@
  </INHOUSE_USERS>
  <FASTCENTRING_PARS>
     <enable>False</enable>
-    <light_factor>4.25</light_factor> 
+    <light_factor>4.25</light_factor>
     <nb_of_images>7</nb_of_images>
     <angle_between_images>45</angle_between_images>
  </FASTCENTRING_PARS>

--- a/mxcubecore/configuration/esrf_id231/sc.xml
+++ b/mxcubecore/configuration/esrf_id231/sc.xml
@@ -1,8 +1,8 @@
 <object class = "ESRFSC3">
   <username>Sample Changer</username>
-  
+
   <!-- SC3 commands and channels -->
-  <exporter_address>pcsc3-id231:9001</exporter_address>    
+  <exporter_address>pcsc3-id231:9001</exporter_address>
   <channel type="exporter" name="_state">State</channel>
   <channel type="exporter" name="_selected_basket">SelectedBasketLocation</channel>
   <channel type="exporter" name="_selected_sample">SelectedSampleLocation</channel>
@@ -30,7 +30,7 @@
   <command type="spec" name="prepareCentring">minidiff_prepare_centring</command>
   <channel type="spec" name="OperationalFlags">SC_MD_FLAGS</channel>
 
-  <!-- other related hardware from minidiff --> 
+  <!-- other related hardware from minidiff -->
   <object hwrid="/wago/cryo" role="Cryo"/>
   <object hwrid="/wago/light" role="Light"/>
 </object>

--- a/mxcubecore/configuration/esrf_id231/slitbox.xml
+++ b/mxcubecore/configuration/esrf_id231/slitbox.xml
@@ -3,9 +3,9 @@
   <motors>
   <back>
       <object hwrid="/eh1/s2v" role="s2v"/>
-      <object hwrid="/eh1/t2v" role="t2v"/>  
-      <object hwrid="/eh1/s2h" role="s2h"/>  
-      <object hwrid="/eh1/t2h" role="t2h"/>  
+      <object hwrid="/eh1/t2v" role="t2v"/>
+      <object hwrid="/eh1/s2h" role="s2h"/>
+      <object hwrid="/eh1/t2h" role="t2h"/>
   </back>
   <front>
       <object hwrid="/eh1/s1v" role="s1v"/>

--- a/mxcubecore/configuration/esrf_id231/zoom_equipment.xml
+++ b/mxcubecore/configuration/esrf_id231/zoom_equipment.xml
@@ -33,7 +33,7 @@
       <name>zoom 3</name>
       <zoom>40</zoom>
       <light>0.33</light>
-      <resox>1.22e-06</resox> 
+      <resox>1.22e-06</resox>
       <resoy>1.34e-06</resoy>
       <beamx>329</beamx>
       <beamy>246</beamy>

--- a/mxcubecore/configuration/esrf_id29/attenuators.xml
+++ b/mxcubecore/configuration/esrf_id29/attenuators.xml
@@ -5,51 +5,51 @@
   <command type="spec" name="setTransmission">transmission</command>
   <channel type="spec" name="attstate">MATT_STATE</channel>
   <channel type="spec" name="attfactor">ATT_FACTOR</channel>
-  <atte> 
+  <atte>
      <label>PyroC 0.1</label>
      <bits>1</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>PyroC 0.25</label>
      <bits>2</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>PyroC 0.5</label>
      <bits>4</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>PyroC 1</label>
      <bits>8</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>PyroC 2</label>
      <bits>16</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>PyroC 4</label>
      <bits>32</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>Al 0.1</label>
      <bits>64</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>Al 0.25</label>
      <bits>128</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>Al 0.5</label>
      <bits>256</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>Al 1</label>
      <bits>512</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>Al 2</label>
      <bits>1024</bits>
   </atte>
-  <atte> 
+  <atte>
      <label>Al 4</label>
      <bits>2048</bits>
   </atte>

--- a/mxcubecore/configuration/esrf_id29/beamline-setup.xml
+++ b/mxcubecore/configuration/esrf_id29/beamline-setup.xml
@@ -1,9 +1,9 @@
 <object class="BeamlineSetup" role="BeamlineSetup">
-  
+
   <!-- Objects directly associatd with hardware -->
   <object href="/attenuators" role="transmission"/>
-  <object href="/udiff" role="diffractometer"/>    
-  <object href="/sc" role="sample_changer"/>    
+  <object href="/udiff" role="diffractometer"/>
+  <object href="/sc" role="sample_changer"/>
   <object href="/resolution" role="resolution"/>
   <object href="/exp/horizontal_motors" role="horizontal_motors"/>
   <object href="/exp/vertical_motors" role="vertical_motors"/>

--- a/mxcubecore/configuration/esrf_id29/exp/horizontal_motors.xml
+++ b/mxcubecore/configuration/esrf_id29/exp/horizontal_motors.xml
@@ -1,5 +1,5 @@
 <object>
   <motors>
-    <object role="horizontal" href="/udiff_phiy"/> 
+    <object role="horizontal" href="/udiff_phiy"/>
   </motors>
 </object>

--- a/mxcubecore/configuration/esrf_id29/filters.xml
+++ b/mxcubecore/configuration/esrf_id29/filters.xml
@@ -1,15 +1,15 @@
 <object class = "Filters">
   <username>OH Filters</username>
-  <axis> 
+  <axis>
      <object hwrid="/filters/mbv2"/>
   </axis>
   <axis>
      <object hwrid="/filters/mbv"/>
   </axis>
-  <axis> 
+  <axis>
      <object hwrid="/filters/din"/>
   </axis>
-  <axis> 
+  <axis>
      <object hwrid="/filters/mbv1"/>
   </axis>
   <axis>

--- a/mxcubecore/configuration/esrf_id29/filters/mbv.xml
+++ b/mxcubecore/configuration/esrf_id29/filters/mbv.xml
@@ -5,9 +5,9 @@
    <filter>
      <username>YAG Screen</username>
      <offset>1.3</offset>
-   </filter> 
+   </filter>
    <filter>
      <username>Out</username>
      <offset>0.3</offset>
-   </filter> 
+   </filter>
 </object>

--- a/mxcubecore/configuration/esrf_id29/filters/mbv1.xml
+++ b/mxcubecore/configuration/esrf_id29/filters/mbv1.xml
@@ -14,7 +14,7 @@
      <username>Out</username>
      <offset>37.7</offset>
    </filter>
-<!--   
+<!--
    <filter>
      <username>Cu</username>
      <offset>50.80</offset>
@@ -34,6 +34,6 @@
    <filter>
      <username>diode</username>
      <offset>102.19</offset>
-   </filter> 
+   </filter>
 -->
 </object>

--- a/mxcubecore/configuration/esrf_id29/flux.xml
+++ b/mxcubecore/configuration/esrf_id29/flux.xml
@@ -4,8 +4,8 @@
   <index>1</index>
   <channel type="taco" name="counts" taconame="id29/wct_eh/1" polling="3000" compare="False">DevCntReadAll</channel>
   <channel type="spec" name="calibration" version="lid292:exp">CALIBRATED_DIODE</channel>
-  <object role="aperture" href="/udiff_aperturemot"/> 
+  <object role="aperture" href="/udiff_aperturemot"/>
   <channel type="spec" name="flag" version="lid292:exp">FLUX_CALCULATION_FLAG</channel>
   <object role="shutter" href="/safshut"/>
   <object role="energy" href="/oh/motors/energy"/>
-</object> 
+</object>

--- a/mxcubecore/configuration/esrf_id29/mirror_align.xml
+++ b/mxcubecore/configuration/esrf_id29/mirror_align.xml
@@ -41,7 +41,7 @@
     <intensity_counter>mirrbvi</intensity_counter>
     <beamx_counter>mirrbvx</beamx_counter>
     <beamy_counter>mirrbvy</beamy_counter>
-    
+
     <slit_hgap>2</slit_hgap>
     <slit_vgap>0.1</slit_vgap>
     <!--

--- a/mxcubecore/configuration/esrf_id29/mxcollect.xml
+++ b/mxcubecore/configuration/esrf_id29/mxcollect.xml
@@ -1,6 +1,6 @@
 <object class="ID29MultiCollect">
   <specversion>lid292:exp</specversion>
-  
+
   <object href="/dbconnection" role="dbserver"/>
   <object href="/safshut" role="safety_shutter"/>
   <object href="/mxlocal" role="beamline_configuration"/>
@@ -41,7 +41,7 @@
   <channel type="spec" name="shutterless">PILATUS_SHUT</channel>
   <command type="spec" name="local_set_experiment_type">pilatus_set_experiment_type</command>
   <command type="spec" name="specific_collect_frame_hook">pilatus_postframe_actions</command>
-  <command type="spec" name="prepare_beamline">prodc_prepare_beamline</command>  
+  <command type="spec" name="prepare_beamline">prodc_prepare_beamline</command>
   <command type="spec" version="lid292:exp" name="reset_detector">id29_finish_bl</command>
   <channel type="spec" version="lid292:exp" name="xds_filename">XDS_INPUT_FILENAME</channel>
   <channel type="spec" version="lid292:exp" name="spec_messages">eprodc_log_message</channel>

--- a/mxcubecore/configuration/esrf_id29/oh/mono.xml
+++ b/mxcubecore/configuration/esrf_id29/oh/mono.xml
@@ -9,7 +9,7 @@
   </pseudo>
   <real>
       <object hwrid="/oh/motors/mono"/>
-      <object hwrid="/oh/motors/push111"/>  
+      <object hwrid="/oh/motors/push111"/>
       <object hwrid="/oh/motors/push311"/>
   </real>
   </motors>

--- a/mxcubecore/configuration/esrf_id29/queue-model.xml
+++ b/mxcubecore/configuration/esrf_id29/queue-model.xml
@@ -1,3 +1,3 @@
 <object class="QueueModel" role="QueueModel">
-  <object href="/queue" role="queue"/>    
+  <object href="/queue" role="queue"/>
 </object>

--- a/mxcubecore/configuration/esrf_id29/raman.xml
+++ b/mxcubecore/configuration/esrf_id29/raman.xml
@@ -4,7 +4,7 @@
   <motors>
     <real>
       <object hwrid="/exp/ramx" role="ramx"/>
-      <object hwrid="/exp/ramy" role="ramy"/>  
+      <object hwrid="/exp/ramy" role="ramy"/>
       <object hwrid="/exp/ramz" role="ramz"/>
     </real>
   </motors>

--- a/mxcubecore/configuration/esrf_id29/sc.xml
+++ b/mxcubecore/configuration/esrf_id29/sc.xml
@@ -1,8 +1,8 @@
 <object class = "ESRFSC3">
   <username>Sample Changer</username>
-  
+
   <!-- SC3 commands and channels -->
-  <exporter_address>pcsc3-id29:9001</exporter_address>    
+  <exporter_address>pcsc3-id29:9001</exporter_address>
   <channel type="exporter" name="_state">State</channel>
   <channel type="exporter" name="_selected_basket">SelectedBasketLocation</channel>
   <channel type="exporter" name="_selected_sample">SelectedSampleLocation</channel>
@@ -29,7 +29,7 @@
   <command type="spec" name="prepareCentring">minidiff_prepare_centring</command>
   <channel type="spec" name="OperationalFlags">SC_MD_FLAGS</channel>
 
-  <!-- other related hardware from minidiff --> 
+  <!-- other related hardware from minidiff -->
   <object hwrid="/wago/cryo"  role="Cryo"/>
   <object hwrid="/udiff_light" role="Light"/>
 </object>

--- a/mxcubecore/configuration/esrf_id29/session.xml
+++ b/mxcubecore/configuration/esrf_id29/session.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 
-<object class = "Session" role = "session">  
+<object class = "Session" role = "session">
 
   <endstation_name>id29</endstation_name>
   <beamline_name>ID29</beamline_name>

--- a/mxcubecore/configuration/esrf_id29/slitbox.xml
+++ b/mxcubecore/configuration/esrf_id29/slitbox.xml
@@ -4,8 +4,8 @@
   <motors>
     <slit1>
       <object hwrid="/exp/s1v" role="s1v"/>
-      <object hwrid="/exp/t1v" role="t1v"/>  
-      <object hwrid="/exp/s1h" role="s1h"/>  
+      <object hwrid="/exp/t1v" role="t1v"/>
+      <object hwrid="/exp/s1h" role="s1h"/>
       <object hwrid="/exp/t1h" role="t1h"/>
       <realmots>t1v t1h</realmots>
     </slit1>

--- a/mxcubecore/configuration/esrf_id29/udiff_aperturemot.xml
+++ b/mxcubecore/configuration/esrf_id29/udiff_aperturemot.xml
@@ -3,17 +3,17 @@
   <diameter>
     <name>10</name>
     <aperture_coef>0.15</aperture_coef>
-  </diameter> 
+  </diameter>
   <diameter>
     <name>20</name>
     <aperture_coef>0.28</aperture_coef>
-  </diameter> 
+  </diameter>
   <diameter>
     <name>30</name>
     <aperture_coef>0.52</aperture_coef>
-  </diameter> 
+  </diameter>
   <diameter>
     <name>75</name>
     <aperture_coef>1.21</aperture_coef>
-  </diameter> 
+  </diameter>
 </object>

--- a/mxcubecore/configuration/esrf_id29/udiff_sample_horizontal.xml
+++ b/mxcubecore/configuration/esrf_id29/udiff_sample_horizontal.xml
@@ -2,7 +2,7 @@
   <username>vert</username>
   <direction>horizontal</direction>
   <unit>1e-3</unit>
-  <object href="/udiff_omega" role="phi"/>  
-  <object href="/udiff_sampx" role="sampx"/>  
-  <object href="/udiff_sampy" role="sampy"/>  
+  <object href="/udiff_omega" role="phi"/>
+  <object href="/udiff_sampx" role="sampx"/>
+  <object href="/udiff_sampy" role="sampy"/>
 </object>

--- a/mxcubecore/configuration/esrf_id29/udiff_sample_vertical.xml
+++ b/mxcubecore/configuration/esrf_id29/udiff_sample_vertical.xml
@@ -2,7 +2,7 @@
   <username>vert</username>
   <direction>vertical</direction>
   <unit>1e-3</unit>
-  <object href="/udiff_omega" role="phi"/>  
-  <object href="/udiff_sampx" role="sampx"/>  
-  <object href="/udiff_sampy" role="sampy"/>  
+  <object href="/udiff_omega" role="phi"/>
+  <object href="/udiff_sampx" role="sampx"/>
+  <object href="/udiff_sampy" role="sampy"/>
 </object>

--- a/mxcubecore/configuration/esrf_id30a2/gphl_beamline_config/filenametemplates.xml
+++ b/mxcubecore/configuration/esrf_id30a2/gphl_beamline_config/filenametemplates.xml
@@ -158,7 +158,7 @@ Element names are tied to the beamline or workflow and cannot be modified
             <name>beam_setting_index</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
@@ -167,7 +167,7 @@ Element names are tied to the beamline or workflow and cannot be modified
             <name>run_number</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
@@ -213,7 +213,7 @@ Element names are tied to the beamline or workflow and cannot be modified
             <name>beam_setting_index</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Parameter">
             <name>inverse_beam_component_sign</name>
             <type>string</type>
@@ -227,7 +227,7 @@ Element names are tied to the beamline or workflow and cannot be modified
             <name>run_number</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
@@ -279,7 +279,7 @@ Element names are tied to the beamline or workflow and cannot be modified
             <name>run_number</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
@@ -381,6 +381,6 @@ Element names are tied to the beamline or workflow and cannot be modified
         <mapsTo>Beamline</mapsTo>
 
     </c:filenamePatternMapping>
-    
+
 
 </xml-fragment>

--- a/mxcubecore/configuration/esrf_id30a2/gphl_beamline_config/transcal_2stage.json
+++ b/mxcubecore/configuration/esrf_id30a2/gphl_beamline_config/transcal_2stage.json
@@ -1,5 +1,5 @@
 [
-    { 
+    {
       "#": "Settings (omega, kappa, phi) for running TransCal on a mini-Kappa (short protocol, without SOC)",
       "settings": [
         0,   0,       0,
@@ -15,10 +15,10 @@
       "noRefineSOC": true,
       "useRecen": false
     },
-    
+
     {
       "#": "Settings(omega, kappa, phi) for running TransCal on a mini-Kappa (medium-length protocol)",
-    
+
       "settings": [
         0.00,     0.00,   -90.00,
         0.00,     0.00,   -45.00,

--- a/mxcubecore/configuration/lnls_manaca/queue.xml
+++ b/mxcubecore/configuration/lnls_manaca/queue.xml
@@ -1,3 +1,3 @@
 <object class="QueueManager" role="Queue">
-  <object href="/beamline-setup" role="beamline_setup"/>    
+  <object href="/beamline-setup" role="beamline_setup"/>
 </object>

--- a/mxcubecore/configuration/lnls_manaca/queue_model.xml
+++ b/mxcubecore/configuration/lnls_manaca/queue_model.xml
@@ -1,3 +1,3 @@
 <object class="QueueModel" role="QueueModel">
-  <object href="/queue" role="queue"/>    
+  <object href="/queue" role="queue"/>
 </object>

--- a/mxcubecore/configuration/lnls_manaca/xml_rpc_server.xml
+++ b/mxcubecore/configuration/lnls_manaca/xml_rpc_server.xml
@@ -2,7 +2,7 @@
   <all_interfaces>
     True
   </all_interfaces>
- 
+
   <port>
     7171
   </port>

--- a/mxcubecore/configuration/lnls_sol/queue.xml
+++ b/mxcubecore/configuration/lnls_sol/queue.xml
@@ -1,3 +1,3 @@
 <object class="QueueManager" role="Queue">
-  <object href="/beamline-setup" role="beamline_setup"/>    
+  <object href="/beamline-setup" role="beamline_setup"/>
 </object>

--- a/mxcubecore/configuration/lnls_sol/queue_model.xml
+++ b/mxcubecore/configuration/lnls_sol/queue_model.xml
@@ -1,3 +1,3 @@
 <object class="QueueModel" role="QueueModel">
-  <object href="/queue" role="queue"/>    
+  <object href="/queue" role="queue"/>
 </object>

--- a/mxcubecore/configuration/lnls_sol/xml_rpc_server.xml
+++ b/mxcubecore/configuration/lnls_sol/xml_rpc_server.xml
@@ -2,7 +2,7 @@
   <all_interfaces>
     True
   </all_interfaces>
- 
+
   <port>
     7171
   </port>

--- a/mxcubecore/configuration/mockup/gphl/alba_session.xml
+++ b/mxcubecore/configuration/mockup/gphl/alba_session.xml
@@ -1,4 +1,4 @@
-<object class = "ALBASession" role = "session">  
+<object class = "ALBASession" role = "session">
   <!-- ATTENTION . base data directories are overwritten in ALBA -->
   <!--   the value in ldap homeDirectory is used for the three base directories -->
   <!--      base_directory, base_process_directory, base_archive_directory -->

--- a/mxcubecore/configuration/mockup/offline-processing-mockup.xml
+++ b/mxcubecore/configuration/mockup/offline-processing-mockup.xml
@@ -3,7 +3,7 @@
     Each autoprocessing program is executable script.
     Script is stored and executed when the event is called
 
-    remove Break to run actual script      
+    remove Break to run actual script
     -->
     <programs>
     <program>

--- a/mxcubecore/configuration/mockup/qt/camera-mockup.xml
+++ b/mxcubecore/configuration/mockup/qt/camera-mockup.xml
@@ -1,3 +1,3 @@
-<object class="QtVideoMockup"> 
-   <interval>1</interval>	
+<object class="QtVideoMockup">
+   <interval>1</interval>
 </object>

--- a/mxcubecore/configuration/mockup/qt/sample-view.xml
+++ b/mxcubecore/configuration/mockup/qt/sample-view.xml
@@ -2,7 +2,7 @@
    <object href="/diffractometer-mockup" role="diffractometer"/>-->
    <object href="/camera-mockup" role="camera"/>
 
-   <!-- Enable move sample buttons 
+   <!-- Enable move sample buttons
         TODO: implement this feature
    <enable_move_buttons>False</enable_move_buttons> -->
 
@@ -11,7 +11,7 @@
 
    <!-- Scale incomming video frame -->
    <!-- <default_image_scale>1</default_image_scale> -->
-   <image_scale_list>(1, 1.5, 2, 2.5, 3, 4, 5)</image_scale_list> 
+   <image_scale_list>(1, 1.5, 2, 2.5, 3, 4, 5)</image_scale_list>
 
    <!-- Scale all graphics view -->
    <!-- <view_scale>1.3</view_scale> -->

--- a/mxcubecore/configuration/mockup/queue-model.xml
+++ b/mxcubecore/configuration/mockup/queue-model.xml
@@ -1,7 +1,7 @@
 <object class="QueueModel" role="QueueModel">
-  <object href="/queue" role="queue"/>    
-  
-  <!-- 
+  <object href="/queue" role="queue"/>
+
+  <!--
   <load_on_start_enabled>True</load_on_start_enabled>
   <load_on_start_filename>/tmp/mxcube/queue.dat</load_on_start_filename>
   -->

--- a/mxcubecore/configuration/mockup/slits-mockup.xml
+++ b/mxcubecore/configuration/mockup/slits-mockup.xml
@@ -10,5 +10,5 @@
        <minGap>0.005</minGap>
        <maxGap>0.300</maxGap>
        <updateTolerance>0.0005</updateTolerance>
-    </gapV>  
+    </gapV>
 </object>

--- a/mxcubecore/configuration/mockup/xml-rpc-server.xml
+++ b/mxcubecore/configuration/mockup/xml-rpc-server.xml
@@ -3,7 +3,7 @@
   <!-- Should XML-RPC server listen on all interfaces?
        False (the default) means listen only on the interface given
        by socket.gethostname()-->
-  <all_interfaces> 
+  <all_interfaces>
     True
   </all_interfaces>
   <port>

--- a/mxcubecore/configuration/soleil/px2/mockups/gphl_beamline_config/filenametemplates.xml
+++ b/mxcubecore/configuration/soleil/px2/mockups/gphl_beamline_config/filenametemplates.xml
@@ -158,7 +158,7 @@ Element names are tied to the beamline or workflow and cannot be modified
             <name>beam_setting_index</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
@@ -167,7 +167,7 @@ Element names are tied to the beamline or workflow and cannot be modified
             <name>run_number</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
@@ -213,7 +213,7 @@ Element names are tied to the beamline or workflow and cannot be modified
             <name>beam_setting_index</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Parameter">
             <name>inverse_beam_component_sign</name>
             <type>string</type>
@@ -227,7 +227,7 @@ Element names are tied to the beamline or workflow and cannot be modified
             <name>run_number</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>
@@ -279,7 +279,7 @@ Element names are tied to the beamline or workflow and cannot be modified
             <name>run_number</name>
             <type>unsignedInt</type>
         </element>
-        
+
         <element xsi:type="tet:Separator">
             <value>_</value>
         </element>

--- a/mxcubecore/configuration/soleil/px2/mockups/gphl_beamline_config/transcal_2stage.json
+++ b/mxcubecore/configuration/soleil/px2/mockups/gphl_beamline_config/transcal_2stage.json
@@ -1,5 +1,5 @@
 [
-    { 
+    {
       "#": "Settings (omega, kappa, phi) for running TransCal on a mini-Kappa (short protocol, without SOC)",
       "settings": [
         0,   0,       0,
@@ -15,10 +15,10 @@
       "noRefineSOC": true,
       "useRecen": false
     },
-    
+
     {
       "#": "Settings(omega, kappa, phi) for running TransCal on a mini-Kappa (medium-length protocol)",
-    
+
       "settings": [
         0.00,     0.00,   -90.00,
         0.00,     0.00,   -45.00,

--- a/mxcubecore/configuration/soleil_px1/beamline-setup.xml
+++ b/mxcubecore/configuration/soleil_px1/beamline-setup.xml
@@ -13,7 +13,7 @@
   <object href="/omega" role="omega_axis"/>
   <object href="/chi" role="kappa_axis"/>
   <object href="/phi" role="kappa_phi_axis"/>
-  <object href="/cryotong" role="sample_changer"/>    
+  <object href="/cryotong" role="sample_changer"/>
   <object href="/resolution" role="resolution"/>
   <object href="/energy" role="energy"/>
   <object href="/energyscan" role="energyscan"/>
@@ -32,9 +32,9 @@
   <object href="/ednaparams" role="workflow"/>
   <object href="/data-analysis" role="data_analysis"/>
   <!--<object href="/workflow-mockup" role="workflow"/> -->
- 
+
   <!-- Procedures and routines -->
-  <object href="/mxcollect" role="collect"/> 
+  <object href="/mxcollect" role="collect"/>
   <object href="/pilatus" role="detector"/>
 
   <!-- Is it possible to change the beam wavelentgh.

--- a/mxcubecore/configuration/soleil_px1/catsmaint.xml
+++ b/mxcubecore/configuration/soleil_px1/catsmaint.xml
@@ -1,6 +1,6 @@
 <object class = "PX1CatsMaint">
   <username>CatsMaint</username>
-  <tangoname>i10-c-cx1/ex/catscryotong</tangoname>    
+  <tangoname>i10-c-cx1/ex/catscryotong</tangoname>
 
   <object role="sample_changer" hwrid="/cryotong"/>
 

--- a/mxcubecore/configuration/soleil_px1/cryotong.xml
+++ b/mxcubecore/configuration/soleil_px1/cryotong.xml
@@ -2,8 +2,8 @@
 
   <username>CryoTong</username>
 
-  <tangoname>i10-c-cx1/ex/catscryotong</tangoname>    
-  <cats_device>i10-c-cx1/ex/cats</cats_device>    
+  <tangoname>i10-c-cx1/ex/catscryotong</tangoname>
+  <cats_device>i10-c-cx1/ex/cats</cats_device>
 
   <useUpdateTimer>False</useUpdateTimer>
 
@@ -11,8 +11,8 @@
   <no_of_baskets>3</no_of_baskets>
   <samples_per_basket>16</samples_per_basket>
 
-  <object role="environment" href="/px1environment" /> 
- 
+  <object role="environment" href="/px1environment" />
+
   <!-- beware some channels are connected to PyCats server, not to cryotong server -->
   <command type="tango" tangoname="i10-c-cx1/ex/cats" name="_cmdScanSample">barcode</command>
 
@@ -60,8 +60,8 @@
   <channel type="tango" polling="1000" name="_chnNumLoadedSample">numSampleOnDiff</channel>
 
 
-  <!-- CHANNELS FROM CATS --> 
-  
+  <!-- CHANNELS FROM CATS -->
+
   <channel type="tango" polling="events" tangoname="i10-c-cx1/ex/cats" name="_chnSampleIsDetected">di_PRI4_SOM</channel>
   <channel type="tango" polling="events" tangoname="i10-c-cx1/ex/cats" name="_chnTotalLidState">di_AllLidsClosed</channel>
 

--- a/mxcubecore/configuration/soleil_px1/energyscan.xml
+++ b/mxcubecore/configuration/soleil_px1/energyscan.xml
@@ -12,7 +12,7 @@
     <object hwrid="/session" role="session"/>
     <object hwrid="/ruche" role="ruche"/>
     <object hwrid="/dbconnection" role="dbserver"/>
-    
+
     <normalization_diode>i10-c-c03/dt/xbpm_diode.2</normalization_diode>
 
     <number_of_steps>80</number_of_steps>
@@ -46,7 +46,7 @@
         <element>
             <symbol>Cr</symbol>
             <energy>K</energy>
-        </element>   
+        </element>
         <element>
             <symbol>Mn</symbol>
             <energy>K</energy>
@@ -202,7 +202,7 @@
         <element>
             <symbol>Dy</symbol>
             <energy>L</energy>
-        </element>    
+        </element>
         <element>
             <symbol>Ho</symbol>
             <energy>L</energy>
@@ -214,7 +214,7 @@
         <element>
             <symbol>Tm</symbol>
             <energy>L</energy>
-        </element>    
+        </element>
         <element>
             <symbol>Yb</symbol>
             <energy>L</energy>

--- a/mxcubecore/configuration/soleil_px1/flux.xml
+++ b/mxcubecore/configuration/soleil_px1/flux.xml
@@ -1,6 +1,6 @@
 <object class="ChannelObject">
   <username>flux</username>
-  <tangoname>i10-c-cx1/ex/flux</tangoname> 
+  <tangoname>i10-c-cx1/ex/flux</tangoname>
   <channel type="tango" polling="2000" name="channel">flux</channel>
   <channel type="tango" polling="2000" name="state">State</channel>
 </object>

--- a/mxcubecore/configuration/soleil_px1/ge1350c.xml
+++ b/mxcubecore/configuration/soleil_px1/ge1350c.xml
@@ -1,7 +1,7 @@
 <object class="Qt4_TangoLimaVideo">
   <username>Prosilica Lima</username>
   <type>prosilica</type>
-  <tangoname>i10-c-cx1/ex/imag.2</tangoname> 
+  <tangoname>i10-c-cx1/ex/imag.2</tangoname>
   <encoding>bayer_2_rgb</encoding>
   <!-- encoding>bayer_demosaicing</encoding -->
   <interval>50</interval>

--- a/mxcubecore/configuration/soleil_px1/light.xml
+++ b/mxcubecore/configuration/soleil_px1/light.xml
@@ -7,5 +7,5 @@
   <command type="tango" tangoname="i10-c-cx1/ex/light.1" name="move">move</command>
   <interval>1000</interval>
   <GUIstep>10.</GUIstep>
-  <object role="environment" href="/px1environment" /> 
+  <object role="environment" href="/px1environment" />
 </object>

--- a/mxcubecore/configuration/soleil_px1/minidiff.xml
+++ b/mxcubecore/configuration/soleil_px1/minidiff.xml
@@ -10,7 +10,7 @@
 
   <object role="zoom" hwrid="/zoom"></object>
   <object role="phi" hwrid="/omega"></object>
-  <object role="phiy" hwrid="/uglidex"></object> 
+  <object role="phiy" hwrid="/uglidex"></object>
   <object role="phiz" hwrid="/uglidey"></object>
   <object role="sampx" hwrid="/phiz"></object>
   <object role="sampy" hwrid="/uglidey"></object>

--- a/mxcubecore/configuration/soleil_px1/mxcollect.xml
+++ b/mxcubecore/configuration/soleil_px1/mxcollect.xml
@@ -18,16 +18,16 @@
   <object href="/beam-info" role="beam_info"/>
   <object href="/mach" role="machine_info"/>
   <object href="/resolution" role="resolution"/>
-  <object href="/dbconnection" role="lims_client"/> 
-  <object href="/Qt4_graphics-manager" role="graphics_manager"/> 
-  <object href="/px1environment" role="environment"/> 
+  <object href="/dbconnection" role="lims_client"/>
+  <object href="/Qt4_graphics-manager" role="graphics_manager"/>
+  <object href="/px1environment" role="environment"/>
   <object href="/flux" role="flux"/>
 
-  <object href="/fastshut" role="fastshut"/> 
-  <object href="/obx" role="safshut"/> 
-  <object href="/frontend" role="frontend"/> 
+  <object href="/fastshut" role="fastshut"/>
+  <object href="/obx" role="safshut"/>
+  <object href="/frontend" role="frontend"/>
 
-  <object href="/lightarm" role="lightarm"/> 
+  <object href="/lightarm" role="lightarm"/>
 
   <imgtojpeg>/nfs/ruche/share-dev/px1dev/MXCuBE/tools/adxv_makejpeg.sh</imgtojpeg>
   <chooch_cmd>/nfs/ruche/share-dev/px1dev/MXCuBE/tools/run_chooch.sh</chooch_cmd>

--- a/mxcubecore/configuration/soleil_px1/px1environment.xml
+++ b/mxcubecore/configuration/soleil_px1/px1environment.xml
@@ -1,6 +1,6 @@
 <object class="PX1Environment">
   <username>PX1Environment</username>
-  <tangoname>i10-c-cx1/ex/PX1Environment</tangoname> 
+  <tangoname>i10-c-cx1/ex/PX1Environment</tangoname>
 
   <channel type="tango" polling="events" name="State">State</channel>
   <channel type="tango" polling="events" name="beamlineMvtAuthorized" tangoname="i10-c-cx1/ex/catscryotong">beamlineMvtAuthorized</channel>

--- a/mxcubecore/configuration/soleil_px1/queue-model.xml
+++ b/mxcubecore/configuration/soleil_px1/queue-model.xml
@@ -1,3 +1,3 @@
 <object class="QueueModel" role="QueueModel">
-  <object href="/queue" role="queue"/>    
+  <object href="/queue" role="queue"/>
 </object>

--- a/mxcubecore/configuration/soleil_px1/queue.xml
+++ b/mxcubecore/configuration/soleil_px1/queue.xml
@@ -1,3 +1,3 @@
 <object class="QueueManager" role="Queue">
-  <object href="/beamline-setup" role="beamline_setup"/>    
+  <object href="/beamline-setup" role="beamline_setup"/>
 </object>

--- a/mxcubecore/configuration/soleil_px1/session.xml
+++ b/mxcubecore/configuration/soleil_px1/session.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 
-<object class = "SOLEILSession" role="session">  
+<object class = "SOLEILSession" role="session">
   <object href="/mxlocal" role="config"/>
-    
+
   <synchrotron_name>SOLEIL</synchrotron_name>
   <endstation_name>px1</endstation_name>
   <beamline_name>PROXIMA1</beamline_name>

--- a/mxcubecore/configuration/soleil_px1/xml-rpc-server.xml
+++ b/mxcubecore/configuration/soleil_px1/xml-rpc-server.xml
@@ -2,7 +2,7 @@
   <all_interfaces>
     True
   </all_interfaces>
- 
+
   <port>
     7171
   </port>

--- a/mxcubecore/configuration/soleil_px1/zoom.xml
+++ b/mxcubecore/configuration/soleil_px1/zoom.xml
@@ -3,7 +3,7 @@
 <!-- device class="TangoMotorWPositionsPX2" -->
 <object class="TangoDCMotorWPositions">
     <username>Zoom</username>
-       <tangoname>i10-c-cx1/ex/zoom.1-mt_tz</tangoname> 
+       <tangoname>i10-c-cx1/ex/zoom.1-mt_tz</tangoname>
     <focus>PhiTableXAxisPosition</focus>
     <channel type="tango" polling="1000" name="state">State</channel>
     <channel type="tango" polling="1000" name="position">position</channel>

--- a/mxcubecore/configuration/soleil_px2/beamline-setup.xml
+++ b/mxcubecore/configuration/soleil_px2/beamline-setup.xml
@@ -4,7 +4,7 @@
     <object href="/diffractometer/omega" role="omega_axis"/>
     <object href="/diffractometer/kappa" role="kappa_axis"/>
     <object href="/diffractometer/phi" role="kappa_phi_axis"/>
-    <object href="/singleton_objects/cats" role="sample_changer"/>    
+    <object href="/singleton_objects/cats" role="sample_changer"/>
     <object href="/singleton_motors/resolution" role="resolution"/>
     <object href="/singleton_motors/photon_energy" role="energy"/>
     <object href="/singleton_motors/transmission" role="transmission"/>
@@ -15,7 +15,7 @@
     <object href="/singleton_objects/session" role="session"/>
     <object href="/singleton_objects/dbconnection" role="lims_client"/>
     <object href="/singleton_objects/data-analysis" role="data_analysis"/>
-    
+
     <!-- Procedures and routines -->
     <object href="/mockups/energyscan-mockup" role="energyscan"/>
     <object href="/experimental_methods/diffraction_methods" role="collect"/>

--- a/mxcubecore/configuration/soleil_px2/diffractometer/aperture_diameter.xml
+++ b/mxcubecore/configuration/soleil_px2/diffractometer/aperture_diameter.xml
@@ -1,6 +1,6 @@
 <object class="NamedState">
     <username>Diameter</username>
-    <exporter_address>172.19.10.119:9001</exporter_address>    
+    <exporter_address>172.19.10.119:9001</exporter_address>
     <channel type="exporter" name="state">CurrentApertureDiameterIndex</channel>
     <channel type="exporter" name="hardware_state">State</channel>
     <channel type="exporter" name="statelist">ApertureDiameters</channel>

--- a/mxcubecore/configuration/soleil_px2/diffractometer/diffractometer.xml
+++ b/mxcubecore/configuration/soleil_px2/diffractometer/diffractometer.xml
@@ -32,8 +32,8 @@
     <object href="/singleton_objects/minikappa-correction" role="minikappa_correction"/>
     <object href="/singleton_objects/camera" role="camera"/>
     <object href="/singleton_objects/cats" role="samplechanger"/>
-    
-    <use_sample_changer>True</use_sample_changer> 
+
+    <use_sample_changer>True</use_sample_changer>
     <zoom_centre>{"x": 680,"y": 512}</zoom_centre>
 
     <omega_reference>{"actuator_name": "phiz", "position": -0.121, "camera_axis":"y","direction": -1}</omega_reference>

--- a/mxcubecore/configuration/soleil_px2/diffractometer/exporter/aperture_diameter.xml
+++ b/mxcubecore/configuration/soleil_px2/diffractometer/exporter/aperture_diameter.xml
@@ -1,6 +1,6 @@
 <object class="NamedState">
     <username>Diameter</username>
-    <exporter_address>172.19.10.119:9001</exporter_address>    
+    <exporter_address>172.19.10.119:9001</exporter_address>
     <channel type="exporter" name="state">CurrentApertureDiameterIndex</channel>
     <channel type="exporter" name="hardware_state">State</channel>
     <channel type="exporter" name="statelist">ApertureDiameters</channel>

--- a/mxcubecore/configuration/soleil_px2/diffractometer/exporter/diffractometer.xml
+++ b/mxcubecore/configuration/soleil_px2/diffractometer/exporter/diffractometer.xml
@@ -12,8 +12,8 @@
     <channel type="exporter" name="CapillaryPosition">CapillaryPosition</channel>
     <channel type="exporter" name="TransferMode">TransferMode</channel>
     <channel type="exporter" name="SampleIsLoaded">SampleIsLoaded</channel>
-    
-    
+
+
     <command type="exporter" name="startSetPhase">startSetPhase</command>
     <command type="exporter" name="startAutoFocus">startAutoFocus</command>
     <command type="exporter" name="saveCentringPositions">saveCentringPositions</command>
@@ -34,8 +34,8 @@
     <object href="/singleton_objects/minikappa-correction" role="minikappa_correction"/>
     <object href="/singleton_objects/camera" role="camera"/>
     <object href="/singleton_objects/cats" role="samplechanger"/>
-    
-    <use_sample_changer>True</use_sample_changer> 
+
+    <use_sample_changer>True</use_sample_changer>
     <zoom_centre>{"x": 680,"y": 512}</zoom_centre>
 
     <omega_reference>{"actuator_name": "phiz", "position": -0.121, "camera_axis":"y","direction": -1}</omega_reference>

--- a/mxcubecore/configuration/soleil_px2/diffractometer/tango_events/diffractometer.xml
+++ b/mxcubecore/configuration/soleil_px2/diffractometer/tango_events/diffractometer.xml
@@ -29,8 +29,8 @@
     <object href="/singleton_objects/minikappa-correction" role="minikappa_correction"/>
     <object href="/singleton_objects/camera" role="camera"/>
     <object href="/singleton_objects/cats" role="samplechanger"/>
-    
-    <use_sample_changer>True</use_sample_changer> 
+
+    <use_sample_changer>True</use_sample_changer>
     <zoom_centre>{"x": 680,"y": 512}</zoom_centre>
 
     <omega_reference>{"actuator_name": "phiz", "position": -0.121, "camera_axis":"y","direction": -1}</omega_reference>

--- a/mxcubecore/configuration/soleil_px2/diffractometer/tango_polling/diffractometer.xml
+++ b/mxcubecore/configuration/soleil_px2/diffractometer/tango_polling/diffractometer.xml
@@ -29,8 +29,8 @@
     <object href="/singleton_objects/minikappa-correction" role="minikappa_correction"/>
     <object href="/singleton_objects/camera" role="camera"/>
     <object href="/singleton_objects/cats" role="samplechanger"/>
-    
-    <use_sample_changer>True</use_sample_changer> 
+
+    <use_sample_changer>True</use_sample_changer>
     <zoom_centre>{"x": 680,"y": 512}</zoom_centre>
 
     <omega_reference>{"actuator_name": "phiz", "position": -0.121, "camera_axis":"y","direction": -1}</omega_reference>


### PR DESCRIPTION
Use the `trailing-whitespace` pre-commit hook to remove trailing empty spaces in files. Only the following file extensions are excluded from this rule:
* `.hkli`
* `.nml`
* `.XDS`