### PR TITLE
Fixes to make GPhL WF work in yaml-configured mock mode

### DIFF
--- a/mxcubecore/BaseHardwareObjects.py
+++ b/mxcubecore/BaseHardwareObjects.py
@@ -881,7 +881,7 @@ class HardwareObjectMixin(CommandContainer):
     def re_emit_values(self) -> None:
         """Update values for all internal attributes
 
-        Should be expanded in subclasse with more updatable attributes
+        Should be expanded in subclasses with more updatable attributes
         (e.g. value, limits)
         """
         self.update_state()

--- a/mxcubecore/HardwareObjects/GenericDiffractometer.py
+++ b/mxcubecore/HardwareObjects/GenericDiffractometer.py
@@ -527,7 +527,7 @@ class GenericDiffractometer(HardwareObject):
             return HardwareObject.__getattr__(self, attr)
 
     # Contained Objects
-    # NBNB Temp[orary hack - should be cleaned up together with configuration
+    # NBNB Temporary hack - should be cleaned up together with configuration
     @property
     def omega(self):
         """omega motor object
@@ -536,6 +536,24 @@ class GenericDiffractometer(HardwareObject):
             AbstractActuator
         """
         return self.motor_hwobj_dict.get("phi")
+
+    @property
+    def kappa(self):
+        """kappa motor object
+
+        Returns:
+            AbstractActuator
+        """
+        return self.get_object_by_role("kappa")
+
+    @property
+    def kappa_phi(self):
+        """kappa motor object
+
+        Returns:
+            AbstractActuator
+        """
+        return self.get_object_by_role("kappa_phi")
 
     @property
     def centring_x(self):

--- a/mxcubecore/HardwareObjects/Gphl/CollectEmulator.py
+++ b/mxcubecore/HardwareObjects/Gphl/CollectEmulator.py
@@ -125,7 +125,7 @@ class CollectEmulator(CollectMockup):
 
         # Add/overwrite parameters from emulator configuration
         conv = conversion.convert_string_value
-        for key, val in self["simcal_parameters"].get_properties().items():
+        for key, val in self.config.simcal_parameters.items():
             setup_data[key] = conv(val)
 
         setup_data["n_vertices"] = 0
@@ -266,7 +266,7 @@ class CollectEmulator(CollectMockup):
         if GPHL_CCP4_PATH:
             envs["GPHL_CCP4_PATH"] = GPHL_CCP4_PATH
         text_type = conversion.text_type
-        for tag, val in self["environment_variables"].get_properties().items():
+        for tag, val in self.config.environment_variables.items():
             envs[text_type(tag)] = text_type(val)
 
         # get crystal data
@@ -303,7 +303,7 @@ class CollectEmulator(CollectMockup):
             hklfile,
         ]
 
-        for tag, val in self["simcal_options"].get_properties().items():
+        for tag, val in self.config.simcal_options.items():
             command_list.extend(conversion.command_option(tag, val, prefix="--"))
         logging.getLogger("HWR").info("Executing command: %s", " ".join(command_list))
         logging.getLogger("HWR").info("Executing environment: %s", sorted(envs.items()))

--- a/mxcubecore/HardwareObjects/Gphl/CollectEmulator.py
+++ b/mxcubecore/HardwareObjects/Gphl/CollectEmulator.py
@@ -45,15 +45,6 @@ class CollectEmulator(CollectMockup):
 
         self._counter = 1
 
-    # def init(self):
-    #     CollectMockup.init(self)
-    #     # NBNB you get an error if you use 'HWR.beamline.session'
-    #     # session_hwobj = self.get_object_by_role("session")
-    #     session = HWR.beamline.session
-    #     if session and self.has_object("override_data_directories"):
-    #         dirs = self["override_data_directories"].get_properties()
-    #         session.set_base_data_directories(**dirs)
-
     def _get_simcal_input(self, data_collect_parameters, crystal_data):
         """Get ordered dict with simcal input from available data"""
 

