### PR TITLE
Not passing motor_name from `XMLRPCServer` rotation axis is known by diffractometer

### DIFF
--- a/mxcubecore/HardwareObjects/MD3UP.py
+++ b/mxcubecore/HardwareObjects/MD3UP.py
@@ -76,7 +76,7 @@ class MD3UP(Microdiff.Microdiff):
             "DetectorGatePulseReadoutTime",
         )
 
-    def set_rotation_axis_position(self, value: float, motor_name="phiy"):
+    def set_rotation_axis_position(self, value: float):
         self._set_rotation_axis_position(value, motor_name="phiy")
 
     # def getBeamPosX(self):

--- a/mxcubecore/HardwareObjects/MiniDiff.py
+++ b/mxcubecore/HardwareObjects/MiniDiff.py
@@ -245,10 +245,10 @@ class MiniDiff(HardwareObject):
         # Agree on a correct method name, inconsistent arguments for move_to_beam, disabled temporarily
         # self.move_to_coord = self.move_to_beam()
 
-    def set_rotation_axis_position(self, value: float, motor_name="phiz"):
-        self._set_rotation_axis_position(value, motor_name=motor_name)
+    def set_rotation_axis_position(self, value: float):
+        self._set_rotation_axis_position(value, motor_name="phiz")
 
-    def _set_rotation_axis_position(self, value: float, motor_name="phiy"):
+    def _set_rotation_axis_position(self, value: float, motor_name="phiz"):
         logging.getLogger("HWR").info(
             f"Setting rotation axis ({motor_name}) position to {value}"
         )

--- a/mxcubecore/HardwareObjects/XMLRPCServer.py
+++ b/mxcubecore/HardwareObjects/XMLRPCServer.py
@@ -732,7 +732,7 @@ class XMLRPCServer(HardwareObject):
         return self.gphl_workflow_status
 
     def set_rotation_axis_position(self, value: float):
-        HWR.beamline.diffractometer.set_rotation_axis_position(value, motor_name="phiy")
+        HWR.beamline.diffractometer.set_rotation_axis_position(value)
 
     def centre_beam(self):
         """


### PR DESCRIPTION
Not passing 'motor_name' (rotation axis) from `XMLRPCServer`. The rotation axis is known by the diffractometer