### PR TITLE
tango poller: handle more exceptions on attribute read errors

### DIFF
--- a/mxcubecore/Command/Tango.py
+++ b/mxcubecore/Command/Tango.py
@@ -272,11 +272,19 @@ class TangoChannel(ChannelObject):
         while True:
             try:  # in case of tango communication errors, retry reading the attribute
                 return read_attr()
-            except PyTango.CommunicationFailed:
+            except PyTango.DevFailed:
                 log.warning(
                     f"error polling {self.raw_device} {self.attribute_name} attribute, retrying.",
                     exc_info=True,
                 )
+                gevent.sleep(0.1)
+            except Exception:
+                log.exception(
+                    "unexpected exception polling %s %s attribute",
+                    self.raw_device,
+                    self.attribute_name,
+                )
+                raise
 
     def poll_failed(self, e, poller_id):
         self.emit("update", None)


### PR DESCRIPTION
Extend attribute reading re-try logic to handle the cases when tango device is offline, for example because it is being restarted.

Catch the more generic `DevFailed` exception, which is raised when tango device is offline. `DevFailed` is the base class for CommunicationFailed exceptions.

Add a `sleep()` between read retries, to avoid spamming retry attempts.

Catch and log unexpected exceptions, to ease the trouble-shooting.