### PR TITLE
Remove __getattr__ from `CommandContainer`

### DIFF
--- a/mxcubecore/CommandContainer.py
+++ b/mxcubecore/CommandContainer.py
@@ -302,11 +302,13 @@ class CommandContainer:
         self.__commands_to_add: List[Tuple[Dict[str, Any], Union[str, None]]] = []
         self.__channels_to_add: List[Tuple[Dict[str, Any], str]] = []
 
-    def __getattr__(self, attr: str) -> CommandObject:
-        try:
-            return self.__dict__["_CommandContainer__commands"][attr]
-        except KeyError:
-            raise AttributeError(attr)
+    def __getattr__(self, attr: str):
+        if attr in self.__commands:
+            logging.getLogger("HWR").warning(
+                "__getattr__ should not be used to retrieve "
+                "commands. Use get_command_object() instead."
+            )
+        super().__getattr__(attr)
 
     def get_channel_object(
         self,

--- a/test/test_command_container.py
+++ b/test/test_command_container.py
@@ -761,48 +761,6 @@ class TestCommandContainer:
 
         assert cmd_container is not None and isinstance(cmd_container, CommandContainer)
 
-    @pytest.mark.parametrize("attr_name", ("test1", "test2", "test3"))
-    @pytest.mark.parametrize(
-        "initial_commands",
-        (
-            {
-                "test1": MagicMock(spec=CommandObject),
-                "test2": MagicMock(spec=CommandObject),
-            },
-        ),
-    )
-    def test_getattr(
-        self,
-        mocker: "MockerFixture",
-        cmd_container: CommandContainer,
-        attr_name: str,
-        initial_commands: Dict[str, Annotated[CommandObject, MagicMock]],
-    ):
-        """Test "__getattr__" method.
-
-        Args:
-            mocker (MockerFixture): Instance of the Pytest mocker fixture.
-            cmd_container (CommandContainer): Object instance.
-            attr_name (str): Attribute name.
-            initial_commands (Dict[str, Annotated[CommandObject, MagicMock]]): Initial commands.
-        """
-
-        # Patch "__commands" with known values to test
-        mocker.patch.object(
-            cmd_container,
-            "_CommandContainer__commands",
-            new=initial_commands,
-        )
-
-        if attr_name in initial_commands.keys():
-            # Check "getattr" returns expected value
-            res = getattr(cmd_container, attr_name)
-            assert res == initial_commands[attr_name]
-        else:
-            # Check "getattr" raises exception on non-existing attribute
-            with pytest.raises(AttributeError):
-                getattr(cmd_container, attr_name)
-
     @pytest.mark.parametrize("channel_name", ("test1", "test2", "test3", "test4"))
     @pytest.mark.parametrize(
         "initial_channels",


### PR DESCRIPTION
Removing `__getattr__` from`CommandContainer`. The method `get_command_object` does the same thing and does not alter the standard python function `getattr`.