### PR TITLE
Fixed return value and call to super().__getattr__ in `CommandContainer`

### DIFF
--- a/mxcubecore/CommandContainer.py
+++ b/mxcubecore/CommandContainer.py
@@ -308,7 +308,7 @@ class CommandContainer:
                 "__getattr__ should not be used to retrieve "
                 "commands. Use get_command_object() instead."
             )
-        super().__getattr__(attr)
+        return super().__getattribute__(attr)
 
     def get_channel_object(
         self,


### PR DESCRIPTION
Fixed return value and call to `super().__getattr__`  for `CommandContainer`. return statement was missing and object does  not have `__getattr__` but `__getattribute__`