### PR TITLE
ISARAMaint: explicitly read `tangoname` config property

### DIFF
--- a/mxcubecore/HardwareObjects/ISARAMaint.py
+++ b/mxcubecore/HardwareObjects/ISARAMaint.py
@@ -91,13 +91,16 @@ class ISARAMaint(HardwareObject):
         self._message = None
 
     def init(self):
-        self.isara_dev = DeviceProxy(self.tangoname)
+        tangoname = self.get_property("tangoname")
+        self.isara_dev = DeviceProxy(tangoname)
 
         polling = self._get_polling()
 
-        self._poll_attribute("Powered", polling, self._powered_updated)
-        self._poll_attribute("PositionName", polling, self._position_name_updated)
-        self._poll_attribute("Message", polling, self._message_updated)
+        self._poll_attribute(tangoname, "Powered", polling, self._powered_updated)
+        self._poll_attribute(
+            tangoname, "PositionName", polling, self._position_name_updated
+        )
+        self._poll_attribute(tangoname, "Message", polling, self._message_updated)
 
     def _get_polling(self):
         """
@@ -110,12 +113,12 @@ class ISARAMaint(HardwareObject):
             # no polling is specified in the XML, use default polling value
             return DEFAULT_POLLING
 
-    def _poll_attribute(self, attr_name: str, polling: int, callback):
+    def _poll_attribute(self, tangoname: str, attr_name: str, polling: int, callback):
         channel = self.add_channel(
             {
                 "type": "tango",
                 "name": f"_chn{attr_name}",
-                "tangoname": self.tangoname,
+                "tangoname": tangoname,
                 "polling": polling,
             },
             attr_name,

--- a/test/test_hwo_isara_maint.py
+++ b/test/test_hwo_isara_maint.py
@@ -120,7 +120,8 @@ def isara_maint():
     # create ISARAMaint hardware object
     #
     maint = ISARAMaint("/sc_maint")
-    maint.tangoname = dev_ctx.get_device_access()
+    maint._config = maint.HOConfig(tangoname=dev_ctx.get_device_access())
+
     # make polling faster, to speed up the tests
     maint.polling = 10
 
@@ -302,7 +303,7 @@ def test_manual_mode_error(isara_maint: ISARAMaint):
     cb_tracker.wait_for_callback()
 
     # put robot into 'manual mode'
-    DeviceProxy(isara_maint.tangoname).disable_remote_mode()
+    DeviceProxy(isara_maint.get_property("tangoname")).disable_remote_mode()
 
     #
     # trying to power on or off the robot, should generate an appropriate error message


### PR DESCRIPTION
With the new hardware object configuration system, all configuration properties need to be explicitly read with for example `get_property().`

Earlier, it seems that it worked automagically.