### PR TITLE
Add support for configuring Sardana commands with YAMLs

### DIFF
--- a/docs/source/dev/commands_channels.md
+++ b/docs/source/dev/commands_channels.md
@@ -43,6 +43,7 @@ Currently, the following protocols can be configured using YAML configuration fi
  - [Tango](#tango-protocol)
  - [exporter](#exporter-protocol)
  - [EPICS](#epics-protocol)
+ - [Sardana](#sardana-protocol)
 
 ## Tango Protocol
 
@@ -295,3 +296,55 @@ In the above example channels `State` and `Volume` are configured.
 The `State` channel will be mapped to PV name _MNC:B:PB04.State_.
 The `Volume` channel will be mapped to PV name _MNC:B:PB04.vlm_.
 For `Volume` channel, polling will be enabled.
+
+## Sardana protocol
+
+The format for specifying _Sardana_ `CommandObject` objects is as follows:
+
+```yaml
+class: <hardware-object-class>
+sardana:
+  <sardana-door-name>:
+    commands:
+      <command-1-name>:
+        <config-prop-1>: <val-1>
+      <command-2-name>:
+        <config-prop-1>: <val-1>
+```
+
+`<sardana-door-name>` specifies the Sardana door to use.
+Multiple `<sardana-door-name>` sections can be specified, in order to use different Sardana doors.
+Each `<sardana-door-name>` contains `commands` sections.
+These sections specify `CommandObject` objects to create using the `<sardana-door-name>` Sardana door.
+
+### Commands
+
+`commands` is a dictionary where each key specifies a `CommandObject` object.
+The key defines the MXCuBE name for the command.
+The values specify an optional dictionary with configuration properties for the `CommandObject` object.
+The following configuration properties are supported:
+
+| property | purpose            | default             |
+|----------|--------------------|---------------------|
+| name     | sardana macro name | MXCuBE command name |
+
+### Example
+
+Below is an example of a hardware object that specifies Sardana commands.
+
+```yaml
+class: MySardana
+sardana:
+  some/sardana/door:
+    commands:
+      Open:
+      Close:
+      Reset:
+        name: Reboot
+```
+
+In the above example, `Open`, `Close` and `Reset` commands are configured.
+All command objects will be executed using _some/sardana/door_ Sardana door.
+
+`Open` and `Close` commands are bound to _Open_ and _Close_ Sardana macros.
+The `Reset` has a configuration property that binds it to _Reboot_ macro.

--- a/mxcubecore/model/protocols/sardana.py
+++ b/mxcubecore/model/protocols/sardana.py
@@ -1,0 +1,49 @@
+from typing import (
+    Dict,
+    Iterable,
+    Optional,
+    Tuple,
+)
+
+from pydantic import (
+    BaseModel,
+    RootModel,
+)
+
+
+class Command(BaseModel):
+    """Sardana command configuration."""
+
+    # name of the Sardana command
+    name: Optional[str] = None
+
+
+class Door(BaseModel):
+    """Configuration of a Sardana door."""
+
+    commands: Optional[Dict[str, Optional[Command]]] = None
+
+    def get_commands(self) -> Iterable[Tuple[str, Command]]:
+        """Get all commands configured for this door.
+
+        This method will fill in optional configuration properties for commands.
+        """
+        if self.commands is None:
+            return []
+
+        for command_name, command_config in self.commands.items():
+            if command_config is None:
+                command_config = Command()  # noqa: PLW2901
+
+            if command_config.name is None:
+                command_config.name = command_name
+
+            yield command_name, command_config
+
+
+class SardanaConfig(RootModel[Dict[str, Door]]):
+    """The 'sardana' section of the hardware object's YAML configuration file."""
+
+    def get_doors(self) -> Iterable[Tuple[str, Door]]:
+        """Get all Sardana doors specified in this section."""
+        return list(self.root.items())

--- a/mxcubecore/protocols_config.py
+++ b/mxcubecore/protocols_config.py
@@ -112,11 +112,32 @@ def _setup_epics_channels(hwobj: HardwareObject, epics_config: dict):
         setup_prefix(prefix, prefix_config)
 
 
+def _setup_sardana_commands(hwobj: HardwareObject, sardana_config: dict):
+    from mxcubecore.model.protocols.sardana import (
+        Door,
+        SardanaConfig,
+    )
+
+    def setup_door(door_name: str, door_config: Door):
+        for command_name, command_config in door_config.get_commands():
+            attrs = {
+                "type": "sardana",
+                "doorname": door_name,
+                "name": command_name,
+            }
+            hwobj.add_command(attrs, command_config.name)
+
+    sardana_cfg = SardanaConfig.model_validate(sardana_config)
+    for door_name, door_config in sardana_cfg.get_doors():
+        setup_door(door_name, door_config)
+
+
 def _protocol_handles():
     return {
         "tango": _setup_tango_commands_channels,
         "exporter": _setup_exporter_commands_channels,
         "epics": _setup_epics_channels,
+        "sardana": _setup_sardana_commands,
     }
 
 

--- a/test/data/sardana_commands.yaml
+++ b/test/data/sardana_commands.yaml
@@ -1,0 +1,12 @@
+# yamllint disable rule:empty-values
+%YAML 1.2
+---
+class: Dummy
+configuration: {}
+sardana:
+  my/sardana/door:
+    commands:
+      Go:
+      Stop:
+        name: halt
+      Abort:

--- a/test/test_setup_commands_channels.py
+++ b/test/test_setup_commands_channels.py
@@ -109,6 +109,14 @@ class _EpicsCh:
     polling: Optional[int] = None
 
 
+@dataclass
+class _SardanaCmd:
+    """describes expected Sardana command object"""
+
+    door_name: str
+    macro_format: str
+
+
 def test_no_commands_channels(test_hwo):
     """test loading a config that does not specify any command or channels"""
     config = _parse_yaml_config("no_commands_channels.yaml")
@@ -396,3 +404,42 @@ def test_epics(test_hwo):
     }
 
     _assert_epics_channels(test_hwo.get_channels(), expected_channels)
+
+
+def _assert_sardana_commands(commands, expected_commands):
+    commands = {command.name(): command for command in commands}
+
+    # check by name that we got all the expected commands
+    assert commands.keys() == expected_commands.keys()
+
+    # check the details of each command
+    for name, command in commands.items():
+        expected = expected_commands[name]
+        assert command.doorname == expected.door_name
+        assert command.macro_format == expected.macro_format
+
+
+def test_sardana(test_hwo):
+    """test loading config with Sardana commands"""
+    door_name = "my/sardana/door"
+    config = _parse_yaml_config("sardana_commands.yaml")
+
+    #
+    # install mock 'taurus' and 'sardana' python modules,
+    # otherwise MXCuBE will fail to create Sardana command objects
+    #
+    import sys
+
+    sys.modules["taurus"] = mock.Mock()
+    sys.modules["sardana.taurus.core.tango.sardana"] = mock.Mock()
+
+    # parse the config with sardana commands
+    setup_commands_channels(test_hwo, config)
+
+    # check that expected command objects were created
+    expected_commands = {
+        "Go": _SardanaCmd(door_name, "Go"),
+        "Stop": _SardanaCmd(door_name, "halt"),
+        "Abort": _SardanaCmd(door_name, "Abort"),
+    }
+    _assert_sardana_commands(test_hwo.get_commands(), expected_commands)


### PR DESCRIPTION
Make it possible to configure Sardana commands when using YAML hardware configuration files.

Adds support for `sardana` section in hardware object configuration files. Using the `sardana` section, it is possible to specify Sardana commands.

Note, this only adds support for _commands_ for now. Currently we at MAXIV are not using Sardana channels. Possibly in the future we can add support for channels, if the need arises.
