### PR TITLE
Added inline documentation

### DIFF
--- a/mxcubecore/model/lims_session.py
+++ b/mxcubecore/model/lims_session.py
@@ -16,97 +16,115 @@ from pydantic.v1 import (
 
 
 class Proposal(BaseModel):
-    """Represents a proposal with key identifying details."""
+    """Proposal with key identifying details.
 
-    proposal_id: str = ""  # Unique identifier for the proposal
-    person_id: str = ""  # Identifier of the person associated
-    type: str = ""  # Type/category of the proposal (e.g., "MX")
-    code: str = ""  # Specific code associated with the proposal e.g., "IH-LS"
-    # Proposal number; may be sequential or unique (uniqueness may depend on
-    # the combination of `code` and `number`)
+    Attributes:
+        proposal_id: Unique identifier for the proposal.
+        person_id: Identifier of the person associated.
+        type: Type/category of the proposal (e.g., "MX").
+        code: Specific code associated with the proposal e.g., "IH-LS".
+        number: Proposal number; may be sequential or unique
+            (uniqueness may depend on the combination of code and number)
+    """
+
+    proposal_id: str = ""
+    person_id: str = ""
+    type: str = ""
+    code: str = ""
     number: str = ""
     title: str = ""  # Title of the proposal
 
 
 class Lims(BaseModel):
-    """Represents a LIMS system"""
+    """Represents a LIMS system.
 
-    name: str = ""  # Unique identifier for the LIMS (e.g: ispyb, icat, ...)
-    description: str = ""  # Free text with a short description
+    Attributes:
+        name: Unique identifier for the LIMS (e.g., "ispyb", "icat").
+        description: Free text providing a short description of the LIMS.
+    """
+
+    name: str = ""
+    description: str = ""
 
 
 class Session(BaseModel):
-    """Represents a experiment in a specific time slot in a beamline
-    for a proposal
-    This class has been kept more or less as-it-is for legacy purposes
-    because ISPyB rely on it
+    """Represents an experiment in a specific time slot on a beamline for a proposal.
+
+    This class is maintained for legacy purposes because ISPyB relies on it.
+
+    Attributes:
+        session_id: Unique identifier for the experiment, dependent on the LIMS.
+        beamline_name: Name of the beamline where the experiment is scheduled.
+        start_date: Official start date (format: YYYYMMDD).
+        start_time: Official start time.
+        end_date: Official end date (format: YYYYMMDD).
+        end_time: Official end time.
+        title: Title of the proposal associated with the session.
+        code: Code associated with the proposal.
+        number: Proposal number.
+        proposal_id: Unique identifier of the proposal.
+        proposal_name: Name of the proposal.
+        comments: Optional comments about the session.
+        start_datetime: Start datetime of the session.
+        end_datetime: End datetime of the session, defaulting to one day after start.
+        actual_start_date: Start date if the session was rescheduled.
+        actual_start_time: Start time if the session was rescheduled.
+        actual_end_date: End date if the session was rescheduled.
+        actual_end_time: End time if the session was rescheduled.
+        nb_shifts: Number of shifts allocated to the session (typically 8 hours per shift).
+        scheduled: Indicates if the session is officially scheduled and approved.
+        is_rescheduled: Indicates if the session was rescheduled in time or beamline.
+        is_scheduled_beamline: Indicates if the session is scheduled on the current beamline.
+        is_scheduled_time: Indicates if the session is currently active.
+        user_portal_URL: Optional link to the session page in the User Portal.
+        data_portal_URL: Optional link to the session page in the data portal or LIMS.
+        logbook_URL: Optional link to the session page in the electronic logbook.
+        volume: Optional volume (in bytes) of data produced.
+        dataset_count: Optional number of datasets collected.
+        sample_count: Optional number of samples collected.
     """
 
-    session_id: str = (
-        ""  # Unique identifier for the experiment (it's dependent of the LIMS)
-    )
-    beamline_name: str = ""  # Beamline where the experiment is scheduled
-    start_date: str = ""  # The official start date. Format: YYYYMDD
+    session_id: str = ""
+    beamline_name: str = ""
+    start_date: str = ""
     start_time: str = ""
-    end_date: str = ""  # The official end date. Format: YYYYMDD
+    end_date: str = ""
     end_time: str = ""
-
-    # Proposal information. It is kept for legacy purpose but it
-    # should be replaced by the Proposal object
     title: str = ""
     code: str = ""
     number: str = ""
     proposal_id: str = ""
     proposal_name: str = ""
-
     comments: Optional[str] = ""
-
     start_datetime: datetime = Field(default_factory=datetime.now)
     end_datetime: Optional[datetime] = Field(
         default_factory=lambda: datetime.now() + timedelta(days=1)
     )
-
-    # Actual start and end date is used when a session is "moved" in time.
-    # Example: data is collected before or after it was originally scheduled
-    actual_start_date: str = (
-        ""  # Start date of a session that has been rescheduled time-wise
-    )
+    actual_start_date: str = ""
     actual_start_time: str = ""
     actual_end_date: str = ""
     actual_end_time: str = ""
-
-    nb_shifts: str = (
-        ""  # Number of shifts allocated to a session.
-        # A shift is typically 8 hours, though this may vary.
-    )
-    scheduled: str = (
-        ""  # True if the session has been officialiy scheduled and approved
-    )
-
-    is_rescheduled: bool = (
-        False  # if the session has been rescheduled in terms of time/beamline.
-    )
-    is_scheduled_beamline: bool = (
-        False  # if the session is scheduled in the current beamline
-    )
-    is_scheduled_time: bool = False  # True if the session is currently active
-
-    # direct links to different services
-    user_portal_URL: Optional[str] = None  # Link to the session page in the UP
-    data_portal_URL: Optional[str] = (
-        None  # Link to the session page in the data portal or lims
-    )
-    logbook_URL: Optional[str] = (
-        None  # Link to the session page in the electronic logbook
-    )
-
-    volume: Optional[str] = None  # Volume (bytes) of data produced
-    dataset_count: Optional[str] = None  # Number of datasets collected
-    sample_count: Optional[str] = None  # Number of samples collected
+    nb_shifts: str = ""
+    scheduled: str = ""
+    is_rescheduled: bool = False
+    is_scheduled_beamline: bool = False
+    is_scheduled_time: bool = False
+    user_portal_URL: Optional[str] = None
+    data_portal_URL: Optional[str] = None
+    logbook_URL: Optional[str] = None
+    volume: Optional[str] = None
+    dataset_count: Optional[str] = None
+    sample_count: Optional[str] = None
 
 
 class Instrument(BaseModel):
-    """This class represents a beamline"""
+    """Represents a beamline.
+
+    Attributes:
+        name: Name of the beamline.
+        id: Unique identifier of the beamline.
+        instrumentScientists: List of scientists associated with the instrument.
+    """
 
     name: str
     id: int
@@ -114,8 +132,20 @@ class Instrument(BaseModel):
 
 
 class Investigation(BaseModel):
-    """This class represents a investigation and is a proposal
-    to replace the session class"""
+    """Represents an investigation and serves as a proposal to replace the Session class.
+
+    Attributes:
+        name: Name of the investigation.
+        startDate: Start date of the investigation.
+        endDate: End date of the investigation.
+        id: Unique identifier of the investigation.
+        title: Title of the investigation.
+        visitId: Identifier for the visit associated with the investigation.
+        summary: Summary description of the investigation.
+        parameters: Dictionary of investigation-specific parameters.
+        instrument: Associated instrument for the investigation.
+        investigationUsers: List of users involved in the investigation.
+    """
 
     name: str
     startDate: datetime
@@ -130,16 +160,31 @@ class Investigation(BaseModel):
 
 
 class Parameter(BaseModel):
-    """Generic reprentation of a parameter atached to any entity like
-    investigation, sample, dataset."""
+    """Represents a generic parameter attached to entities like investigations, samples, or datasets.
 
-    name: str  # name of the parameter
-    value: str  # its value
-    id: int  # identifier of the parameter
-    units: str  # units if any
+    Attributes:
+        name: Name of the parameter.
+        value: Value assigned to the parameter.
+        id: Unique identifier of the parameter.
+        units: Measurement units, if applicable.
+    """
+
+    name: str
+    value: str
+    id: int
+    units: str
 
 
 class MetaPage(BaseModel):
+    """Pagination metadata.
+
+    Attributes:
+        totalWithoutFilters: Total count of items without filters applied.
+        total: Total count of items with filters applied.
+        totalPages: Total number of pages available.
+        currentPage: Current page number.
+    """
+
     totalWithoutFilters: int
     total: int
     totalPages: int
@@ -147,38 +192,58 @@ class MetaPage(BaseModel):
 
 
 class Meta(BaseModel):
+    """Metadata containing pagination details.
+
+    Attributes:
+        page: Pagination details.
+    """
+
     page: MetaPage
 
 
 class LimsUser(BaseModel):
-    """Represents and users that is connected to MXCuBE"""
+    """Represents a user connected to MXCuBE.
 
-    user_name: str = ""  # identifier of the users, most likely login name
-    sessions: Optional[
-        List[Session]
-    ] = []  # The sessions that the user is allowed to collect data from.
+    Attributes:
+        user_name: Identifier for the user, typically their login name.
+        sessions: List of sessions the user is allowed to collect data from.
+    """
+
+    user_name: str = ""
+    sessions: Optional[List[Session]] = []
 
 
 class LimsSessionManager(BaseModel):
-    active_session: Optional[Session] = None  # the current active sessions
-    sessions: Optional[
-        List[Session]
-    ] = []  # Selectable sessions that are calculated based on the connected users
-    users: Optional[
-        Dict[str, LimsUser]
-    ] = {}  # the list of users that are currently connected
+    """Manages LIMS sessions and connected users.
+
+    Attributes:
+        active_session: The current active session, if any.
+        sessions: List of selectable sessions determined based on connected users.
+        users: Dictionary of currently connected users.
+    """
+
+    active_session: Optional[Session] = None
+    sessions: Optional[List[Session]] = []
+    users: Optional[Dict[str, LimsUser]] = {}
 
 
 class SampleSheet(BaseModel):
-    """Represents a description of the sample sheet as defined on
-    some user portals"""
+    """Represents a description of a sample sheet as defined in user portals.
+
+    Attributes:
+        id: Unique identifier for the sample sheet.
+        name: Name of the sample sheet, often corresponding to the protein's name.
+        investigation: Investigation associated with the sample sheet.
+        modTime: Last modification time of the sample sheet.
+        parameters: Generic list of parameters, dependent on the user portal.
+        datasets: List of datasets collected for this sample.
+        meta: Pagination metadata.
+    """
 
     id: int
-    name: str  # Name of the samplesheet that use to correspond to the protein's name
+    name: str
     investigation: Investigation
     modTime: datetime
-    parameters: List[
-        Parameter
-    ]  # Generic list of parameters that will depend on the user portal
-    datasets: List[Any]  # datasets collected for this sample
-    meta: Meta  # pagination parameters
+    parameters: List[Parameter]
+    datasets: List[Any]
+    meta: Meta

--- a/mxcubecore/model/lims_session.py
+++ b/mxcubecore/model/lims_session.py
@@ -18,7 +18,7 @@ from pydantic.v1 import (
 class Proposal(BaseModel):
     """Proposal with key identifying details.
 
-    Attributes:
+    Parameters:
         proposal_id: Unique identifier for the proposal.
         person_id: Identifier of the person associated.
         type: Type/category of the proposal (e.g., "MX").
@@ -39,7 +39,7 @@ class Proposal(BaseModel):
 class Lims(BaseModel):
     """Represents a LIMS system.
 
-    Attributes:
+    Parameters:
         name: Unique identifier for the LIMS (e.g., "ispyb", "icat").
         description: Free text providing a short description of the LIMS.
     """
@@ -53,7 +53,7 @@ class Session(BaseModel):
 
     This class is maintained for legacy purposes because ISPyB relies on it.
 
-    Attributes:
+    Parameters:
         session_id: Unique identifier for the experiment, dependent on the LIMS.
         beamline_name: Name of the beamline where the experiment is scheduled.
         start_date: Official start date (format: YYYYMMDD).
@@ -121,7 +121,7 @@ class Session(BaseModel):
 class Instrument(BaseModel):
     """Represents a beamline.
 
-    Attributes:
+    Parameters:
         name: Name of the beamline.
         id: Unique identifier of the beamline.
         instrumentScientists: List of scientists associated with the instrument.
@@ -136,7 +136,7 @@ class Investigation(BaseModel):
     """Represents an investigation and serves as a proposal to replace
     the Session class.
 
-    Attributes:
+    Parameters:
         name: Name of the investigation.
         startDate: Start date of the investigation.
         endDate: End date of the investigation.
@@ -165,7 +165,7 @@ class Parameter(BaseModel):
     """Represents a generic parameter attached to entities like investigations,
     samples, or datasets.
 
-    Attributes:
+    Parameters:
         name: Name of the parameter.
         value: Value assigned to the parameter.
         id: Unique identifier of the parameter.
@@ -181,7 +181,7 @@ class Parameter(BaseModel):
 class MetaPage(BaseModel):
     """Pagination metadata.
 
-    Attributes:
+    Parameters:
         totalWithoutFilters: Total count of items without filters applied.
         total: Total count of items with filters applied.
         totalPages: Total number of pages available.
@@ -197,7 +197,7 @@ class MetaPage(BaseModel):
 class Meta(BaseModel):
     """Metadata containing pagination details.
 
-    Attributes:
+    Parameters:
         page: Pagination details.
     """
 
@@ -207,7 +207,7 @@ class Meta(BaseModel):
 class LimsUser(BaseModel):
     """Represents a user connected to MXCuBE.
 
-    Attributes:
+    Parameters:
         user_name: Identifier for the user, typically their login name.
         sessions: List of sessions the user is allowed to collect data from.
     """
@@ -219,7 +219,7 @@ class LimsUser(BaseModel):
 class LimsSessionManager(BaseModel):
     """Manages LIMS sessions and connected users.
 
-    Attributes:
+    Parameters:
         active_session: The current active session, if any.
         sessions: List of selectable sessions determined based on connected users.
         users: Dictionary of currently connected users.
@@ -233,7 +233,7 @@ class LimsSessionManager(BaseModel):
 class SampleSheet(BaseModel):
     """Represents a description of a sample sheet as defined in user portals.
 
-    Attributes:
+    Parameters:
         id: Unique identifier for the sample sheet.
         name: Name of the sample sheet, often corresponding to the protein's name.
         investigation: Investigation associated with the sample sheet.

--- a/mxcubecore/model/lims_session.py
+++ b/mxcubecore/model/lims_session.py
@@ -67,19 +67,19 @@ class Session(BaseModel):
         proposal_name: Name of the proposal.
         comments: Optional comments about the session.
         start_datetime: Start datetime of the session.
-        end_datetime: End datetime of the session, defaulting to one day after start.
+        end_datetime: End datetime of the session
         actual_start_date: Start date if the session was rescheduled.
         actual_start_time: Start time if the session was rescheduled.
         actual_end_date: End date if the session was rescheduled.
         actual_end_time: End time if the session was rescheduled.
-        nb_shifts: Number of shifts allocated to the session (typically 8 hours per shift).
-        scheduled: Indicates if the session is officially scheduled and approved.
-        is_rescheduled: Indicates if the session was rescheduled in time or beamline.
-        is_scheduled_beamline: Indicates if the session is scheduled on the current beamline.
-        is_scheduled_time: Indicates if the session is currently active.
+        nb_shifts: Number of shifts allocated to the session (typically 8h)
+        scheduled: if the session is officially scheduled and approved.
+        is_rescheduled: if the session was rescheduled in time or beamline.
+        is_scheduled_beamline: if the session is scheduled on the current bm
+        is_scheduled_time: if the session is currently active.
         user_portal_URL: Optional link to the session page in the User Portal.
-        data_portal_URL: Optional link to the session page in the data portal or LIMS.
-        logbook_URL: Optional link to the session page in the electronic logbook.
+        data_portal_URL: link to the data portal or LIMS.
+        logbook_URL: Optional link to the session page in the  logbook.
         volume: Optional volume (in bytes) of data produced.
         dataset_count: Optional number of datasets collected.
         sample_count: Optional number of samples collected.
@@ -133,7 +133,8 @@ class Instrument(BaseModel):
 
 
 class Investigation(BaseModel):
-    """Represents an investigation and serves as a proposal to replace the Session class.
+    """Represents an investigation and serves as a proposal to replace
+    the Session class.
 
     Attributes:
         name: Name of the investigation.
@@ -161,7 +162,8 @@ class Investigation(BaseModel):
 
 
 class Parameter(BaseModel):
-    """Represents a generic parameter attached to entities like investigations, samples, or datasets.
+    """Represents a generic parameter attached to entities like investigations,
+    samples, or datasets.
 
     Attributes:
         name: Name of the parameter.

--- a/mxcubecore/model/lims_session.py
+++ b/mxcubecore/model/lims_session.py
@@ -16,28 +16,43 @@ from pydantic.v1 import (
 
 
 class Proposal(BaseModel):
-    proposal_id: str = ""
-    person_id: str = ""
-    type: str = ""
-    code: str = ""
+    """Represents a proposal with key identifying details."""
+
+    proposal_id: str = ""  # Unique identifier for the proposal
+    person_id: str = ""  # Identifier of the person associated
+    type: str = ""  # Type/category of the proposal (e.g., "MX")
+    code: str = ""  # Specific code associated with the proposal e.g., "IH-LS"
+    # Proposal number; may be sequential or unique (uniqueness may depend on
+    # the combination of `code` and `number`)
     number: str = ""
-    title: str = ""
+    title: str = ""  # Title of the proposal
 
 
 class Lims(BaseModel):
-    name: str = ""
-    description: str = ""
+    """Represents a LIMS system"""
+
+    name: str = ""  # Unique identifier for the LIMS (e.g: ispyb, icat, ...)
+    description: str = ""  # Free text with a short description
 
 
 class Session(BaseModel):
-    session_id: str = ""
-    beamline_name: str = ""
-    start_date: str = ""  # YYYYMDD
+    """Represents a experiment in a specific time slot in a beamline
+    for a proposal
+    This class has been kept more or less as-it-is for legacy purposes
+    because ISPyB rely on it
+    """
+
+    session_id: str = (
+        ""  # Unique identifier for the experiment (it's dependent of the LIMS)
+    )
+    beamline_name: str = ""  # Beamline where the experiment is scheduled
+    start_date: str = ""  # The official start date. Format: YYYYMDD
     start_time: str = ""
-    end_date: str = ""  # YYYYMDD
+    end_date: str = ""  # The official end date. Format: YYYYMDD
     end_time: str = ""
 
-    # Proposal information
+    # Proposal information. It is kept for legacy purpose but it
+    # should be replaced by the Proposal object
     title: str = ""
     code: str = ""
     number: str = ""
@@ -51,37 +66,57 @@ class Session(BaseModel):
         default_factory=lambda: datetime.now() + timedelta(days=1)
     )
 
-    # If rescheduled the actual dates are used instead
-    actual_start_date: str = ""
+    # Actual start and end date is used when a session is "moved" in time.
+    # Example: data is collected before or after it was originally scheduled
+    actual_start_date: str = (
+        ""  # Start date of a session that has been rescheduled time-wise
+    )
     actual_start_time: str = ""
     actual_end_date: str = ""
     actual_end_time: str = ""
 
-    nb_shifts: str = ""
-    scheduled: str = ""
+    nb_shifts: str = (
+        ""  # Number of shifts allocated to a session.
+        # A shift is typically 8 hours, though this may vary.
+    )
+    scheduled: str = (
+        ""  # True if the session has been officialiy scheduled and approved
+    )
 
-    # status of the session depending on wether it has been rescheduled or moved
-    is_rescheduled: bool = False
-    is_scheduled_time: bool = False
-    is_scheduled_beamline: bool = False
+    is_rescheduled: bool = (
+        False  # if the session has been rescheduled in terms of time/beamline.
+    )
+    is_scheduled_beamline: bool = (
+        False  # if the session is scheduled in the current beamline
+    )
+    is_scheduled_time: bool = False  # True if the session is currently active
 
     # direct links to different services
-    user_portal_URL: Optional[str] = None
-    data_portal_URL: Optional[str] = None
-    logbook_URL: Optional[str] = None
+    user_portal_URL: Optional[str] = None  # Link to the session page in the UP
+    data_portal_URL: Optional[str] = (
+        None  # Link to the session page in the data portal or lims
+    )
+    logbook_URL: Optional[str] = (
+        None  # Link to the session page in the electronic logbook
+    )
 
-    volume: Optional[str] = None
-    dataset_count: Optional[str] = None
-    sample_count: Optional[str] = None
+    volume: Optional[str] = None  # Volume (bytes) of data produced
+    dataset_count: Optional[str] = None  # Number of datasets collected
+    sample_count: Optional[str] = None  # Number of samples collected
 
 
 class Instrument(BaseModel):
+    """This class represents a beamline"""
+
     name: str
     id: int
     instrumentScientists: List[Any]
 
 
 class Investigation(BaseModel):
+    """This class represents a investigation and is a proposal
+    to replace the session class"""
+
     name: str
     startDate: datetime
     endDate: datetime
@@ -95,10 +130,13 @@ class Investigation(BaseModel):
 
 
 class Parameter(BaseModel):
-    name: str
-    value: str
-    id: int
-    units: str
+    """Generic reprentation of a parameter atached to any entity like
+    investigation, sample, dataset."""
+
+    name: str  # name of the parameter
+    value: str  # its value
+    id: int  # identifier of the parameter
+    units: str  # units if any
 
 
 class MetaPage(BaseModel):
@@ -113,21 +151,34 @@ class Meta(BaseModel):
 
 
 class LimsUser(BaseModel):
-    user_name: str = ""
-    sessions: Optional[List[Session]] = []
+    """Represents and users that is connected to MXCuBE"""
+
+    user_name: str = ""  # identifier of the users, most likely login name
+    sessions: Optional[
+        List[Session]
+    ] = []  # The sessions that the user is allowed to collect data from.
 
 
 class LimsSessionManager(BaseModel):
-    active_session: Optional[Session] = None
-    sessions: Optional[List[Session]] = []
-    users: Optional[Dict[str, LimsUser]] = {}
+    active_session: Optional[Session] = None  # the current active sessions
+    sessions: Optional[
+        List[Session]
+    ] = []  # Selectable sessions that are calculated based on the connected users
+    users: Optional[
+        Dict[str, LimsUser]
+    ] = {}  # the list of users that are currently connected
 
 
 class SampleSheet(BaseModel):
+    """Represents a description of the sample sheet as defined on
+    some user portals"""
+
     id: int
-    name: str
+    name: str  # Name of the samplesheet that use to correspond to the protein's name
     investigation: Investigation
     modTime: datetime
-    parameters: List[Parameter]
-    datasets: List[Any]
-    meta: Meta
+    parameters: List[
+        Parameter
+    ]  # Generic list of parameters that will depend on the user portal
+    datasets: List[Any]  # datasets collected for this sample
+    meta: Meta  # pagination parameters

--- a/mxcubecore/model/lims_session.py
+++ b/mxcubecore/model/lims_session.py
@@ -25,6 +25,7 @@ class Proposal(BaseModel):
         code: Specific code associated with the proposal e.g., "IH-LS".
         number: Proposal number; may be sequential or unique
             (uniqueness may depend on the combination of code and number)
+        title:  Title of the proposal
     """
 
     proposal_id: str = ""
@@ -32,7 +33,7 @@ class Proposal(BaseModel):
     type: str = ""
     code: str = ""
     number: str = ""
-    title: str = ""  # Title of the proposal
+    title: str = ""
 
 
 class Lims(BaseModel):


### PR DESCRIPTION
This MR proposes adding inline documentation to the lims_session file. This class contains the models primarily used for LIMS. It was created by inferring the fields and classes used in ISPyB and has been extended with additional necessary classes.

This should hopefully make sense for most facilities using a proposal system for experiments, but it may require some work to better generalize the concepts and refine them.

