### PR TITLE
Documents new `ui:options.group` property

### DIFF
--- a/docs/source/dev/queue.md
+++ b/docs/source/dev/queue.md
@@ -251,6 +251,7 @@ class MyDataModel(BaseModel):
                 "ui:order": [
                     "field1",
                     "field2",
+                    "field3",
                     "*",
                 ],
                 "field1": {
@@ -259,12 +260,20 @@ class MyDataModel(BaseModel):
                 "field2": {
                     "ui:options": {"col": 8}
                 },
+                "field3": {
+                    "ui:options": {"group": 'SomeGroup'}
+                }
             }
         )
 ```
 
-**Note**: The `"ui:options.col"` key is specific to MXCuBE-Web, i.e. it is not defined in the `rjsf` library.
-These values correspond to Bootstrap's `col-*` classes; i.e. these should be integers between 1 and 12 or `auto`.
-Here's more about Bootstrap's [grid system](https://getbootstrap.com/docs/4.0/layout/grid/#grid-options)
+**Note**: The `"ui:options.col"` and `"ui:options.group` keys are specific to MXCuBE-Web, i.e. it is not defined in the `rjsf` library.
+
+-   `ui:options.col`
+    These values correspond to Bootstrap's `col-*` classes; i.e. these should be integers between 1 and 12 or `auto`.
+    Here's more about Bootstrap's [grid system](https://getbootstrap.com/docs/4.0/layout/grid/#grid-options)
+-   `ui:options.group`
+    These define groups of fields. Fields in one group are displayed together. A group may be collapsed, to hide fields from one group.
+    If a field is not assigned to any group, it is assigned to a default `Acquisition` group.
 
 For a complete example see: [test_collection.py](https://github.com/mxcube/mxcubecore/blob/develop/mxcubecore/queue_entry/test_collection.py)

--- a/mxcubecore/queue_entry/test_collection.py
+++ b/mxcubecore/queue_entry/test_collection.py
@@ -22,6 +22,12 @@ __category__ = "General"
 class TestUserCollectionParameters(BaseModel):
     num_images: int = Field(0, description="")
     exp_time: float = Field(100e-6, gt=0, lt=1, description="s")
+    cell_a: float = Field(0.0, title="Cell A")
+    cell_b: float = Field(0.0, title="Cell B")
+    cell_c: float = Field(0.0, title="Cell C")
+    cell_alpha: float = Field(0.0, title="Cell Alpha")
+    cell_beta: float = Field(0.0, title="Cell Beta")
+    cell_gamma: float = Field(0.0, title="Cell Gamma")
 
     class Config:
         extra: "ignore"
@@ -40,7 +46,19 @@ class TestCollectionTaskParameters(BaseModel):
 
     @staticmethod
     def ui_schema():
-        return json.dumps({})
+        processing_group = {"group": "Processing"}
+        col_4 = {"col": 4}
+        processing_ui_options = {"ui:options": {**processing_group, **col_4}}
+        return json.dumps(
+            {
+                "cell_a": processing_ui_options,
+                "cell_b": processing_ui_options,
+                "cell_c": processing_ui_options,
+                "cell_alpha": processing_ui_options,
+                "cell_beta": processing_ui_options,
+                "cell_gamma": processing_ui_options,
+            }
+        )
 
 
 class TestCollectionQueueModel(DataCollection):


### PR DESCRIPTION
The `TestCollection` queue entry is enhanced to both use `ui:options.col` and `ui:options.group` settings to provide a reference for other implementations of custom tasks.

This property is added in: https://github.com/mxcube/mxcubeweb/pull/1678 - I mark this as draft until that one is merged.