### PR TITLE
Applying ruff rule: commented-out-code (ERA001) for tests

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -5809,7 +5809,6 @@ convention = "google"
     "SLF001",
 ]
 "test/conftest.py" = [
-    "ERA001",
     "N814",
     "PT003",
     "PTH100",
@@ -5819,7 +5818,6 @@ convention = "google"
     "T201",
 ]
 "test/test_aperture.py" = [
-    "ERA001",
     "SLF001",
 ]
 "test/test_base_hardware_objects.py" = [
@@ -5828,7 +5826,6 @@ convention = "google"
     "C419",
     "E501",
     "E713",
-    "ERA001",
     "PLR0913",
     "PT003",
     "PT007",
@@ -5838,12 +5835,10 @@ convention = "google"
     "SLF001",
 ]
 "test/test_beam.py" = [
-    "ERA001",
     "PERF401",
     "SLF001",
 ]
 "test/test_beam_definer.py" = [
-    "ERA001",
 ]
 "test/test_beamline_ho_id.py" = [
     "SIM300",
@@ -5853,7 +5848,6 @@ convention = "google"
     "E501",
     "E712",
     "E713",
-    "ERA001",
     "F821",
     "FBT001",
     "PLR0913",
@@ -5874,10 +5868,8 @@ convention = "google"
 "test/test_detector_distance.py" = [
 ]
 "test/test_energy.py" = [
-    "ERA001",
 ]
 "test/test_flux.py" = [
-    "ERA001",
     "SLF001",
     "T201",
 ]
@@ -5901,16 +5893,13 @@ convention = "google"
 "test/test_sample_view.py" = [
 ]
 "test/test_shutter.py" = [
-    "ERA001",
     "T201",
 ]
 "test/test_transmission.py" = [
-    "ERA001",
 ]
 "test/test_utils_units.py" = [
     "N802",
 ]
 "test/test_xrf.py" = [
-    "ERA001",
     "S108",
 ]

--- a/test/test_base_hardware_objects.py
+++ b/test/test_base_hardware_objects.py
@@ -1081,48 +1081,6 @@ class TestHardwareObjectMixin:
             HardwareObjectMixin,
         )
 
-    # def test_misc(self):
-    #     """ """
-
-    #     # __bool__
-    #     # __nonzero__
-    #     # _init
-    #     # init
-    #     # pydantic_model
-    #     # exported_attributes
-
-    # def test_get_type_annotations(self): ...
-
-    # def test_execute_exported_command(self): ...
-
-    # def test_abort(self): ...
-
-    # def test_stop(self): ...
-
-    # def test_get_state(self): ...
-
-    # def test_get_specific_state(self): ...
-
-    # def test_wait_ready(self): ...
-
-    # def test_is_ready(self): ...
-
-    # def test_update_state(self): ...
-
-    # def test_update_specific_state(self): ...
-
-    # def test_re_emit_values(self): ...
-
-    # def test_force_emit_signals(self): ...
-
-    # def test_clear_gevent(self): ...
-
-    # def test_emit(self): ...
-
-    # def test_connect(self): ...
-
-    # def test_disconnect(self): ...
-
 
 class TestHardwareObject:
     """Run tests for "HardwareObject" class"""
@@ -1139,24 +1097,6 @@ class TestHardwareObject:
             HardwareObject,
         )
 
-    # def test_misc(self):
-    #     """ """
-
-    #     # exported_attributes
-    #     # __getstate__
-
-    # def test_init(self): ...
-
-    # def test_setstate(self): ...
-
-    # def test_getattr(self): ...
-
-    # def test_commit_changes(self): ...
-
-    # def test_rewrite_xml(self): ...
-
-    # def test_xml_source(self): ...
-
 
 class TestHardwareObjectYaml:
     """Run tests for "HardwareObjectYaml" class"""
