### PR TITLE
Adds `create_point` attribute to data collections

### DIFF
--- a/docs/source/dev/queue.md
+++ b/docs/source/dev/queue.md
@@ -149,7 +149,7 @@ As with any queue entry in MXCuBE the "dynamic" queue entry also has to inherit 
 # Using BaseQueueEntry and DataCollection making the "Dynmaic" queue entries behave as
 # native queue entries
 
-from mxcubecore.queue_entry.base_queue_entry import BaseQueueEntry
+from mxcubecore.queue_entry.base_queue_entry import BaseQueueEntry, TaskPrerequisite
 from mxcubecore.model.queue_model_objects import (
     DataCollection,
 )
@@ -167,7 +167,13 @@ class TestCollectionQueueEntry(BaseQueueEntry):
     QMO = TestCollectionQueueModel
     DATA_MODEL = TestCollectionTaskParameters
     NAME = "Test collection"
-    REQUIRES = ["point", "line", "no_shape", "chip", "mesh"]
+    REQUIRES = [
+        TaskPrerequisite.POINT,
+        TaskPrerequisite.LINE,
+        TaskPrerequisite.CHIP,
+        TaskPrerequisite.MESH,
+        TaskPrerequisite.NO_SHAPE_2D,
+    ]
 
     def __init__(self, view, data_model: TestCollectionQueueModel):
         super().__init__(view=view, data_model=data_model)

--- a/mxcubecore/queue_entry/base_queue_entry.py
+++ b/mxcubecore/queue_entry/base_queue_entry.py
@@ -28,6 +28,7 @@ import sys
 import time
 import traceback
 from collections import namedtuple
+from enum import Enum
 
 import gevent
 
@@ -47,6 +48,51 @@ __category__ = "General"
 status_list = ["SUCCESS", "WARNING", "FAILED", "SKIPPED", "RUNNING", "NOT_EXECUTED"]
 QueueEntryStatusType = namedtuple("QueueEntryStatusType", status_list)
 QUEUE_ENTRY_STATUS = QueueEntryStatusType(0, 1, 2, 3, 4, 5)
+
+
+class TaskPrerequisite(str, Enum):
+    """Defines possible values for task prerequisites.
+
+    These should be stored in the REQUIRED class variables of
+    the queue entry classes.
+
+    Currently they mostly correspond to the canvas shape,
+    i.e. if
+
+    .. code-block:: python
+
+        REQUIRES = [
+            TaskPrerequisite.POINT,
+            TaskPrerequisite.LINE,
+        ]
+
+    Task will be available from the context menu when
+    right clicking on a point or line shape.
+
+    Example:
+        .. code-block:: python
+
+            class MyQueueEntry(BaseQueueEntry):
+                QMO = MyQueueModel
+                DATA_MODEL = MyTaskParameters
+                NAME = "MyQueueEntry"
+                REQUIRES = [
+                    TaskPrerequisite.POINT,
+                    TaskPrerequisite.LINE,
+                    TaskPrerequisite.CHIP,
+                    TaskPrerequisite.MESH,
+                    TaskPrerequisite.NO_SHAPE_2D,
+                ]
+    """
+
+    POINT = "point"
+    LINE = "line"
+    NO_SHAPE = "no_shape"
+    CHIP = "chip"
+    MESH = "mesh"
+    # This is used for the case when no shape is selected and we want to
+    # create a 2D point in the place where context menu was opened.
+    NO_SHAPE_2D = "no_shape_2d"
 
 
 class QueueExecutionException(Exception):

--- a/mxcubecore/queue_entry/test_collection.py
+++ b/mxcubecore/queue_entry/test_collection.py
@@ -12,7 +12,7 @@ from mxcubecore.model.common import (
     StandardCollectionParameters,
 )
 from mxcubecore.model.queue_model_objects import DataCollection
-from mxcubecore.queue_entry.base_queue_entry import BaseQueueEntry
+from mxcubecore.queue_entry.base_queue_entry import BaseQueueEntry, TaskPrerequisite
 
 __credits__ = ["MXCuBE collaboration"]
 __license__ = "LGPLv3+"
@@ -56,7 +56,13 @@ class TestCollectionQueueEntry(BaseQueueEntry):
     QMO = TestCollectionQueueModel
     DATA_MODEL = TestCollectionTaskParameters
     NAME = "TestCollection"
-    REQUIRES = ["point", "line", "no_shape", "chip", "mesh"]
+    REQUIRES = [
+        TaskPrerequisite.POINT,
+        TaskPrerequisite.LINE,
+        TaskPrerequisite.CHIP,
+        TaskPrerequisite.MESH,
+        TaskPrerequisite.NO_SHAPE_2D,
+    ]
 
     def __init__(self, view, data_model: TestCollectionQueueModel):
         super().__init__(view=view, data_model=data_model)


### PR DESCRIPTION

This parameter is optional.
It's purpose is to allow generic tasks to create a 2d point when it's ran with no shape selected. Similarily to the Data Collection task. Creating the point will be relegated to frontend, as screen coordinates are required to create a 2D point.

Default value of `False` does not do anything.

This PR does not change any present behaviour (other than few more bytes in `/available_tasks` request :smiley_cat: ).
It will do something when [this frontend PR](https://github.com/mxcube/mxcubeweb/pull/1619) is merged :)

I am not really fond of how it's solved there, but I have no better idea  :shrug: 