### PR TITLE
HWO logging decorator

### DIFF
--- a/mxcubecore/__init__.py
+++ b/mxcubecore/__init__.py
@@ -52,7 +52,7 @@ def hwo_header_log(_func=None, *, level: int = logging.DEBUG):
                                 "HardwareObject instance's methods only")
             args = list(args)
             self = args.pop(0)
-
+            hwo_name = f' ({self.name().strip("/")})' if self.name() else ''
             # Remove named parameters which are not in the signature of the method
             code_obj = func.__code__
             kwargs = {k: v for k, v in kwargs.items()
@@ -63,8 +63,7 @@ def hwo_header_log(_func=None, *, level: int = logging.DEBUG):
             params_str = f"{args_str}{', ' if args and kwargs else ''}{kwargs_str}"
             method_name = func.__name__
             signature = f"{method_name}({params_str})"
-            self.log.log(level, f"In {signature}")
-
+            self.log.log(level, f"{hwo_name} In {signature}")
             retval = func(self, *args, **kwargs)
             return retval
         return fun_wrapper

--- a/mxcubecore/__init__.py
+++ b/mxcubecore/__init__.py
@@ -52,7 +52,7 @@ def hwo_header_log(_func=None, *, level: int = logging.DEBUG):
                                 "HardwareObject instance's methods only")
             args = list(args)
             self = args.pop(0)
