### PR TITLE
Added get_samples function to retrieve the acronym

### DIFF
--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -21,6 +21,7 @@ from mxcubecore.HardwareObjects.abstract.AbstractLims import AbstractLims
 from mxcubecore.model.lims_session import (
     Lims,
     LimsSessionManager,
+    SampleSheet,
     Session,
 )
 
@@ -128,6 +129,9 @@ class ICATLIMS(AbstractLims):
                 lims_name,
             )
             parcels = self.get_parcels_by_investigation_id()
+
+            sample_sheets = self.get_samples_sheets()
+
             queue_samples = []
             for parcel in parcels:
                 pucks = parcel["content"]
@@ -150,7 +154,7 @@ class ICATLIMS(AbstractLims):
                         )
                         for tracking_sample in tracking_samples:
                             queue_samples.append(
-                                self.__to_sample(tracking_sample, puck)
+                                self.__to_sample(tracking_sample, puck, sample_sheets)
                             )
 
         except Exception as e:
@@ -169,8 +173,28 @@ class ICATLIMS(AbstractLims):
                 return x["value"]
         return ""
 
-    def __to_sample(self, tracking_sample, puck):
+    def get_sample_sheet_by_id(self, samples: List[SampleSheet], sample_id: int) -> Optional[SampleSheet]:
+        """
+        Retrieves a sample by its unique ID.
+
+        Args:
+            samples (List[Sample]): A list of Sample objects.
+            sample_id (int): The unique identifier of the sample to retrieve.
+
+        Returns:
+            Optional[Sample]: The Sample object if found, otherwise None.
+        """
+        return next((sample for sample in samples if sample.id == sample_id), None)
+
+    def __to_sample(self, tracking_sample, puck, sample_sheets: List[SampleSheet]):
         """Converts the sample tracking into the expected sample data structure"""
+
+        sample_name = str(tracking_sample["name"])
+        protein_acronym = sample_name
+        sample_sheet = self.get_sample_sheet_by_id(sample_sheets, tracking_sample["sampleId"])
+        if sample_sheet is not None:
+            protein_acronym = sample_sheet.name
+
         experiment_plan = tracking_sample["experimentPlan"]
         return {
             "cellA": self.find(experiment_plan, "unit_cell_a"),
@@ -201,10 +225,10 @@ class ICATLIMS(AbstractLims):
                 "requiredResolution": self.find(experiment_plan, "requiredResolution"),
             },
             "experimentType": self.find(experiment_plan, "workflowType"),
-            "proteinAcronym": tracking_sample["name"],
+            "proteinAcronym": protein_acronym,
             "sampleId": tracking_sample["sampleId"],
             "sampleLocation": tracking_sample["sampleContainerPosition"],
-            "sampleName": str(tracking_sample["name"]),
+            "sampleName": sample_name,
             "smiles": None,
         }
 
@@ -519,6 +543,29 @@ class ICATLIMS(AbstractLims):
             )
         return []
 
+    def get_samples_sheets(self) -> List[SampleSheet]:
+        """Returns the samples associated to an investigation"""
+        try:
+            logging.getLogger("HWR").debug(
+                "[ICAT] Retrieving samples by investigation_id %s "
+                % (self.session_manager.active_session.session_id)
+            )
+            samples = self.icatClient.get_samples_by(
+                self.session_manager.active_session.session_id
+            )
+            logging.getLogger("HWR").debug(
+                "[ICAT] Successfully retrieved %s samples" % (len(samples))
+            )
+            # Convert to object
+            sample_sheets = [SampleSheet.parse_obj(sample) for sample in samples]
+
+            return sample_sheets
+        except Exception as e:
+            logging.getLogger("HWR").error(
+                "[ICAT] get_samples_by_investigation_id %s " % (str(e))
+            )
+        return []
+
     def echo(self):
         """Mockup for the echo method."""
         return True
@@ -731,9 +778,9 @@ class ICATLIMS(AbstractLims):
 
             # This forces the ingester to associate the dataset to the experiment by ID
             if self.session_manager.active_session.session_id:
-                metadata["investigationId"] = (
-                    self.session_manager.active_session.session_id
-                )
+                metadata[
+                    "investigationId"
+                ] = self.session_manager.active_session.session_id
 
             # Store metadata on disk
             self.add_sample_metadata(metadata, collection_parameters)

--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -128,7 +128,7 @@ class ICATLIMS(AbstractLims):
                 self.session_manager.active_session.proposal_name,
                 lims_name,
             )
-            parcels = self.get_parcels_by_investigation_id()
+            parcels = self.get_parcels()
 
             sample_sheets = self.get_samples_sheets()
 
