### PR TITLE
Add bandit and sonar check and report

### DIFF
--- a/.github/workflows/bandit_sonar.yaml
+++ b/.github/workflows/bandit_sonar.yaml
@@ -1,0 +1,78 @@
+---
+
+name: Bandit and SonarQube
+
+"on":
+  pull_request: null
+  push: null
+  workflow_dispatch: null
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  bandit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate Bandit skips from Ruff
+        id: bandit_skips
+        run: |
+          pip install ruff jq
+          SKIPS=$(ruff rule --all --output-format json \
+            | jq -r '.[] | select(.code | test("^S[0-9]{3}$")) | .code' \
+            | sed 's/S/B/' \
+            | paste -sd, -)
+          echo "skips=$SKIPS" >> $GITHUB_OUTPUT
+
+      - name: Bandit Scan
+        uses: shundor/python-bandit-scan@ab1d87dfccc5a0ffab88be3aaac6ffe35c10d6cd
+        with:
+          exit_zero: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          excluded_paths: ./test/
+          level: MEDIUM
+          confidence: HIGH
+          skips: ${{ steps.bandit_skips.outputs.skips }}
+
+      - name: Upload SARIF file to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: bandit
+
+  sonarcloud:
+    name: SonarCloud Scan
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v2
+        with:
+          args: >
+            -Dsonar.organization=mxcubeweb
+            -Dsonar.projectKey=mxcube_mxcubeweb
+            -Dsonar.coverage.exclusions=**
+            -Dsonar.cpd.exclusions=**
+            -Dsonar.cpd.skip=true
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/bandit_sonar.yaml
+++ b/.github/workflows/bandit_sonar.yaml
@@ -20,6 +20,10 @@ jobs:
       - name: Generate Bandit skips from Ruff
         id: bandit_skips
         run: |
+          # Extract all Ruff security rules (Sxxx), convert them to Bandit codes (Bxxx),
+          # and join them as a comma-separated list for Bandit's --skip option.
+          # This keeps Bandit and Ruff in sync,
+          # so ignored security rules in Ruff are also skipped by Bandit.
           pip install ruff jq
           SKIPS=$(ruff rule --all --output-format json \
             | jq -r '.[] | select(.code | test("^S[0-9]{3}$")) | .code' \

--- a/.github/workflows/bandit_sonar.yaml
+++ b/.github/workflows/bandit_sonar.yaml
@@ -7,14 +7,13 @@ name: Bandit and SonarQube
   push: null
   workflow_dispatch: null
 
-permissions:
-  contents: read
-  security-events: write
-  actions: read
-
 jobs:
   bandit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     steps:
       - uses: actions/checkout@v4
 
@@ -28,25 +27,32 @@ jobs:
             | paste -sd, -)
           echo "skips=$SKIPS" >> $GITHUB_OUTPUT
 
-      - name: Bandit Scan
-        uses: shundor/python-bandit-scan@ab1d87dfccc5a0ffab88be3aaac6ffe35c10d6cd
-        with:
-          exit_zero: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          excluded_paths: ./test/
-          level: MEDIUM
-          confidence: HIGH
-          skips: ${{ steps.bandit_skips.outputs.skips }}
+      - name: Install Bandit
+        run: pip install 'bandit>=1.7.4'
 
-      - name: Upload SARIF file to GitHub
-        uses: github/codeql-action/upload-sarif@v3
+      - name: Run Bandit
+        run: |
+          bandit -r . \
+            --exclude ./test/ \
+            --severity-level medium \
+            --confidence-level high \
+            --skip "${{ steps.bandit_skips.outputs.skips }}" \
+            --format json \
+            -o results.json || true
+
+      - name: Upload Bandit results as artifact
+        uses: actions/upload-artifact@v4
         with:
-          sarif_file: results.sarif
-          category: bandit
+          name: bandit-results
+          path: results.json
 
   sonarcloud:
     name: SonarCloud Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     if: >
       github.event.pull_request.head.repo.full_name == github.repository ||
       github.event_name != 'pull_request'


### PR DESCRIPTION
This is the same workflow than in mxcubeWeb. It introduces a new GitHub Actions workflow to integrate Bandit and SonarQube scans into the CI/CD pipeline. The workflow aims to enhance security and code quality by automating static analysis and vulnerability detection.

### New CI/CD Workflow for Static Analysis and Security Scans:

* **Added Bandit Scan Job**: Configured a Bandit scan to detect security issues in Python code. The job dynamically generates skip rules using Ruff, executes Bandit with specified confidence and severity levels, and uploads the results in SARIF format to GitHub.

* **Added SonarCloud Scan Job**: Configured SonarCloud to perform code quality and duplication analysis. The job sets up Java, caches SonarCloud dependencies, and runs the scan with specific exclusions and settings for the project.
* (`.github/workflows/bandit_sonar.yaml`)