### PR TITLE
Handle Tango exceptions during attribute polling

### DIFF
--- a/mxcubecore/Command/Tango.py
+++ b/mxcubecore/Command/Tango.py
@@ -272,60 +272,20 @@ class TangoChannel(ChannelObject):
         TangoChannel._tangoEventsProcessingTimer.send()
 
     def poll(self):
-        def read_attr():
-            if self.read_as_str:
-                value = self.raw_device.read_attribute(
-                    self.attribute_name, PyTango.DeviceAttribute.ExtractAs.String
-                ).value
-            else:
-                value = self.raw_device.read_attribute(self.attribute_name).value
+        if self.read_as_str:
+            value = self.raw_device.read_attribute(
+                self.attribute_name, PyTango.DeviceAttribute.ExtractAs.String
+            ).value
+        else:
+            value = self.raw_device.read_attribute(self.attribute_name).value
 
-            return value
-
-        while True:
-            try:  # in case of tango communication errors, retry reading the attribute
-                return read_attr()
-            except PyTango.DevFailed:
-                log.warning(
-                    f"error polling {self.raw_device} {self.attribute_name} attribute, retrying.",
-                    exc_info=True,
-                )
-                gevent.sleep(0.1)
-            except Exception:
-                log.exception(
-                    "unexpected exception polling %s %s attribute",
-                    self.raw_device,
-                    self.attribute_name,
-                )
-                raise
+        return value
 
     def poll_failed(self, e, poller_id):
         self.emit("update", None)
-        """
-        emit_update = True
-        if self.value is None:
-          emit_update = False
-        else:
-          self.value = None
-
-        try:
-            self.init_device()
-        except:
-            pass
-
         poller = Poller.get_poller(poller_id)
         if poller is not None:
             poller.restart(1000)
-
-        try:
-          raise e
-        except:
-          logging.exception("%s: Exception happened while polling %s", self.name(), self.attribute_name)
-
-        if emit_update:
-          # emit at the end => can raise exceptions in callbacks
-          self.emit('update', None)
-        """
 
     def get_info(self):
         self._device_initialized.wait(timeout=3)

--- a/mxcubecore/Poller.py
+++ b/mxcubecore/Poller.py
@@ -180,6 +180,7 @@ class _Poller:
                 error_cb = self.error_callback_ref()
                 if error_cb is not None:
                     self.queue.put(PollingException(e, self.get_id()))
+                self.old_res = NotInitializedValue
                 break
 
             del polled_call


### PR DESCRIPTION
Restart attribute polling after a tango exception and trigger a value update after recovering from a tango exception.


### The Issues (code few months ago):

1) When a Tango read_attribute(...) call raises an exception, that attribute stops being polled. As a result, the `update` signal of the related `TangoChannel` is no longer emitted.

2) Now, consider a scenario where an attribute read fails in one poll cycle, but succeeds in the next one. If the value hasn't changed since the last successful read (before the Exception), the `Poller` won't emit an  `update` signal.
    This behavior can cause issues, especially for HWO states. I'll try to clarify with an example.
  Example Scenario:
   >1) The Omega motor's state is successfully read from the Tango device, it returned `ON` state (`READY` in mxcube).
   >![image](https://github.com/user-attachments/assets/b292ef90-9dce-4ae4-9bee-8e9f26455dbd)
   >2) A Tango exception occurs during `read_attribute`, so the `update` slot of the motor HWO receives `None`. In this case, the state is interpreted as `UNKNOWN`.
   >![image](https://github.com/user-attachments/assets/8c946b7d-4ab7-463e-894a-6789710aa9e0)
   >3) The attribute is successfully read again. At this point, I'd expect a signal to be emitted to indicate the motor is back to `READY`. But since from the `Poller` point of view the value hasn’t changed (still `ON`), no  `update` signal is sent, and the state remains `UNKNOWN`
   >![image](https://github.com/user-attachments/assets/8c946b7d-4ab7-463e-894a-6789710aa9e0)

#### Notes:

- Fix for the first issue:
  In `.../command/Tango.py`
  ```diff
      def poll_failed(self, e, poller_id):
          self.emit("update", None)
  +       poller = Poller.get_poller(poller_id)
  +       if poller is not None:
  +         poller.restart(1000)
  ```
  I want also to highlight that I found this lines in a commented block of `poll_failed(...)`

- Fix for the second issue:
  In `Poller.py`
  ```diff
                  error_cb = self.error_callback_ref()
                  if error_cb is not None:
                      self.queue.put(PollingException(e, self.get_id()))
  +               self.old_res = NotInitializedValue
                  break
  
              del polled_call
  ```


### Current Code
If I understood correctly, the current fix adds a retry loop to handle Tango exceptions and in case of others Exception polling would just stop. This loop prevents to return new value to the `Poller` until the attribute is read successfully. 

However, with this fix, the HWO is no longer notified when a Tango exception happens, in the previous version, the `Poller` emitted a `None`.  Is this change intentional? Or am I missing something?


