### PR TITLE
Ruff: PT011 pytest-raises-too-broad

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -6186,14 +6186,12 @@ convention = "google"
 ]
 "test/TestAbstractActuatorBase.py" = [
     "N999",
-    "PT011",
     "PT012",
     "SLF001",
 ]
 "test/TestAbstractMotorBase.py" = [
     "B017",
     "N999",
-    "PT011",
     "PT012",
     "SLF001",
 ]
@@ -6201,7 +6199,6 @@ convention = "google"
     "B017",
     "C400",
     "N999",
-    "PT011",
     "PT012",
 ]
 "test/TestHardwareObjectBase.py" = [
@@ -6318,7 +6315,6 @@ convention = "google"
     "PIE804",
 ]
 "test/test_resolution.py" = [
-    "PT011",
     "PT012",
     "PT022",
     "SLF001",

--- a/test/TestAbstractActuatorBase.py
+++ b/test/TestAbstractActuatorBase.py
@@ -79,7 +79,9 @@ class TestAbstractActuatorBase(TestHardwareObjectBase.TestHardwareObjectBase):
 
         if test_object.read_only:
             # test that there is an exception as read only
-            with pytest.raises(ValueError):
+            with pytest.raises(
+                ValueError, match="Attempt to set value for read-only Actuator"
+            ):
                 test_object.set_value(test_object.default_value)
         else:
             # Test set_value with and without a timeout (different code branch)

--- a/test/TestAbstractMotorBase.py
+++ b/test/TestAbstractMotorBase.py
@@ -120,7 +120,7 @@ class TestAbstractMotorBase(TestAbstractActuatorBase.TestAbstractActuatorBase):
         assert not test_object.validate_value(toobig), (
             "Too-big value %s validates as OK" % toobig
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"Invalid value [\d\.]*"):
             test_object.set_value(toobig, timeout=None)
 
         # Must be set first so the next command causes a change
@@ -157,7 +157,7 @@ class TestAbstractMotorBase(TestAbstractActuatorBase.TestAbstractActuatorBase):
 
         # Must be set first so the next command causes a change
         test_object.set_value(low, timeout=90)
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError):
             test_object.set_value(high, timeout=1.0e-6)
 
     def test_setting_timeouts_2(self, test_object):
@@ -173,7 +173,7 @@ class TestAbstractMotorBase(TestAbstractActuatorBase.TestAbstractActuatorBase):
 
         # Must be set first so the next command causes a change
         test_object.set_value(high, timeout=None)
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError):
             test_object.set_value(low, timeout=0)
             test_object.wait_ready(timeout=1.0e-6)
 

--- a/test/TestAbstractNStateBase.py
+++ b/test/TestAbstractNStateBase.py
@@ -68,7 +68,7 @@ class TestAbstractNStateBase(TestAbstractActuatorBase.TestAbstractActuatorBase):
 
         # Must be set first so the next command causes a change
         test_object.set_value(val1, timeout=90)
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError):
             test_object.set_value(val2, timeout=1.0e-6)
 
     def test_setting_timeouts_2(self, test_object):
@@ -83,6 +83,6 @@ class TestAbstractNStateBase(TestAbstractActuatorBase.TestAbstractActuatorBase):
 
         # Must be set first so the next command causes a change
         test_object.set_value(val2, timeout=None)
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError):
             test_object.set_value(val1, timeout=0)
             test_object.wait_ready(timeout=1.0e-6)

--- a/test/test_resolution.py
+++ b/test/test_resolution.py
@@ -77,7 +77,7 @@ class TestResolution(TestAbstractMotorBase.TestAbstractMotorBase):
             f"Too big value {toobig} validates as OK"
         )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"Invalid value [\d\.]*"):
             test_object.set_value(toobig, timeout=None)
 
         # Must be set first so the next command causes a change


### PR DESCRIPTION
Getting rid of ruff PT011 rule.
Related issue: https://github.com/mxcube/mxcubecore/issues/1230