### PR TITLE
Reverted previous change from dict to {}

### DIFF
--- a/mxcubecore/HardwareObjects/EdnaWorkflow.py
+++ b/mxcubecore/HardwareObjects/EdnaWorkflow.py
@@ -146,7 +146,7 @@ class EdnaWorkflow(HardwareObject):
         workflow_list = []
 
         for _wf in self.get_property("workflow"):
-            wf = {_wf}
+            wf = dict(_wf)
             workflow_list.append(wf)
             wf["requires"] = [r.strip() for r in wf.get("requires", "").split(",")]
             wf["doc"] = ""

--- a/mxcubecore/HardwareObjects/sample_centring.py
+++ b/mxcubecore/HardwareObjects/sample_centring.py
@@ -91,7 +91,7 @@ def prepare(centring_motors_dict):
     move_motors(motors_to_move)
 
     SAVED_INITIAL_POSITIONS = {
-        [(m.motor, m.motor.get_value()) for m in centring_motors_dict.values()]
+        m.motor: m.motor.get_value() for m in centring_motors_dict.values()
     }
 
     phi = centring_motors_dict["phi"]


### PR DESCRIPTION
Reverted previous change from `dict` to `{}`. This was a change made in https://github.com/mxcube/mxcubecore/pull/1264, fixing/satisfying C408. 

The automatic fix proposed by Ruff does not seem to take into account that the `dict` function can take a tuple and create the dictionary from that. While `{}` won't do this.

