### PR TITLE
GenericDiffractometer: remove redefined get_motors()

### DIFF
--- a/mxcubecore/HardwareObjects/GenericDiffractometer.py
+++ b/mxcubecore/HardwareObjects/GenericDiffractometer.py
@@ -521,9 +521,6 @@ class GenericDiffractometer(HardwareObject):
                 return self.pixels_per_mm_y
             return HardwareObject.__getattr__(self, attr)
 
-    def get_motors(self):
-        return self.motor_hwobj_dict
-
     # Contained Objects
     # NBNB Temp[orary hack - should be cleaned up together with configuration
     @property


### PR DESCRIPTION
Remove the duplicated `GenericDiffractometer.get_motors()` method.

The `get_motors()` is defined twice, the first definition is not used, as it's overwritten by the second one. Remove it.