--- a/mxcubecore/HardwareObjects/Gphl/GphlWorkflowConnection.py
+++ b/mxcubecore/HardwareObjects/Gphl/GphlWorkflowConnection.py
@@ -1031,6 +1031,8 @@ class GphlWorkflowConnection(HardwareObject):
         for item in collectionDone.scanIdMap.items():
             scanIdMap[jvm.java.util.UUID.fromString(conversion.text_type(item[0]))] = (
                 jvm.java.util.UUID.fromString(conversion.text_type(item[1]))
+                if item[1]
+                else None
             )
         return jvm.astra.messagebus.messages.information.CollectionDoneImpl(
             proposalId,

--- a/mxcubecore/HardwareObjects/QtGraphicsManager.py
+++ b/mxcubecore/HardwareObjects/QtGraphicsManager.py
@@ -145,6 +145,7 @@ class QtGraphicsManager(AbstractSampleView):
         self.graphics_move_down_item = None
         self.graphics_move_left_item = None
         self.graphics_magnification_item = None
+        self.camera_hwobj = None
 
     def init(self):
         """Main init function. Initiates all graphics items, hwobjs and

--- a/mxcubecore/HardwareObjects/abstract/AbstractCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractCollect.py
@@ -103,9 +103,9 @@ class AbstractCollect(HardwareObject, object):
 
         undulators = []
         try:
-            for undulator in self["undulators"]:
+            for undulator in self.config.undulators:
                 undulators.append(undulator)
-        except BaseException:
+        except Exception:
             pass
 
         beam_div_hor, beam_div_ver = HWR.beamline.beam.get_beam_divergence()

--- a/mxcubecore/HardwareObjects/mockup/BeamMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/BeamMockup.py
@@ -91,6 +91,9 @@ class BeamMockup(AbstractBeam):
         if _check_beam:
             self._check_beam = literal_eval(_check_beam)
 
+        # Needed to trigger first value setting
+        self.get_value()
+
         self.re_emit_values()
         self.emit("beamPosChanged", (self._beam_position_on_screen,))
 

--- a/mxcubecore/HardwareObjects/mockup/DetectorMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/DetectorMockup.py
@@ -35,7 +35,7 @@ class DetectorMockup(AbstractDetector):
         )
         self._roi_mode = 0
         self._exposure_time_limits = eval(
-            self.get_property("exposure_time_limits", "[0.04, 60000]")
+            self.get_property("exposure_time_limits", "[0.02, 60000]")
         )
         self.update_state(self.STATES.READY)
         self.distance_motor_hwobj = self.get_object_by_role("detector_distance")

--- a/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
@@ -49,8 +49,6 @@ class DiffractometerMockup(GenericDiffractometer):
         self.focus = None
         self.frontlight = None
         self.frontlightswitch = None
-        self.kappa = None
-        self.kappa_phi = None
         self.phi = None
         self.phiy = None
         self.phiz = None

--- a/mxcubecore/HardwareObjects/mockup/FluxMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/FluxMockup.py
@@ -45,15 +45,10 @@ class FluxMockup(AbstractFlux):
     def init(self):
         super().init()
         self.current_flux_dict["flux"] = self.default_value
-        gevent.spawn(self._update_flux)
-
-    def _update_flux(self):
-        while True:
-            self.measure_flux()
-            gevent.sleep(3)
 
     def get_value(self):
         """Get flux at current transmission in units of photons/s"""
+        self.measure_flux()
         return self.current_flux_dict["flux"]
 
     def measure_flux(self) -> None:

--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -2055,8 +2055,6 @@ class GphlWorkflow(TaskNode):
             "initial_strategy",
             "strategy_variant",
             "strategy_options",
-            "acquisition_dose",
-            "characterisation_dose",
         ):
             summary[tag] = getattr(self, tag)
         summary["wavelengths"] = tuple(x.wavelength for x in self.wavelengths)
@@ -2064,7 +2062,13 @@ class GphlWorkflow(TaskNode):
         summary["orgxy"] = self.detector_setting.orgxy
         summary["strategy_variant"] = self.strategy_options.get("variant", "not set")
         summary["orientation_count"] = len(self.goniostat_translations)
-        summary["radiation_dose"] = self.calc_maximum_dose() * self.transmission / 100.0
+        summary["characterisation_dose"] = self.characterisation_dose
+        summary["dose_per_repetition"] = self.acquisition_dose
+
+        summary["total_radiation_dose"] = (
+            summary["dose_per_repetition"] * summary["repetition_count"]
+            + summary["characterisation_dose"]
+        )
         summary["total_dose_budget"] = self.recommended_dose_budget()
         return summary
 


### PR DESCRIPTION
This PR gives the changes necessary to allow the Global Phasing WF  to work correctly in mock mode with the latest yaml configuration and after recent code changes. It includes changes to motor handling in GenericDiffractometer (which was broken), various bug fixes to Mock Hardware objects, bug fixes to GPhL code, and a few typo fixes and similar clean-up.