### PR TITLE
Fixed apparent typo in log name

### DIFF
--- a/mxcubecore/BaseHardwareObjects.py
+++ b/mxcubecore/BaseHardwareObjects.py
@@ -645,7 +645,7 @@ class HardwareObjectMixin(CommandContainer):
         self._exports_config_list = []
 
         self.log: "Logger" = logging.getLogger("HWR").getChild(self.__class__.__name__)
-        self.user_log: "Logger" = logging.getLogger("user_log_level")
+        self.user_log: "Logger" = logging.getLogger("user_level_log")
 
     def __bool__(self) -> Literal[True]:
         return True


### PR DESCRIPTION
This is the only appearance of 'user_log_level', everywhere else has 'user_level_log'