### PR TITLE
Let Ruff show fixes made in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,10 +33,10 @@ repos:
 
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.6
+    rev: v0.9.10
     hooks:
       - id: ruff
-        args: [--fix]
+        args: [--fix, --show-fixes]
       - id: ruff-format
 
 


### PR DESCRIPTION
When `ruff check` fixes some files it does not explicitly display what is being changed. This is typically not an issue when running locally as one can inspect the `git diff`.

But this is an issue when running on GitHub Actions workflows. In such cases there is no access to the changed files.

Adding the `--show-fixes` argument to the `pre-commit` hook for `ruff check` should bring more clarity in all cases.

GitHub: https://github.com/mxcube/mxcubecore/issues/1220