### PR TITLE
Make the user log messages match the UI terms ("resume" instead of "continue")

### DIFF
--- a/mxcubecore/queue_entry/base_queue_entry.py
+++ b/mxcubecore/queue_entry/base_queue_entry.py
@@ -909,7 +909,7 @@ def center_before_collect(view, dm, queue, sample_view):
     view.setText(1, "Waiting for input")
     log = logging.getLogger("user_level_log")
 
-    log.info("Please select, or center on a new position and press continue.")
+    log.info("Please select, or center on a new position and press resume.")
 
     queue.pause(True)
     pos, shape = None, None

--- a/mxcubecore/queue_entry/sample_centring.py
+++ b/mxcubecore/queue_entry/sample_centring.py
@@ -83,9 +83,7 @@ class SampleCentringQueueEntry(BaseQueueEntry):
         if motor_positions:
             HWR.beamline.diffractometer.move_motors(motor_positions)
 
-        log.warning(
-            "Please center a new or select an existing point and press resume."
-        )
+        log.warning("Please center a new or select an existing point and press resume.")
         self.get_queue_controller().pause(True)
 
         shapes = list(HWR.beamline.sample_view.get_selected_shapes())

--- a/mxcubecore/queue_entry/sample_centring.py
+++ b/mxcubecore/queue_entry/sample_centring.py
@@ -84,7 +84,7 @@ class SampleCentringQueueEntry(BaseQueueEntry):
             HWR.beamline.diffractometer.move_motors(motor_positions)
 
         log.warning(
-            "Please center a new or select an existing point and press continue."
+            "Please center a new or select an existing point and press resume."
         )
         self.get_queue_controller().pause(True)
 


### PR DESCRIPTION
If you add a DC to a sample and then click on "Run Queue", the message shown in the user log says:
"Please select, or center on a new position and press continue."
Should we replace that "continue" with "Resume" ?

