### PR TITLE
Add protection against repeated clicks during manual centring

### DIFF
--- a/mxcubecore/HardwareObjects/GenericDiffractometer.py
+++ b/mxcubecore/HardwareObjects/GenericDiffractometer.py
@@ -1095,7 +1095,9 @@ class GenericDiffractometer(HardwareObject):
                 "Diffractometer: could not center to beam, aborting"
             )
 
-    def image_clicked(self, x: float, y: float, xi: float | None=None, yi: float | None=None):
+    def image_clicked(
+        self, x: float, y: float, xi: float | None = None, yi: float | None = None
+    ):
         """Handles a user click sent from the frontend during the manual centring.
 
         This method is called by the backend when the user clicks on the sample

--- a/mxcubecore/HardwareObjects/GenericDiffractometer.py
+++ b/mxcubecore/HardwareObjects/GenericDiffractometer.py
@@ -268,7 +268,7 @@ class GenericDiffractometer(HardwareObject):
         self.use_sample_centring = None
 
         # Preventing user multiple clicks during manual centring step
-        self.waiting_for_click = None # None = legacy/no-wait mode, True = waiting, False = manual centring in progress
+        self.waiting_for_click = None  # None = legacy/no-wait mode, True = waiting, False = manual centring in progress
         self.click_lock = Semaphore()
 
         # time to delay for state polling for controllers
@@ -1095,7 +1095,7 @@ class GenericDiffractometer(HardwareObject):
                 "Diffractometer: could not center to beam, aborting"
             )
 
-    def image_clicked(self, x: float, y: float, xi=None, yi=None):
+    def image_clicked(self, x: float, y: float, xi: float | None=None, yi: float | None=None):
         """Handles a user click sent from the frontend during the manual centring.
 
         This method is called by the backend when the user clicks on the sample
@@ -1108,10 +1108,10 @@ class GenericDiffractometer(HardwareObject):
           - False: already received a click, ignore further clicks
 
         Args:
-            x (float): X coordinate of the click.
-            y (float): Y coordinate of the click.
-            xi (float, optional): ...
-            yi (float, optional): ...
+            x: X coordinate of the click.
+            y: Y coordinate of the click.
+            xi: ...
+            yi: ...
 
         Raises:
             RuntimeError: If a click is received while a previous one is still being processed.

--- a/mxcubecore/HardwareObjects/GenericDiffractometer.py
+++ b/mxcubecore/HardwareObjects/GenericDiffractometer.py
@@ -39,6 +39,7 @@ from typing import (
 import gevent
 import gevent.event
 import numpy
+from gevent.lock import Semaphore
 from pydantic.v1 import (
     BaseModel,
     Field,
@@ -265,6 +266,10 @@ class GenericDiffractometer(HardwareObject):
 
         # flag for using sample_centring hwobj or not
         self.use_sample_centring = None
+
+        # Preventing user multiple clicks during manual centring step
+        self.waiting_for_click = None # None = legacy/no-wait mode, True = waiting, False = manual centring in progress
+        self.click_lock = Semaphore()
 
         # time to delay for state polling for controllers
         # not updating state immediately after cmd started
@@ -1090,14 +1095,43 @@ class GenericDiffractometer(HardwareObject):
                 "Diffractometer: could not center to beam, aborting"
             )
 
-    def image_clicked(self, x, y, xi=None, yi=None):
+    def image_clicked(self, x: float, y: float, xi=None, yi=None):
+        """Handles a user click sent from the frontend during the manual centring.
+
+        This method is called by the backend when the user clicks on the sample
+        image in the frontend.
+
+        The attribute `self.waiting_for_click` controls whether the click should
+        be accepted or ignored:
+          - None: click is accepted (legacy)
+          - True: waiting for a click, accept it and mark it as received
+          - False: already received a click, ignore further clicks
+
+        Args:
+            x (float): X coordinate of the click.
+            y (float): Y coordinate of the click.
+            xi (float, optional): ...
+            yi (float, optional): ...
+
+        Raises:
+            RuntimeError: If a click is received while a previous one is still being processed.
         """
-        Descript. :
-        """
-        if self.use_sample_centring:
-            sample_centring.user_click(x, y)
-        else:
-            self.user_clicked_event.set((x, y))
+        with self.click_lock:
+            # "waiting for click" logic is not implememted (legacy) or it is actually waiting for a click
+            if self.waiting_for_click is None or self.waiting_for_click:
+                if self.waiting_for_click:
+                    self.waiting_for_click = False
+                if self.use_sample_centring:
+                    sample_centring.user_click(x, y)
+                else:
+                    self.user_clicked_event.set((x, y))
+            # Already received a click, ignore further clicks
+            else:
+                self.log.warning(
+                    "User attempted to click while the previous centring step was still in progress. Click ignored"
+                )
+                err_msg = "Click ignored: a centring step is still being processed. Please wait before clicking again."
+                raise RuntimeError(err_msg)
 
     def accept_centring(self):
         """

--- a/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
@@ -148,6 +148,7 @@ class DiffractometerMockup(GenericDiffractometer):
         """
         for click in range(3):
             self.user_clicked_event = AsyncResult()
+            self.waiting_for_click = True
             x, y = self.user_clicked_event.get()
             if click < 2:
                 self.motor_hwobj_dict["phi"].set_value_relative(90)


### PR DESCRIPTION
This is a follow-up to the discussion started in PR [#1649](https://github.com/mxcube/mxcubeweb/pull/1649) in `mxcubeweb`.

fixes the issue where negative click values were being shown in the frontend when a user clicked on the sample image **during** manual centering (The related changes on the `mxcubeweb` side have already been merged).

For a detailed explanation of the problem, please refer to the `mxcubeweb` PR linked above.

## `GenericDiffractometer`

As Marcus suggested, we’ve updated the `GenericDiffractometer` to include the “wait for a click” logic that we had already implemented in our Diffractometer HWO.

To make use of this new behavior, you just need to add a single line in the `manual_centring()` method of your `<Site>Diffractometer` HWO (this HWO should inherit from `GenericDiffractometer`) 

```diff
    def manual_centring(self):
        """
        Descript. :
        """
        for click in range(3):
            self.user_clicked_event = AsyncResult()
+           self.waiting_for_click = True
            x, y = self.user_clicked_event.get()
            if click < 2:
                self.motor_hwobj_dict["phi"].set_value_relative(90)
        self.last_centred_position[0] = x
        self.last_centred_position[1] = y
        centred_pos_dir = self._get_random_centring_position()
        return centred_pos_dir

```
The snippet above comes from `MockupDiffractometer` which has been updated to support this new logic.

*Backward compatibility* is maintained for subclasses that haven't yet implemented this change.

## `MiniDiff`

@marcus-oscarsson I went through the `MiniDiff` code, but it already has waiting mechanism in place https://github.com/mxcube/mxcubecore/blob/908fe54eae36cabd012ce7dccd2bafb81a16a1ed/mxcubecore/HardwareObjects/sample_centring.py#L413-L419 which prevents user clicks from interfering with the current centering step, furthermore as far as I understood the `image_clicked()` method isn’t triggered by `mxcubeweb` (i.e. in `components/sampleview.py`) So I imagine it's used in `mxcubeqt` instead.