### PR TITLE
LIMS tests: mock suds in more places

### DIFF
--- a/test/test_hwo_maxiv_ispyblims.py
+++ b/test/test_hwo_maxiv_ispyblims.py
@@ -16,15 +16,13 @@ REST_ROOT = "http://example.com/rest/"
 USER = "testusr"
 PASS = "testpsd"  # noqa: S105
 
-# @patch("suds.client.Client")
-# @patch("mxcubecore.HardwareRepository")
-
 
 @pytest.fixture
 @patch("mxcubecore.HardwareObjects.abstract.AbstractLims.HWR")
 @patch("mxcubecore.HardwareObjects.abstract.ISPyBAbstractLims.HWR")
 @patch("mxcubecore.HardwareObjects.abstract.ISPyBDataAdapter.Client")
-def ispyb_lims(_suds_mock, _hwr_mock, hwr_mock):
+@patch("mxcubecore.HardwareObjects.UserTypeISPyBLims.Client")
+def ispyb_lims(_suds_mock1, _suds_mock2, _hwr_mock, hwr_mock):
     # make sure mocked session HWOBJ have session set
     hwr_mock.beamline.session.beamline_name = "ID42"
 


### PR DESCRIPTION
When testing ISPyBLims code, make sure we mock suds client used in `mxcubecore.HardwareObjects.UserTypeISPyBLims` module as well.

Otherwise a real suds Client will be used, which will try to make HTTP requests. The tests would (sometimes!?) wait until request timed out, thus slowing down the test suite.

This makes the tests run like 1 minuter faster!