### PR TITLE
ISPyB: handle `loginTranslate` property correctly

### DIFF
--- a/mxcubecore/HardwareObjects/abstract/ISPyBAbstractLims.py
+++ b/mxcubecore/HardwareObjects/abstract/ISPyBAbstractLims.py
@@ -50,7 +50,7 @@ class ISPyBAbstractLIMS(AbstractLims):
             if self.ldapConnection is None:
                 logging.getLogger("HWR").debug("LDAP Server is not available")
 
-        self.loginTranslate = self.get_property("loginTranslate") or True
+        self.loginTranslate = self.get_property("loginTranslate", default_value=True)
 
         # ISPyB Credentials
         self.ws_root = self.get_property("ws_root")


### PR DESCRIPTION
Fix an issue with loading `loginTranslate` configuration property of ISPyB LIMS hardware objects.

Load boolean `False` value correctly from config file.  Without this change, if the config file specified boolean false value, the `self.loginTranslate` was set to `True`.

For example, following config file did not work correctly:

    class: MAXIV.ISPyBLims.ISPyBLims
    configuration:
      base_url: https://ispyb.maxiv.lu.se
      loginTranslate: false