### PR TITLE
Updates some tests to work with YAML

### DIFF
--- a/test/pytest/test_hwo_maxiv_ispyblims.py
+++ b/test/pytest/test_hwo_maxiv_ispyblims.py
@@ -32,8 +32,10 @@ def ispyb_lims(_suds_mock, _hwr_mock, hwr_mock):
     from mxcubecore.HardwareObjects.MAXIV.ISPyBLims import ISPyBLims
 
     lims = ISPyBLims(name="dummy")
-    lims.set_property("ws_root", "http://example.com/tstWS/")
-    lims.set_property("rest_root", REST_ROOT)
+    lims._config = lims.HOConfig(  # noqa: SLF001
+        ws_root="http://example.com/tstWS/",
+        rest_root=REST_ROOT,
+    )
     lims.init()
 
     return lims

--- a/test/pytest/test_hwo_tango_shutter.py
+++ b/test/pytest/test_hwo_tango_shutter.py
@@ -52,7 +52,9 @@ def shutter():
     #
     hwo_shutter = TangoShutter.TangoShutter("/random_name")
     hwo_shutter.tangoname = tangods_test_context.get_device_access()
-    hwo_shutter.set_property("values", TANGO_SHUTTER_STATES_MAPPING)
+    hwo_shutter._config = hwo_shutter.HOConfig(  # noqa: SLF001
+        values=TANGO_SHUTTER_STATES_MAPPING,
+    )
     hwo_shutter.add_channel(
         {
             "name": "State",


### PR DESCRIPTION
Updates `MAXIV.ISPyBLims` and `TangoShutter` to work with the new YAML code.

Rreplaces calls to `set_property()` in test fixtures, with `HOConfig` object creation.