### PR TITLE
Fixing attribute lookup/retreival and setting for HardwareObjects

### DIFF
--- a/mxcubecore/BaseHardwareObjects.py
+++ b/mxcubecore/BaseHardwareObjects.py
@@ -61,7 +61,6 @@ if TYPE_CHECKING:
 
     from pydantic.v1 import BaseModel
 
-    from .CommandContainer import CommandObject
 
 __copyright__ = """ Copyright © 2010-2020 by the MXCuBE collaboration """
 __license__ = "LGPLv3+"
@@ -149,9 +148,16 @@ class ConfiguredObject:
     def get_by_id(self, _id: str) -> "ConfiguredObject":
         result = self
         for name in _id.split("."):
-            result = getattr(result, name)
+            # Roles are no longer added to HardwareObjects as attributes so
+            # we have to retreive them by role
+            result = result.get_object_by_role(name)
+
+            if not result:
+                result = getattr(result, name)
+
             if result is None:
                 break
+
         return result
 
     @property
@@ -331,19 +337,6 @@ class HardwareObjectNode:
     def __len__(self) -> int:
         warnings.warn("%s.__len__ is Deprecated. Avoid" % self.__class__.__name__)
         return sum(map(len, self.__objects))
-
-    def __setattr__(self, attr: str, value: Any) -> None:
-        try:
-            config = self.__dict__.get("_config")
-            if attr not in self.__dict__ and config and attr in config.model_dump():
-                warnings.warn(
-                    "%s.__setattr__ is Deprecated. Avoid" % self.__class__.__name__
-                )
-                self._set_property(attr, value)
-            else:
-                self.__dict__[attr] = value
-        except AttributeError:
-            self.__dict__[attr] = value
 
     def __getitem__(
         self,
@@ -1072,18 +1065,6 @@ class HardwareObject(ConfiguredObject, HardwareObjectNode, HardwareObjectMixin):
 
         obj = get_hardware_repository().get_hardware_object(name)
         self.__dict__.update(obj.__dict__)
-
-    def __getattr__(self, attr: str) -> Union["CommandObject", Any]:
-        if attr.startswith("__"):
-            raise AttributeError(attr)
-
-        try:
-            return CommandContainer.__getattr__(self, attr)
-        except AttributeError:
-            try:
-                return super().__getattr__(attr)
-            except AttributeError:
-                raise AttributeError(attr)
 
     def commit_changes(self) -> None:
         """Commit last changes back to configuration."""

--- a/mxcubecore/BaseHardwareObjects.py
+++ b/mxcubecore/BaseHardwareObjects.py
@@ -52,7 +52,7 @@ from typing_extensions import (
     Literal,
     Self,
 )
-
+from types import MappingProxyType
 from mxcubecore.CommandContainer import CommandContainer
 from mxcubecore.dispatcher import dispatcher
 
@@ -112,7 +112,6 @@ class ConfiguredObject:
         self._name = name
         self._config: Optional["ConfiguredObject.HOConfig"] = None
         self._hwobj_container: Optional[ConfiguredObject] = hwobj_container
-        self._roles = []
         self._hwobj_by_role = {}
 
     @property
@@ -169,15 +168,7 @@ class ConfiguredObject:
         Returns:
             OrderedDict[str, Union[Self, None]]: Contained objects mapped by role.
         """
-        result = {}
-        for tag in self._roles:
-            if hasattr(self._hwobj_by_role, tag):
-                result[tag] = getattr(self._hwobj_by_role, tag)
-            else:
-                raise ValueError(
-                    "%s object has no attribute %s" % (self.__class__.__name__, tag)
-                )
-        return result
+        return MappingProxyType(self._hwobj_by_role)
 
     def get_properties(self) -> Dict[str, Any]:
         """Get configured properties (not roles)"""
@@ -212,7 +203,7 @@ class ConfiguredObject:
         Returns:
             List[str]: List of hardware object roles.
         """
-        return list(self._roles)
+        return list(self._hwobj_by_role.keys())
 
     def print_log(
         self,
@@ -678,7 +669,6 @@ class HardwareObjectMixin(CommandContainer):
         # Add methods that are exported programatically
         for attr_name in dir(self):
             _attr = getattr(self, attr_name)
-
             if getattr(_attr, "__exported__", False):
                 self._exports[attr_name] = []
 

--- a/mxcubecore/Command/Tango.py
+++ b/mxcubecore/Command/Tango.py
@@ -168,6 +168,7 @@ class TangoChannel(ChannelObject):
         self.device_name = tangoname
         self.device = None
         self.value = Poller.NotInitializedValue
+        self.poller = None
         self.polling = polling
         self.polling_timer = None
         self.polling_events = False
@@ -176,6 +177,18 @@ class TangoChannel(ChannelObject):
         self._device_initialized = gevent.event.Event()
         self.init_device()
         self.continue_init(None)
+
+    def stop_polling(self):
+        """Stop polling the underlying Tango attribute.
+
+        If this channel is currently polling its tango attribute, via
+        'attribute read' calls, stop polling.
+
+        If no polling is active, this method does nothing.
+        """
+        if self.poller is not None:
+            self.poller.stop()
+            self.poller = None
 
     def init_poll_failed(self, e, poller_id):
         self._device_initialized.clear()
@@ -191,7 +204,7 @@ class TangoChannel(ChannelObject):
         if isinstance(self.polling, int):
             self.raw_device = DeviceProxy(self.device_name)
 
-            Poller.poll(
+            self.poller = Poller.poll(
                 self.poll,
                 polling_period=self.polling,
                 value_changed_callback=self.update,

--- a/mxcubecore/HardwareObjects/abstract/AbstractSampleView.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractSampleView.py
@@ -42,12 +42,15 @@ class AbstractSampleView(HardwareObject):
 
     def __init__(self, name):
         super().__init__(name)
-        self.camera = None
         self._focus = None
         self._zoom = None
         self._frontlight = None
         self._backlight = None
         self._shapes = None
+
+    @property
+    def camera(self):
+        return self.get_object_by_role("camera")
 
     @abc.abstractmethod
     def get_snapshot(

--- a/mxcubecore/HardwareObjects/abstract/sample_changer/Component.py
+++ b/mxcubecore/HardwareObjects/abstract/sample_changer/Component.py
@@ -7,7 +7,7 @@ class Component(object):
         self.container = container
         self.address = address
         self.scannable = scannable
-        self.id = None
+        self._id = None
         self.present = False
         self.selected = False
         self.scanned = False
@@ -26,7 +26,7 @@ class Component(object):
         Can be None if sample is unknown or not present
         :rtype: str
         """
-        return self.id
+        return self._id
 
     def get_address(self):
         """
@@ -123,8 +123,8 @@ class Component(object):
         Clears all sample info (also in components if object is a container)
         """
         changed = False
-        if self.id is not None:
-            self.id = None
+        if self._id is not None:
+            self._id = None
             changed = True
         if self.present:
             self.present = False
@@ -138,10 +138,10 @@ class Component(object):
     #########################           PROTECTED           #########################
     def _set_info(self, present=False, id=None, scanned=False):
         changed = False
-        if self.id != id:
-            self.id = id
+        if self._id != id:
+            self._id = id
             changed = True
-        if self.id:
+        if self._id:
             present = True
         if self.present != present:
             self.present = present

--- a/mxcubecore/HardwareObjects/mockup/BeamMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/BeamMockup.py
@@ -65,14 +65,9 @@ class BeamMockup(AbstractBeam):
         # get_object_by_role()
         #
         _definer_type = None
-        if self.aperture is None:
-            self._aperture = self.get_object_by_role("aperture")
-
-        if self.slits is None:
-            self._slits = self.get_object_by_role("slits")
-
-        if self.definer is None:
-            self._definer = self.get_object_by_role("definer")
+        self._aperture = self.get_object_by_role("aperture")
+        self._slits = self.get_object_by_role("slits")
+        self._definer = self.get_object_by_role("definer")
 
         if self.aperture:
             _definer_type = "aperture"

--- a/mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
@@ -29,6 +29,8 @@ class ISPyBClientMockup(ProposalTypeISPyBLims):
     def __init__(self, name):
         super().__init__(name)
 
+        self.loginType = LOGIN_TYPE_FALLBACK
+
     def init(self):
         try:
             self.base_result_url = self.get_property("base_result_url").strip()
@@ -67,9 +69,7 @@ class ISPyBClientMockup(ProposalTypeISPyBLims):
             "Laboratory": {"laboratoryId": 1, "name": "TEST eh1"},
         }
 
-    @property
-    def loginType(self):
-        return self.get_property("loginType", LOGIN_TYPE_FALLBACK)
+        self.loginType = self.get_property("loginType", LOGIN_TYPE_FALLBACK)
 
     def get_login_type(self):
         warnings.warn(

--- a/mxcubecore/HardwareRepository.py
+++ b/mxcubecore/HardwareRepository.py
@@ -235,7 +235,6 @@ def load_from_yaml(
                     f"load_from_yaml Class {_container.__class__.__name__} has no attribute {role}",
                     stacklevel=2,
                 )
-            _container._roles.append(role)
             _container._hwobj_by_role[role] = result
         try:
             # Initialise object
@@ -290,7 +289,6 @@ def _attach_xml_objects(yaml_export_directory: Optional[Path], container, hwobj,
 
     hwobj._hwobj_container = container
     hwobj._name = role
-    container._roles.append(role)
     container._hwobj_by_role[role] = hwobj
 
     objects_by_role = hwobj._objects_by_role

--- a/mxcubecore/HardwareRepository.py
+++ b/mxcubecore/HardwareRepository.py
@@ -169,6 +169,10 @@ def load_from_yaml(
 
     if not msg0:
         try:
+            config = configuration.pop("configuration", {})
+            # Set configuration with non-object properties.
+            result._config = result.HOConfig(**config)
+
             # Initialise object
             result._init()
         except Exception:
@@ -181,9 +185,6 @@ def load_from_yaml(
     if not msg0:
         # Recursively load contained objects (of any type that the system can support)
         objects = configuration.pop("objects", {})
-        config = configuration.pop("configuration", {})
-        # Set configuration with non-object properties.
-        result._config = result.HOConfig(**config)
 
         setup_commands_channels(result, configuration)
 

--- a/mxcubecore/HardwareRepository.py
+++ b/mxcubecore/HardwareRepository.py
@@ -293,7 +293,6 @@ def _attach_xml_objects(yaml_export_directory: Optional[Path], container, hwobj,
     container._roles.append(role)
     container._hwobj_by_role[role] = hwobj
 
-    setattr(container, role, hwobj)
     objects_by_role = hwobj._objects_by_role
     for role2, hwobj2 in objects_by_role.items():
         _attach_xml_objects(yaml_export_directory, hwobj, hwobj2, role2)

--- a/test/pytest/test_hwo_isara_maint.py
+++ b/test/pytest/test_hwo_isara_maint.py
@@ -104,6 +104,7 @@ def _disconnect_channels(maint: ISARAMaint):
     }
 
     for ch in maint.get_channels():
+        ch.stop_polling()
         ch.disconnect_signal("update", callbacks[ch.name()])
 
 


### PR DESCRIPTION
While testing the mockups with the merged YAML code I noticed an issue with the HardwareObjects that have attribute names that are the same as a configuration property name. `MDCameraMokcup` is a good example that as a internal attribute `image_name`:

    https://github.com/mxcube/mxcubecore/blob/613505a24909edbffde6877881f65ead16327a40/mxcubecore/HardwareObjects/mockup/MDCameraMockup.py#L36

And the configuration file property is also called, reasonably, `image_name`. 

The problem with this is that `__setattr__` and `__getattr_` have been defined "asymmetrically" so that the configuration file property is set via `__setattr__ ->self._set_property(attr, value)` and retrieved by `__getattr_->self.__dict__[attr]`.

    https://github.com/mxcube/mxcubecore/blob/613505a24909edbffde6877881f65ead16327a40/mxcubecore/BaseHardwareObjects.py#L335

    https://github.com/mxcube/mxcubecore/blob/613505a24909edbffde6877881f65ead16327a40/mxcubecore/BaseHardwareObjects.py#L1076

This PR removes the custom definitions of `__setattr__` and `__getattr__` from `HardwareObject` and `HardwareObjectNode`. The behavior above is is a consequence of the removal of `PropertySet` (https://github.com/mxcube/mxcubecore/pull/1177/files#diff-3822e4536634bf372f5d0cc7f0fd470b4a5fc2a2741127801c417464b9480779L302).

The custom definition of `__setattr__` and `__getattr__` was also hiding another important other issue, which was the the python property concept did not work as expected. The situation before the fix proposed in this PR allowed for setting a  property value without setter. However the value retrieved would not be the expected value.

We where very lucky to not bump into this issue on the beamline while we where testing and we did not re-test with the mockups which is our mistake this time. Our apologies for that.

We should really be very careful when re-defining `__setattr__` and `__getattr__`. Actually I would recommend never doing so unless its a very well documented and exceptional case. I looked through the code base and there are still a few custom `__getattr__` for a few specific hardware objects that we should look at, but they are less problematic.