### PR TITLE
Ruff: PT012 pytest-raises-with-multiple-statements

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -6165,20 +6165,17 @@ convention = "google"
 ]
 "test/TestAbstractActuatorBase.py" = [
     "N999",
-    "PT012",
     "SLF001",
 ]
 "test/TestAbstractMotorBase.py" = [
     "B017",
     "N999",
-    "PT012",
     "SLF001",
 ]
 "test/TestAbstractNStateBase.py" = [
     "B017",
     "C400",
     "N999",
-    "PT012",
 ]
 "test/TestHardwareObjectBase.py" = [
     "N999",
@@ -6268,7 +6265,6 @@ convention = "google"
 ]
 "test/test_flux.py" = [
     "ERA001",
-    "PT012",
     "PT022",
     "SLF001",
     "T201",
@@ -6293,7 +6289,6 @@ convention = "google"
     "PIE804",
 ]
 "test/test_resolution.py" = [
-    "PT012",
     "PT022",
     "SLF001",
 ]

--- a/test/TestAbstractActuatorBase.py
+++ b/test/TestAbstractActuatorBase.py
@@ -174,8 +174,8 @@ class TestAbstractActuatorBase(TestHardwareObjectBase.TestHardwareObjectBase):
 
         # Must be set to None so the next command causes a change
         test_object._nominal_value = None
+        test_object.set_value(startval, timeout=0)
         with pytest.raises(RuntimeError):
-            test_object.set_value(startval, timeout=0)
             test_object.wait_ready(timeout=1.0e-6)
 
     def test_signal_value_changed(self, test_object):

--- a/test/TestAbstractMotorBase.py
+++ b/test/TestAbstractMotorBase.py
@@ -173,8 +173,8 @@ class TestAbstractMotorBase(TestAbstractActuatorBase.TestAbstractActuatorBase):
 
         # Must be set first so the next command causes a change
         test_object.set_value(high, timeout=None)
+        test_object.set_value(low, timeout=0)
         with pytest.raises(RuntimeError):
-            test_object.set_value(low, timeout=0)
             test_object.wait_ready(timeout=1.0e-6)
 
     def test_signal_limits_changed(self, test_object):

--- a/test/TestAbstractNStateBase.py
+++ b/test/TestAbstractNStateBase.py
@@ -84,5 +84,5 @@ class TestAbstractNStateBase(TestAbstractActuatorBase.TestAbstractActuatorBase):
         # Must be set first so the next command causes a change
         test_object.set_value(val2, timeout=None)
         test_object.set_value(val1, timeout=0)
-        with pytest.raises(RuntimeError)):
+        with pytest.raises(RuntimeError):
             test_object.wait_ready(timeout=1.0e-6)

--- a/test/TestAbstractNStateBase.py
+++ b/test/TestAbstractNStateBase.py
@@ -83,6 +83,6 @@ class TestAbstractNStateBase(TestAbstractActuatorBase.TestAbstractActuatorBase):
 
         # Must be set first so the next command causes a change
         test_object.set_value(val2, timeout=None)
-        with pytest.raises(RuntimeError):
-            test_object.set_value(val1, timeout=0)
+        test_object.set_value(val1, timeout=0)
+        with pytest.raises(RuntimeError)):
             test_object.wait_ready(timeout=1.0e-6)

--- a/test/test_flux.py
+++ b/test/test_flux.py
@@ -64,6 +64,5 @@ class TestFlux(TestAbstractActuatorBase.TestAbstractActuatorBase):
     def test_flux_methods(self, test_object):
         """Test the methods"""
         # Test timeout - expecting to have RuntimeError
-        with pytest.raises(RuntimeError) as info:
+        with pytest.raises(RuntimeError):
             test_object.wait_for_beam(0)
-        print(f"------> Flux: {info}")

--- a/test/test_flux.py
+++ b/test/test_flux.py
@@ -65,5 +65,5 @@ class TestFlux(TestAbstractActuatorBase.TestAbstractActuatorBase):
         """Test the methods"""
         # Test timeout - expecting to have RuntimeError
         with pytest.raises(RuntimeError) as info:
-            print(f"------> Flux: {info}")
             test_object.wait_for_beam(0)
+        print(f"------> Flux: {info}")

--- a/test/test_resolution.py
+++ b/test/test_resolution.py
@@ -50,8 +50,8 @@ class TestResolution(TestAbstractMotorBase.TestAbstractMotorBase):
             msg += f"_nominal_limits value is {test_object._nominal_limits}"
             assert test_object._nominal_limits == (None, None), msg
 
+        test_object._nominal_limits = (None, None)
         with pytest.raises(NotImplementedError):
-            test_object._nominal_limits = (None, None)
             test_object.set_limits(limits)
 
     def test_update_state(self, test_object):


### PR DESCRIPTION
Getting rid of ruff PT012 rule.
Related issue: https://github.com/mxcube/mxcubecore/issues/1230