### PR TITLE
MAXIV MachInfo: make it possible to use YAML conf file

### DIFF
--- a/mxcubecore/HardwareObjects/MAXIV/MachInfo.py
+++ b/mxcubecore/HardwareObjects/MAXIV/MachInfo.py
@@ -57,8 +57,8 @@ class MachInfo(AbstractMachineInfo):
         parameters (str): topics to export, see AbstractMachineInfo class for details
     """
 
-    def __init__(self, *args):
-        super().__init__(*args)
+    def __init__(self, name):
+        super().__init__(name)
         self.mach_info = None
         self.mach_curr = None
 


### PR DESCRIPTION
Make it possible to create MachInfo objects with `MachInfo(name='foo')` expression.

This is the expression used when loading hardware objects from a YAML configuration file.