-            hwo_name = f' ({self.name().strip("/")})' if self.name() else ''
+            hwo_name = f' ({self.name.strip("/")})' if self.name else ''
             # Remove named parameters which are not in the signature of the method
             code_obj = func.__code__
             kwargs = {k: v for k, v in kwargs.items()

--- a/mxcubecore/__init__.py
+++ b/mxcubecore/__init__.py
@@ -41,7 +41,7 @@ class ColorFormatter(logging.Formatter):
         return formatter.format(record)
 
 
-def hwo_header_log(_func=None, *, level: int = logging.DEBUG):
+def trace_call_log(_func=None, *, level: int = logging.DEBUG):
     def decorator_wrapper(func):
         @functools.wraps(func)
         def fun_wrapper(*args, **kwargs):

--- a/mxcubecore/__init__.py
+++ b/mxcubecore/__init__.py
@@ -12,9 +12,8 @@ from colorama import (
     Style,
 )
 
-from mxcubecore import HardwareRepository as HWR
 from mxcubecore import BaseHardwareObjects as BHWO
-
+from mxcubecore import HardwareRepository as HWR
 from mxcubecore import __version__
 
 __version__ = __version__.__version__
@@ -46,17 +45,22 @@ def hwo_header_log(_func=None, *, level: int = logging.DEBUG):
     def decorator_wrapper(func):
         @functools.wraps(func)
         def fun_wrapper(*args, **kwargs):
-
             if len(args) == 0 or (not isinstance(args[0], BHWO.HardwareObject)):
-                raise TypeError("Not valid method. Decorator can be applied to"
-                                "HardwareObject instance's methods only")
+                err_msg = (
+                    "Not valid method. Decorator can be applied to an"
+                    " HardwareObject instance's methods only"
+                )
+                raise TypeError(err_msg)
             args = list(args)
             self = args.pop(0)
-            hwo_name = f' ({self.name.strip("/")})' if self.name else ''
+            hwo_name = f" ({self.name.strip('/')})" if self.name else ""
             # Remove named parameters which are not in the signature of the method
             code_obj = func.__code__
-            kwargs = {k: v for k, v in kwargs.items()
-                      if k in code_obj.co_varnames[:code_obj.co_argcount]}
+            kwargs = {
+                k: v
+                for k, v in kwargs.items()
+                if k in code_obj.co_varnames[: code_obj.co_argcount]
+            }
 
             args_str = ",".join([str(arg) for arg in args])
             kwargs_str = ",".join(["%s=%s" % (k, v) for k, v in kwargs.items()])
@@ -64,14 +68,13 @@ def hwo_header_log(_func=None, *, level: int = logging.DEBUG):
             method_name = func.__name__
             signature = f"{method_name}({params_str})"
             self.log.log(level, f"{hwo_name} In {signature}")
-            retval = func(self, *args, **kwargs)
-            return retval
+            return func(self, *args, **kwargs)
+
         return fun_wrapper
 
     if _func is None:
         return decorator_wrapper
-    else:
-        return decorator_wrapper(_func)
+    return decorator_wrapper(_func)
 
 
 def getStdHardwareObjectsPath():

--- a/mxcubecore/__init__.py
+++ b/mxcubecore/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import functools
 import logging
 import os
 import sys
@@ -12,6 +13,8 @@ from colorama import (
 )
 
 from mxcubecore import HardwareRepository as HWR
+from mxcubecore import BaseHardwareObjects as BHWO
+
 from mxcubecore import __version__
 
 __version__ = __version__.__version__
@@ -37,6 +40,39 @@ class ColorFormatter(logging.Formatter):
     def format(self, record):
         formatter = logging.Formatter(self.FORMATS.get(record.levelno) % self._fmt)
         return formatter.format(record)
+
+
+def hwo_header_log(_func=None, *, level: int = logging.DEBUG):
+    def decorator_wrapper(func):
+        @functools.wraps(func)
+        def fun_wrapper(*args, **kwargs):
+
+            if len(args) == 0 or (not isinstance(args[0], BHWO.HardwareObject)):
+                raise TypeError("Not valid method. Decorator can be applied to"
+                                "HardwareObject instance's methods only")
+            args = list(args)
+            self = args.pop(0)
+
+            # Remove named parameters which are not in the signature of the method
+            code_obj = func.__code__
+            kwargs = {k: v for k, v in kwargs.items()
+                      if k in code_obj.co_varnames[:code_obj.co_argcount]}
+
+            args_str = ",".join([str(arg) for arg in args])
+            kwargs_str = ",".join(["%s=%s" % (k, v) for k, v in kwargs.items()])
+            params_str = f"{args_str}{', ' if args and kwargs else ''}{kwargs_str}"
+            method_name = func.__name__
+            signature = f"{method_name}({params_str})"
+            self.log.log(level, f"In {signature}")
+
+            retval = func(self, *args, **kwargs)
+            return retval
+        return fun_wrapper
+
+    if _func is None:
+        return decorator_wrapper
+    else:
+        return decorator_wrapper(_func)
 
 
 def getStdHardwareObjectsPath():


### PR DESCRIPTION
This PR introduces a decorator that automatically logs a message before executing a method of an HWO.

I often found myself manually adding logging statements to track the flow of execution and to see what arguments a method was receiving. So, I thought it would be useful to simplify this process with a decorator.

Not sure if this will be helpful for others as well, happy to hear your thoughts!

### How to use
To use the decorator, just import it and apply it to the method you'd like to log.

#### Example 
In the HWO `MotorMockup.py`

```diff
  from mxcubecore.HardwareObjects.mockup.ActuatorMockup import ActuatorMockup
+ from mxcubecore import hwo_header_log

__copyright__ = """ Copyright © 2010-2020 by the MXCuBE collaboration """
...

class MotorMockup(ActuatorMockup, AbstractMotor):

    ...

+   @hwo_header_log
    def _move(self, value):
        """Simulated motor movement.
        Args:
            value (float): target position

        ...    

```
Each time `_move()` is called, a log line like this will be printed:
```shell
2025-05-16 18:54:29,881 |HWR.MotorMockup|DEBUG  |  (kappa) In _move(11.1)
```
The log line includes:
- The name of the HWO class
- The username (if defined)
- The method name
- The parameters received

> By default, the log level is `DEBUG`, but you can change it by passing a level argument to the decorator:
`@hwo_header_log(level=logging.INFO)`
