### PR TITLE
Ruff: 105 & 106 hardcoded-password-string / hardcoded-password-func-arg

### DIFF
--- a/mxcubecore/Command/exporter/MDEvents.py
+++ b/mxcubecore/Command/exporter/MDEvents.py
@@ -102,7 +102,7 @@ class MDEvents(ExporterClient):
     PROPERTY_SCAN_RANGE = "ScanRange"
     PROPERTY_SCAN_NUMBER_OF_PASSES = "ScanNumberOfPasses"
     PROPERTY_SCAN_SPEED = "ScanExposureTime"
-    PROPERTY_SCAN_PASS_DURATION = "ScanPassDuration"
+    PROPERTY_SCAN_PASS_DURATION = "ScanPassDuration"  # noqa: S105
     PROPERTY_FRAME_NUMBER = "FrameNumber"
     PROPERTY_SAMPLE_UID = "SampleUID"
     PROPERTY_SAMPLE_IMAGE_NAME = "SampleImageName"

--- a/mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
@@ -85,10 +85,10 @@ class ISPyBClientMockup(ProposalTypeISPyBLims):
         if user_name != "idtest0":
             raise Exception(f"Could not authenticate")
 
-        if password == "wrong":
+        if password == "wrong":  # noqa: S105
             raise Exception("Could not authenticate")
 
-        if password == "ispybDown":
+        if password == "ispybDown":  # noqa: S105
             raise Exception("Could not authenticate")
 
     def _create_test_session(self):

--- a/mxcubecore/HardwareObjects/mockup/ISPyBRestClientMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/ISPyBRestClientMockup.py
@@ -16,7 +16,7 @@ _CONNECTION_ERROR_MSG = (
     + "the server is running and that your "
     + "configuration is correct"
 )
-_NO_TOKEN_MSG = "Could not connect to ISPyB, no valid REST token available."
+_NO_TOKEN_MSG = "Could not connect to ISPyB, no valid REST token available."  # noqa: S105
 
 
 class ISPyBRestClientMockup(HardwareObject):
@@ -101,9 +101,9 @@ class ISPyBRestClientMockup(HardwareObject):
         :returns: None
 
         """
-        if password == "wrong":
+        if password == "wrong":  # noqa: S105
             raise Exception("Wrong credentials")
-        self.__rest_token = "#MOCKTOKEN123"
+        self.__rest_token = "#MOCKTOKEN123"  # noqa: S105
         self.__rest_token_timestamp = datetime.now()
         self.__rest_username = user
         self.__rest_password = password

--- a/ruff.toml
+++ b/ruff.toml
@@ -365,7 +365,6 @@ convention = "google"
     "N802",
     "N999",
     "RUF012",
-    "S105",
     "T201",
     "TD001",
     "TD002",
@@ -5518,7 +5517,6 @@ convention = "google"
     "N815",
     "N999",
     "PIE790",
-    "S105",
     "S110",
     "SIM102",
     "SIM105",
@@ -5539,7 +5537,6 @@ convention = "google"
     "N999",
     "PIE790",
     "RET504",
-    "S105",
     "SIM105",
     "T201",
     "TRY002",
@@ -6278,8 +6275,6 @@ convention = "google"
 "test/test_hwo_maxiv_ispyblims.py" = [
     "C408",
     "E501",
-    "S105",
-    "S106",
 ]
 "test/test_mach_info.py" = [
     "PT022",

--- a/test/test_hwo_maxiv_ispyblims.py
+++ b/test/test_hwo_maxiv_ispyblims.py
@@ -14,7 +14,7 @@ ISPYB_AUTH_ERROR_MESSSAGE = (
 
 REST_ROOT = "http://example.com/rest/"
 USER = "testusr"
-PASS = "testpsd"
+PASS = "testpsd"  # noqa: S105
 
 # @patch("suds.client.Client")
 # @patch("mxcubecore.HardwareRepository")
@@ -54,7 +54,7 @@ def test_login_ok(post_mock, ispyb_lims):
     """test the case when user logs in successfully"""
 
     # mocks the ISPyB client to return valid token on POST request
-    post_mock.return_value.json.return_value = dict(token="dummy-token")
+    post_mock.return_value.json.return_value = dict(token="dummy-token")  # noqa: S106
 
     is_ok, err = ispyb_lims.ispyb_login(USER, PASS)
 


### PR DESCRIPTION
Getting rid of ruff S105 and S106 rules.
Related issue: https://github.com/mxcube/mxcubecore/issues/1230