### PR TITLE
Make the manual centering procedure's name customizable

### DIFF
--- a/mxcubecore/HardwareObjects/GenericDiffractometer.py
+++ b/mxcubecore/HardwareObjects/GenericDiffractometer.py
@@ -836,7 +836,7 @@ class GenericDiffractometer(HardwareObject):
             self.reject_centring()
 
     def start_manual_centring(self, sample_info=None, wait_result=None):
-        self.emit_progress_message("%s centring..." % self.CENTRING_METHOD_MANUAL)
+        self.emit_progress_message(f"{self.CENTRING_METHOD_MANUAL} centring...")
         if self.use_sample_centring:
             self.current_centring_procedure = sample_centring.start(
                 {

--- a/mxcubecore/HardwareObjects/GenericDiffractometer.py
+++ b/mxcubecore/HardwareObjects/GenericDiffractometer.py
@@ -836,7 +836,7 @@ class GenericDiffractometer(HardwareObject):
             self.reject_centring()
 
     def start_manual_centring(self, sample_info=None, wait_result=None):
-        self.emit_progress_message("Manual 3 click centring...")
+        self.emit_progress_message("%s centring..." % self.CENTRING_METHOD_MANUAL)
         if self.use_sample_centring:
             self.current_centring_procedure = sample_centring.start(
                 {


### PR DESCRIPTION
This PR combined with this https://github.com/mxcube/mxcubeweb/pull/1710 in `mxcubeweb` allows making the name of the manual centering procedure customizable.

## HowTo
You have to change the `GenericDiffractometer` subclass like this:

`DiffractometerMockup.py`
```diff
class DiffractometerMockup(GenericDiffractometer):
     ...

    def __init__(self, name):
        """
        Descript. :
        """
+       manual_centring_method_name = "Manual 2-click"
+       GenericDiffractometer.CENTRING_METHOD_MANUAL = manual_centring_method_name
+       GenericDiffractometer.MANUAL3CLICK_MODE = manual_centring_method_name
        GenericDiffractometer.__init__(self, name)

        # child object slots
        self.backlight = None
        self.backlightswitch = None
        ...
```