@@ -523,7 +523,7 @@ class ICATLIMS(AbstractLims):
     def to_sessions(self, investigations):
         return [self.__to_session(investigation) for investigation in investigations]
 
-    def get_parcels_by_investigation_id(self):
+    def get_parcels(self):
         """Returns the parcels associated to an investigation"""
         try:
             logging.getLogger("HWR").debug(
@@ -533,6 +533,7 @@ class ICATLIMS(AbstractLims):
             parcels = self.icatClient.get_parcels_by(
                 self.session_manager.active_session.session_id
             )
+            print(parcels[0])
             logging.getLogger("HWR").debug(
                 "[ICAT] Successfully retrieved %s parcels" % (len(parcels))
             )

--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -781,9 +781,9 @@ class ICATLIMS(AbstractLims):
 
             # This forces the ingester to associate the dataset to the experiment by ID
             if self.session_manager.active_session.session_id:
-                metadata["investigationId"] = (
-                    self.session_manager.active_session.session_id
-                )
+                metadata[
+                    "investigationId"
+                ] = self.session_manager.active_session.session_id
 
             # Store metadata on disk
             self.add_sample_metadata(metadata, collection_parameters)

--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -173,13 +173,15 @@ class ICATLIMS(AbstractLims):
                 return x["value"]
         return ""
 
-    def get_sample_sheet_by_id(self, samples: List[SampleSheet], sample_id: int) -> Optional[SampleSheet]:
+    def get_sample_sheet_by_id(
+        self, samples: List[SampleSheet], sample_id: int
+    ) -> Optional[SampleSheet]:
         """
-        Retrieves a sample by its unique ID.
+        Retrieves a sample sheet by its unique ID.
 
         Args:
-            samples (List[Sample]): A list of Sample objects.
-            sample_id (int): The unique identifier of the sample to retrieve.
+            samples (List[SampleSheet]): A list of Sample objects.
+            sample_id (int): The unique identifier of the sample sheet to retrieve.
 
         Returns:
             Optional[Sample]: The Sample object if found, otherwise None.
@@ -191,7 +193,9 @@ class ICATLIMS(AbstractLims):
 
         sample_name = str(tracking_sample["name"])
         protein_acronym = sample_name
-        sample_sheet = self.get_sample_sheet_by_id(sample_sheets, tracking_sample["sampleId"])
+        sample_sheet = self.get_sample_sheet_by_id(
+            sample_sheets, tracking_sample["sampleId"]
+        )
         if sample_sheet is not None:
             protein_acronym = sample_sheet.name
 
@@ -533,7 +537,7 @@ class ICATLIMS(AbstractLims):
             parcels = self.icatClient.get_parcels_by(
                 self.session_manager.active_session.session_id
             )
-            print(parcels[0])
+
             logging.getLogger("HWR").debug(
                 "[ICAT] Successfully retrieved %s parcels" % (len(parcels))
             )
@@ -545,7 +549,7 @@ class ICATLIMS(AbstractLims):
         return []
 
     def get_samples_sheets(self) -> List[SampleSheet]:
-        """Returns the samples associated to an investigation"""
+        """Returns the samples sheets associated to an investigation"""
         try:
             logging.getLogger("HWR").debug(
                 "[ICAT] Retrieving samples by investigation_id %s "
@@ -558,9 +562,7 @@ class ICATLIMS(AbstractLims):
                 "[ICAT] Successfully retrieved %s samples" % (len(samples))
             )
             # Convert to object
-            sample_sheets = [SampleSheet.parse_obj(sample) for sample in samples]
-
-            return sample_sheets
+            return [SampleSheet.parse_obj(sample) for sample in samples]
         except Exception as e:
             logging.getLogger("HWR").error(
                 "[ICAT] get_samples_by_investigation_id %s " % (str(e))
@@ -779,9 +781,9 @@ class ICATLIMS(AbstractLims):
 
             # This forces the ingester to associate the dataset to the experiment by ID
             if self.session_manager.active_session.session_id:
-                metadata[
-                    "investigationId"
-                ] = self.session_manager.active_session.session_id
+                metadata["investigationId"] = (
+                    self.session_manager.active_session.session_id
+                )
 
             # Store metadata on disk
             self.add_sample_metadata(metadata, collection_parameters)

--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -781,9 +781,9 @@ class ICATLIMS(AbstractLims):
 
             # This forces the ingester to associate the dataset to the experiment by ID
             if self.session_manager.active_session.session_id:
-                metadata[
-                    "investigationId"
-                ] = self.session_manager.active_session.session_id
+                metadata["investigationId"] = (
+                    self.session_manager.active_session.session_id
+                )
 
             # Store metadata on disk
             self.add_sample_metadata(metadata, collection_parameters)

--- a/mxcubecore/model/lims_session.py
+++ b/mxcubecore/model/lims_session.py
@@ -3,6 +3,7 @@ from datetime import (
     timedelta,
 )
 from typing import (
+    Any,
     Dict,
     List,
     Optional,
@@ -74,6 +75,43 @@ class Session(BaseModel):
     sample_count: Optional[str] = None
 
 
+class Instrument(BaseModel):
+    name: str
+    id: int
+    instrumentScientists: List[Any]
+
+
+class Investigation(BaseModel):
+    name: str
+    startDate: datetime
+    endDate: datetime
+    id: int
+    title: str
+    visitId: str
+    summary: str
+    parameters: Dict[str, Any]
+    instrument: Instrument
+    investigationUsers: List[Any]
+
+
+class Parameter(BaseModel):
+    name: str
+    value: str
+    id: int
+    units: str
+
+
+class MetaPage(BaseModel):
+    totalWithoutFilters: int
+    total: int
+    totalPages: int
+    currentPage: int
+
+
+class Meta(BaseModel):
+    page: MetaPage
+
+
 class LimsUser(BaseModel):
     user_name: str = ""
     sessions: Optional[List[Session]] = []
@@ -83,3 +121,13 @@ class LimsSessionManager(BaseModel):
     active_session: Optional[Session] = None
     sessions: Optional[List[Session]] = []
     users: Optional[Dict[str, LimsUser]] = {}
+
+
+class SampleSheet(BaseModel):
+    id: int
+    name: str
+    investigation: Investigation
+    modTime: datetime
+    parameters: List[Parameter]
+    datasets: List[Any]
+    meta: Meta

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,14 +26,14 @@ files = [
 
 [[package]]
 name = "anyio"
-version = "4.8.0"
+version = "4.9.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "anyio-4.8.0-py3-none-any.whl", hash = "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a"},
-    {file = "anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a"},
+    {file = "anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c"},
+    {file = "anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028"},
 ]
 
 [package.dependencies]
@@ -43,8 +43,8 @@ sniffio = ">=1.1"
 typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
-doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
-test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21)"]
+doc = ["Sphinx (>=8.2,<9.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
+test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21)"]
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
@@ -1958,13 +1958,13 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pyicat-plus"
-version = "0.5.1"
+version = "0.6.0"
 description = "Python client to ICAT+"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "pyicat_plus-0.5.1.tar.gz", hash = "sha256:2875c35352e3315e1b2d51bc98850b76c5df09cea0032955cbb69520ff87cfc5"},
+    {file = "pyicat_plus-0.6.0.tar.gz", hash = "sha256:3b727b4b227c789ea629ca52a6cab745e692611b13c49ce0a58b0a5582d918a6"},
 ]
 
 [package.dependencies]
@@ -2649,14 +2649,14 @@ test = ["pytest"]
 
 [[package]]
 name = "starlette"
-version = "0.46.0"
+version = "0.46.1"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "starlette-0.46.0-py3-none-any.whl", hash = "sha256:913f0798bd90ba90a9156383bcf1350a17d6259451d0d8ee27fc0cf2db609038"},
-    {file = "starlette-0.46.0.tar.gz", hash = "sha256:b359e4567456b28d473d0193f34c0de0ed49710d75ef183a74a5ce0499324f50"},
+    {file = "starlette-0.46.1-py3-none-any.whl", hash = "sha256:77c74ed9d2720138b25875133f3a2dae6d854af2ec37dceb56aef370c1d8a227"},
+    {file = "starlette-0.46.1.tar.gz", hash = "sha256:3c88d58ee4bd1bb807c0d1acb381838afc7752f9ddaec81bbe4383611d833230"},
 ]
 
 [package.dependencies]
@@ -2948,4 +2948,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "30d71eddffb1456b2c708e38e64e24e68f69d4525a6971594cbfe0cff153de83"
+content-hash = "0d0c85f6cb654fe1a82673579b6dd2022b8e8bd09acc776e01f561150aac1382"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ PyTango = "^9.3.6"
 python-ldap = "^3.4.0"
 requests = "^2.31.0"
 colorama = "^0.4.6"
-pyicat-plus = {version = "^0.5.1", optional = true}
+pyicat-plus = {version = "^0.6.0", optional = true}
 mxcube-video-streamer = ">=1.8.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
The acronym is a mandatory parameter for each sample, as it is frequently used when creating the final target folder.
However, it is not retrieved when downloading the puck information, so a second request is made to obtain the sample (or sample sheets) by investigation.

This PR proposes to retrieve such information when the synchronization is triggered as well as a new model has been added to: `model/lims_session`

I wonder if this file should be renamed (to `lims` if it groups all models for the lims) or refactored in smaller bits