### PR TITLE
Remove exception in `tests` GitHub Action workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,6 @@ name: Pytest
 
 "on":
   pull_request:
-    paths-ignore:
-      - docs/**
     types: [opened, reopened, synchronize]
 
 jobs:


### PR DESCRIPTION
Since the jobs in this workflow are "required" for merge requests, the workflow should never be skipped.