### PR TITLE
Update beam position when the zoom level changes

### DIFF
--- a/mxcubecore/HardwareObjects/ESRF/ESRFBeam.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFBeam.py
@@ -348,17 +348,18 @@ class ESRFBeam(AbstractBeam):
         Returns:
             X and Y coordinates of the beam position in pixels.
         """
-        if self._beam_position_on_screen == [0, 0]:
-            try:
-                _beam_position_on_screen = (
-                    HWR.beamline.diffractometer.get_beam_position()
-                )
-            except AttributeError:
-                _beam_position_on_screen = (
-                    HWR.beamline.sample_view.camera.get_width() / 2,
-                    HWR.beamline.sample_view.camera.get_height() / 2,
-                )
-            self._beam_position_on_screen = _beam_position_on_screen
+        try:
+            _beam_position_on_screen = HWR.beamline.diffractometer.get_beam_position()
+        except AttributeError:
+            msg = "Could not read beam position from MD, using OAV center"
+            logging.getLogger("HWR").warning(msg)
+            _beam_position_on_screen = (
+                HWR.beamline.sample_view.camera.get_width() / 2,
+                HWR.beamline.sample_view.camera.get_height() / 2,
+            )
+
+        self._beam_position_on_screen = _beam_position_on_screen
+
         return self._beam_position_on_screen
 
     def get_beam_size(self) -> tuple[float, float]:

--- a/mxcubecore/HardwareObjects/MiniDiff.py
+++ b/mxcubecore/HardwareObjects/MiniDiff.py
@@ -456,6 +456,7 @@ class MiniDiff(HardwareObject):
         self.emit("zoomMotorPredefinedPositionChanged", (positionName, offset))
 
     def zoomMotorStateChanged(self, state):
+        HWR.beamline.beam.re_emit_values()
         self.emit("zoomMotorStateChanged", (state,))
         self.emit("minidiffStateChanged", (state,))
 

--- a/mxcubecore/HardwareObjects/abstract/AbstractBeam.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractBeam.py
@@ -292,6 +292,7 @@ class AbstractBeam(HardwareObject):
 
         HardwareObject.re_emit_values(self)
         if self._beam_width != 9999 and self._beam_height != 9999:
+            self.get_beam_position_on_screen()
             self.emit("beamSizeChanged", (self._beam_width, self._beam_height))
             self.emit("beamInfoChanged", (self._beam_info_dict))
             self.emit("beamPosChanged", (self._beam_position_on_screen,))


### PR DESCRIPTION
The diffractometer supports configuring/calibrating the beam center as a function of the zoom. This updates the beam position when the zoom changes.