@@ -1169,7 +1109,3 @@ class TestHardwareObjectYaml:
         """
 
         assert hw_obj_yml is not None and isinstance(hw_obj_yml, HardwareObjectYaml)
-
-    # def test_user_name(self): ...
-
-    # def test_gui(self): ...

--- a/test/test_beam.py
+++ b/test/test_beam.py
@@ -207,7 +207,6 @@ class TestBeam(TestHardwareObjectBase.TestHardwareObjectBase):
         # slit size in mm, aperture diameters are in microns
         target_width = target_height = max_diameter / 2000.0
         test_object.set_value([target_width, target_height])
-        # beam_width, beam_height, beam_shape, _ = test_object.get_value()
         beam_width, beam_height = test_object.get_beam_size()
         assert target_width == beam_width
         assert target_height == beam_height

--- a/test/test_command_container.py
+++ b/test/test_command_container.py
@@ -864,24 +864,6 @@ class TestCommandContainer:
     @pytest.mark.parametrize(
         "attributes_dict",
         (
-            # {
-            #     "name": "test1",
-            #     "type": "spec",
-            # },
-            # {
-            #     "name": "test2",
-            #     "type": "spec",
-            #     "version": "test_version",
-            # },
-            # {
-            #     "name": "test3",
-            #     "type": "taco",
-            # },
-            # {
-            #     "name": "test4",
-            #     "type": "taco",
-            #     "taconame": "test_taconame",
-            # },
             {
                 "name": "test5",
                 "type": "tango",
@@ -904,24 +886,6 @@ class TestCommandContainer:
                 "name": "test9",
                 "type": "epics",
             },
-            # {
-            #     "name": "test10",
-            #     "type": "tine",
-            # },
-            # {
-            #     "name": "test11",
-            #     "type": "tine",
-            #     "tinename": "test_tinename",
-            # },
-            # {
-            #     "name": "test12",
-            #     "type": "sardana",
-            # },
-            # {
-            #     "name": "test13",
-            #     "type": "sardana",
-            #     "taurusname": "test_taurusname",
-            # },
             {
                 "name": "test14",
                 "type": "mockup",
@@ -976,13 +940,9 @@ class TestCommandContainer:
         get_logger_patch = mocker.patch("logging.getLogger", return_value=logger_patch)
 
         # Patch imports to test in isolation
-        # mocker.patch("mxcubecore.Command.Spec.SpecChannel")
-        # mocker.patch("mxcubecore.Command.Taco.TacoChannel")
         mocker.patch("mxcubecore.Command.Tango.TangoChannel")
         mocker.patch("mxcubecore.Command.Exporter.ExporterChannel")
         mocker.patch("mxcubecore.Command.Epics.EpicsChannel")
-        # mocker.patch("mxcubecore.Command.Tine.TineChannel")
-        # mocker.patch("mxcubecore.Command.Sardana.SardanaChannel")
         mocker.patch("mxcubecore.Command.Mockup.MockupChannel")
 
         # Reset logger patch to remove calls from mock imports
@@ -1359,10 +1319,6 @@ class TestCommandContainer:
     @pytest.mark.parametrize(
         "arg1",
         (
-            # {"name": "test1", "type": "spec"},
-            # {"name": "test2", "type": "spec", "version": "test_version"},
-            # {"name": "test3", "type": "taco"},
-            # {"name": "test4", "type": "taco", "taconame": "test_taconame"},
             {"name": "test5", "type": "tango"},
             {"name": "test6", "type": "tango", "tangoname": "test_tangoname"},
             {"name": "test7", "type": "tango", "polling": 500},
@@ -1399,10 +1355,6 @@ class TestCommandContainer:
                 "exporter_address": "localhost:9000",
             },
             {"name": "test15", "type": "epics"},
-            # {"name": "test16", "type": "tine"},
-            # {"name": "test17", "type": "tine", "tinename": "test_tinename"},
-            # {"name": "test18", "type": "sardana"},
-            # {"name": "test19", "type": "sardana", "taurusname": "test_taurusname"},
             {"name": "test20", "type": "mockup"},
             {"name": "test21", "type": "mockup", "default_value": "1"},
         ),
@@ -1443,15 +1395,9 @@ class TestCommandContainer:
         get_logger_patch = mocker.patch("logging.getLogger", return_value=logger_patch)
 
         # Patch imports to test in isolation
-        # mocker.patch("mxcubecore.Command.Spec.SpecCommand")
-        # mocker.patch("mxcubecore.Command.Taco.TacoCommand")
         mocker.patch("mxcubecore.Command.Tango.TangoCommand")
         mocker.patch("mxcubecore.Command.Exporter.ExporterCommand")
         mocker.patch("mxcubecore.Command.Epics.EpicsCommand")
-        # mocker.patch("mxcubecore.Command.Sardana.SardanaCommand")
-        # mocker.patch("mxcubecore.Command.Sardana.SardanaMacro")
-        # mocker.patch("mxcubecore.Command.Pool.PoolCommand")
-        # mocker.patch("mxcubecore.Command.Tine.TineCommand")
         mocker.patch("mxcubecore.Command.Mockup.MockupCommand")
 
         # Reset logger patch to remove calls from mock imports


### PR DESCRIPTION
Commented out code in test tiles was relatively non-problem-prone to be removed.

Related issues: 
* https://github.com/mxcube/mxcubecore/issues/1230
* https://github.com/mxcube/mxcubecore/issues/1224
* https://github.com/mxcube/mxcubecore/issues/1316

Related PRs: 
* https://github.com/mxcube/mxcubecore/pull/1320 (to be merged after 1320)
* https://github.com/mxcube/mxcubecore/pull/1315