### PR TITLE
Added type annotations and exception safety on Crims.py 

### DIFF
--- a/mxcubecore/HardwareObjects/abstract/sample_changer/Crims.py
+++ b/mxcubecore/HardwareObjects/abstract/sample_changer/Crims.py
@@ -1,21 +1,34 @@
-import urllib
-import xml.etree.cElementTree as et
+import logging
 from io import BytesIO
+from typing import List, Optional, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 import requests
-from PIL import Image
+from defusedxml import ElementTree
+from PIL import Image, UnidentifiedImageError
 
 
-def get_image(url):
-    f = urllib.request.urlopen(url)
-    img = f.read()
-    return img
+def get_image(url: str) -> Optional[bytes]:
+    try:
+        return urlopen(url).read()
+    except (URLError, HTTPError) as e:
+        logging.getLogger("user_level_log").warning(
+            "Failed to fetch image from %s: %s", url, e
+        )
+        return None
 
 
-def get_image_size(url):
-    img_data = requests.get(url).content
-    im = Image.open(BytesIO(img_data))
-    return (im.size)
+def get_image_size(url: str) -> Tuple[int, int]:
+    try:
+        img_data = requests.get(url, timeout=900).content
+        with Image.open(BytesIO(img_data)) as im:
+            return im.size
+    except (requests.RequestException, UnidentifiedImageError, OSError) as e:
+        logging.getLogger("user_level_log").warning(
+            "Failed to get image size from %s: %s", url, e
+        )
+        return (0, 0)
 
 
 class CrimsXtal:
@@ -35,37 +48,37 @@ class CrimsXtal:
         self.shape = ""
         self.image_url = ""
         self.image_rotation = 0.0
+        self.image_height = 0.0
+        self.image_width = 0.0
+        self.image_date = ""
         self.summary_url = ""
 
-    def get_address(self):
-        return "%s%02d-%d" % (self.row, self.column, self.shelf)
+    def get_address(self) -> str:
+        return f"{self.row}{self.column:02d}-{self.shelf}"
 
-    def get_image(self):
-        if len(self.image_url) > 0:
+    def get_image(self) -> Optional[bytes]:
+        if self.image_url:
             try:
-                if self.image_url.startswith("http://"):
-                    self.image_url = "https://" + self.image_url[7]
-                image_string = urllib.request.urlopen(self.image_url).read()
-                return image_string
-            except Exception:
-                return
+                secure_url = self.image_url.replace("http://", "https://", 1)
+                return urlopen(secure_url).read()
+            except (URLError, HTTPError) as e:
+                logging.getLogger("user_level_log").warning(
+                    "Failed to load image from %s: %s", self.image_url, e
+                )
+        return None
 
-    def get_image_size(self):
-        img_data = requests.get(self.image_url).content
-        im = Image.open(BytesIO(img_data))
-        return (im.size)
+    def get_image_size(self) -> Tuple[int, int]:
+        return get_image_size(self.image_url)
 
-    def get_summary_url(self):
-        if len(self.summary_url == 0):
-            return None
-        return self.summary_url
+    def get_summary_url(self) -> Optional[str]:
+        return self.summary_url or None
 
 
 class Plate:
     def __init__(self, *args):
-        self.barcode = ""
-        self.plate_type = ""
-        self.xtal_list = []
+        self.barcode: str = ""
+        self.plate_type: str = ""
+        self.xtal_list: List[CrimsXtal] = []
 
 
 class ProcessingPlan:
@@ -73,58 +86,68 @@ class ProcessingPlan:
         self.plate = Plate()
 
 
-def get_processing_plan(barcode, crims_url, crims_user_agent, harvester_key):
-    processing_plan = None
+def get_processing_plan(
+    barcode: str, crims_url: str, crims_user_agent: str, harvester_key: str
+) -> Optional[ProcessingPlan]:
     try:
-        xml = None
         url = f"{crims_url}{barcode}/plans/xml"
 
         headers = {
-            'User-Agent' : crims_user_agent,
-            'harvester-key' : harvester_key,
+            "User-Agent": crims_user_agent,
+            "harvester-key": harvester_key,
         }
 
-        req = urllib.request.Request(url, data=None, headers=headers)
+        req = Request(url, headers=headers)
 
-        with urllib.request.urlopen(req) as response:
-            xml = response.read()
+        with urlopen(req) as response:
+            xml_content = response.read()
 
-        tree = et.fromstring(xml)
+        tree = ElementTree.fromstring(xml_content)
+
+        plate_elem = tree.find("Plate")
 
         processing_plan = ProcessingPlan()
-        plate = tree.findall("Plate")[0]
+        processing_plan.plate.barcode = plate_elem.findtext("Barcode", "")
+        processing_plan.plate.plate_type = plate_elem.findtext("PlateType", "")
+        for drop in plate_elem.findall("Drop"):
+            if drop.find("Pin"):
+                try:
+                    xtal = CrimsXtal()
+                    xtal.pin_id = drop.find("Pin").find("PinUUID").text
+                    xtal.crystal_uuid = (
+                        drop.find("Pin").find("Xtal").find("CrystalUUID").text
+                    )
+                    xtal.sample = drop.find("Sample").text
+                    xtal.id_sample = int(drop.find("idSample").text)
+                    xtal.column = int(drop.find("Column").text)
+                    xtal.row = drop.find("Row").text
+                    xtal.shelf = int(drop.find("Shelf").text)
+                    xtal.offset_x = (
+                        float(drop.find("Pin").find("Xtal").find("X").text) / 100.0
+                    )
+                    xtal.offset_y = (
+                        float(drop.find("Pin").find("Xtal").find("Y").text) / 100.0
+                    )
+                    xtal.shape = drop.find("Pin").find("Shape").text
+                    xtal.image_url = drop.find("IMG_URL").text
 
