### PR TITLE
Enable Ruff's fix feature in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     rev: v0.9.6
     hooks:
       - id: ruff
-      # TODO: args: [--fix]
+        args: [--fix]
       - id: ruff-format
 
 


### PR DESCRIPTION
This was disabled by mistake in this commit: ed895b1b06a89e799bf072450d3140b9097f2c7a

GitHub: related to <https://github.com/mxcube/mxcubecore/pull/1152>