### PR TITLE
Applying ruff rule ERA001 commented-out-code on BaseHardwareObjects.py

### DIFF
--- a/mxcubecore/BaseHardwareObjects.py
+++ b/mxcubecore/BaseHardwareObjects.py
@@ -87,9 +87,6 @@ class DefaultSpecificState(enum.Enum):
 class ConfiguredObject:
     """Superclass for classes that take configuration from YAML files"""
 
-    # class HOConfig(pydantic.BaseModel):
-    #     model_config = pydantic.ConfigDict(extra="allow")
-
     class HOConfig:
         """Temporary replacement for Pydantic class
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -43,7 +43,6 @@ convention = "google"
     "BLE001",
     "E501",
     "EM101",
-    "ERA001",
     "FBT001",
     "FIX002",
     "I001",


### PR DESCRIPTION
Related issue: https://github.com/mxcube/mxcubecore/issues/1230
Commented-out by commit https://github.com/mxcube/mxcubecore/commit/2dbbae4d25a8047ccdb052074c461ea377769500