### PR TITLE
Show diff on Pre-commit failure in GitHub workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Run Pre-Commit hooks
         run: >
           ${MAMBA_EXE} run --name mxcubecore
-          pre-commit run --all-files
+          pre-commit run --all-files --show-diff-on-failure
 
 ...


### PR DESCRIPTION
Use the `--show-diff-on-failure` option when running `pre-commit` in GitHub Actions workflow.

Some pre-commit hooks might modify files to fix issues, but not all hooks explicitly describe what they modified. When pre-commit is being run locally it is easy to check `git diff`. But if it is running in something like a GitHub Actions workflow, there is no access to the modified files and `git diff`, so it is difficult to understand where the issues are.

GitHub: https://github.com/mxcube/mxcubecore/issues/1220