-        processing_plan.plate.barcode = plate.find("Barcode").text
-        processing_plan.plate.plate_type = plate.find("PlateType").text
-        for x in plate.findall("Drop"):
-            if (x.find("Pin")):
-                xtal = CrimsXtal()
-                xtal.pin_id = x.find("Pin").find("PinUUID").text
-                xtal.crystal_uuid = x.find("Pin").find("Xtal").find("CrystalUUID").text
-                # xtal.label = x.find("Label").text
-                # xtal.login = plate.find("Login").text
-                xtal.sample = x.find("Sample").text
-                xtal.id_sample = int(x.find("idSample").text)
-                xtal.column = int(x.find("Column").text)
-                xtal.row = x.find("Row").text
-                xtal.shelf = int(x.find("Shelf").text)
-                # xtal.comments = x.find("Comments").text
-                xtal.offset_x = float(x.find("Pin").find("Xtal").find("X").text) / 100.0
-                xtal.offset_y = float(x.find("Pin").find("Xtal").find("Y").text) / 100.0
-                xtal.shape = x.find("Pin").find("Shape").text
-                xtal.image_url = x.find("IMG_URL").text
+                    xtal.image_height = get_image_size(drop.find("IMG_URL").text)[0]
+                    xtal.image_width = get_image_size(drop.find("IMG_URL").text)[1]
 
-                xtal.image_height = get_image_size(x.find("IMG_URL").text)[0]
-                xtal.image_width = get_image_size(x.find("IMG_URL").text)[1]
-
-                xtal.image_date = x.find("IMG_Date").text
-                xtal.image_rotation = float(x.find("ImageRotation").text)
-                # xtal.summary_url = x.find("SUMMARY_URL").text
-                processing_plan.plate.xtal_list.append(xtal)
+                    xtal.image_date = drop.find("IMG_Date").text
+                    xtal.image_rotation = float(drop.find("ImageRotation").text)
+                    processing_plan.plate.xtal_list.append(xtal)
+                except (ValueError, TypeError) as e:
+                    logging.getLogger("user_level_log").warning(
+                        "Error parsing crystal info: %s", e
+                    )
+                    continue
         return processing_plan
-    except Exception as ex:
-        print("Error on getting processing plan because of: %s" % str(ex))
-        return processing_plan
+    except (URLError, HTTPError, ElementTree.ParseError) as e:
+        logging.getLogger("user_level_log").warning(
+            "Error getting processing plan from  %s : %s", url, e
+        )
+        return None
 
 
 def send_data_collection_info_to_crims(
@@ -134,26 +157,21 @@ def send_data_collection_info_to_crims(
     dcid: str,
     proposal: str,
     rest_token: str,
-    crims_key: str
-) -> str:
+    crims_key: str,
+) -> bool:
+    """Send Data collected to CRIMS
+    Return (bool): Whether the request failed (false) or proceed (true)
+    """
+    url = (
+        f"{crims_url}{crystaluuid}/dcgroupid/{datacollectiongroupid}/dcid/"
+        f"{dcid}/mx/{proposal}/token/{rest_token}?janitor_key={crims_key}"
+    )
     try:
-
-        url = (
-            f"{crims_url}{crystaluuid}/dcgroupid/{datacollectiongroupid}/dcid/"
-            f"{dcid}/mx/{proposal}/token/{rest_token}?janitor_key={crims_key}"
-        )
-
-        # data = {
-        #     "crystal_uuid": str(crystaluuid),
-        #     "datacollectionGroupId": str(datacollectiongroupid),
-        #     "dcid": str(dcid),
-        #     "mx": str(proposal),
-        #     "token": str(rest_token),
-        # }
         response = requests.get(url, timeout=900)
-        # response = post(url, data=data, timeout=900)
-        print(response.text)
-        return response.text
-    except Exception as ex:
-        msg = "POST to %s failed reason %s" % (url, str(ex))
-        return msg
+        logging.getLogger("user_level_log").info(
+            "Request to %s Proceed: %s", url, response.text
+        )
+        return True
+    except requests.RequestException as e:
+        logging.getLogger("user_level_log").warning("Request to %s failed: %s", url, e)
+        return False

--- a/poetry.lock
+++ b/poetry.lock
@@ -491,6 +491,18 @@ files = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+description = "XML bomb protection for Python stdlib modules"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+groups = ["main"]
+files = [
+    {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
+    {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.9"
 description = "Distribution utilities"
@@ -2962,4 +2974,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "827cd11c1fb64ec3380165bfd6ad6d5a2546b5c11d847768e11b0126e89e8a45"
+content-hash = "01e3ff5fcf6550ab48b281a22c06f050b891e9474f6dae460b668d85dc98c820"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2974,4 +2974,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "01e3ff5fcf6550ab48b281a22c06f050b891e9474f6dae460b668d85dc98c820"
+content-hash = "2dc4658cf2a82f3d78c73b6bbc39be8a3ef8bc0b1f04569ad0e5b9102e2ea13a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ requests = "^2.31.0"
 colorama = "^0.4.6"
 pyicat-plus = {version = "^0.6.0", optional = true}
 mxcube-video-streamer = ">=1.8.2"
+defusedxml = "0.7.1"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^4.1.0"


### PR DESCRIPTION
This PR introduces a partial  refactor of Crims.py

-  Replaced deprecated xml.etree.cElementTree with defusedxml.ElementTree.
 this imply adding "**defusedxml**" to the project 
- Removed old keys that no longer part of the API

- Replaced all except Exception: blocks with specific exception (pylint W0703)

- Added type annotations throughout for better clarity

Consolidated duplicated functions (get_image_size)
