### PR TITLE
ISARAMaint: check if it's possible to read attributes

### DIFF
--- a/mxcubecore/HardwareObjects/ISARAMaint.py
+++ b/mxcubecore/HardwareObjects/ISARAMaint.py
@@ -6,6 +6,7 @@ from tango import (
 )
 
 from mxcubecore.BaseHardwareObjects import HardwareObject
+from mxcubecore.utils.tango import TangoAttributeReadError, add_attribute_channel
 
 """
 The sample changer maintenance hardware object for ISARA2 robot.
@@ -93,14 +94,7 @@ class ISARAMaint(HardwareObject):
     def init(self):
         tangoname = self.get_property("tangoname")
         self.isara_dev = DeviceProxy(tangoname)
-
-        polling = self._get_polling()
-
-        self._poll_attribute(tangoname, "Powered", polling, self._powered_updated)
-        self._poll_attribute(
-            tangoname, "PositionName", polling, self._position_name_updated
-        )
-        self._poll_attribute(tangoname, "Message", polling, self._message_updated)
+        self._setup_attribute_polling(tangoname)
 
     def _get_polling(self):
         """
@@ -113,18 +107,36 @@ class ISARAMaint(HardwareObject):
             # no polling is specified in the XML, use default polling value
             return DEFAULT_POLLING
 
-    def _poll_attribute(self, tangoname: str, attr_name: str, polling: int, callback):
-        channel = self.add_channel(
-            {
-                "type": "tango",
-                "name": f"_chn{attr_name}",
-                "tangoname": tangoname,
-                "polling": polling,
-            },
-            attr_name,
-        )
+    def _setup_attribute_polling(self, tangoname: str):
+        polling = self._get_polling()
 
-        channel.connect_signal("update", callback)
+        try:
+            add_attribute_channel(
+                self,
+                tangoname,
+                "Powered",
+                polling,
+                self._powered_updated,
+            )
+            add_attribute_channel(
+                self,
+                tangoname,
+                "PositionName",
+                polling,
+                self._position_name_updated,
+            )
+            add_attribute_channel(
+                self,
+                tangoname,
+                "Message",
+                polling,
+                self._message_updated,
+            )
+        except TangoAttributeReadError as ex:
+            self.log.warning(
+                "ISARA: could not connect to '%s' tango attribute",
+                ex.attribute_name,
+            )
 
     def _update_state(self):
         for attr in [self._powered, self._position_name, self._message]:

--- a/mxcubecore/utils/tango.py
+++ b/mxcubecore/utils/tango.py
@@ -1,0 +1,71 @@
+from tango import DevFailed
+
+from mxcubecore.BaseHardwareObjects import HardwareObject
+from mxcubecore.Command.Tango import TangoChannel
+
+
+class TangoAttributeReadError(Exception):
+    def __init__(self, attribute_name: str):
+        super().__init__()
+        self.attribute_name = attribute_name
+
+
+def add_attribute_channel(
+    hwo: HardwareObject,
+    tango_device: str,
+    attribute_name: str,
+    polling: int,
+    update_callback=None,
+) -> TangoChannel:
+    """Utility function to add Tango attribute Channel to a hardware object.
+
+    This function adds a Channel object to specified hardware object and checks
+    that it's possible to read the specified tango attribute.
+
+    If there is errors reading the attribute, the TangoAttributeReadError
+    exception is raised.
+
+    Parameters:
+        hwo: The hardware object where to add the Channel object.
+        tango_device: Tango device name.
+        attribute_name: The tango attribute name.
+        polling: Attribute polling periodicity.
+        update_callback: Optional callback, if provided it is connected to
+           "update" signal of Channel object
+    """
+
+    channel = hwo.add_channel(
+        {
+            "type": "tango",
+            "tangoname": tango_device,
+            "name": attribute_name,
+            "polling": polling,
+        },
+        attribute_name,
+    )
+
+    if not channel.is_connected():
+        raise TangoAttributeReadError(attribute_name)
+
+    #
+    # check if it's possible to read the Attribute
+    #
+    try:
+        val = channel.get_value()
+    except DevFailed:
+        raise TangoAttributeReadError(attribute_name) from None
+
+    #
+    # add "update" callback
+    #
+    if update_callback is not None:
+        channel.connect_signal("update", update_callback)
+        #
+        # We have 'consumed' the initial value of this channel above,
+        # when we were testing if it's readable. The standard polling
+        # will not invoke the callback with that value now.
+        # Make sure initial value is passed to the callback.
+        #
+        update_callback(val)
+
+    return channel

--- a/test/test_hwo_isara_maint.py
+++ b/test/test_hwo_isara_maint.py
@@ -1,5 +1,7 @@
+from typing import Callable
+
 import pytest
-from gevent.event import Event
+from gevent.queue import Queue
 from tango import (
     DeviceProxy,
     Except,
@@ -98,9 +100,9 @@ def _disconnect_channels(maint: ISARAMaint):
 
     # the hard-coded list of attribute poller callbacks
     callbacks = {
-        "_chnPowered": maint._powered_updated,
-        "_chnPositionName": maint._position_name_updated,
-        "_chnMessage": maint._message_updated,
+        "Powered": maint._powered_updated,
+        "PositionName": maint._position_name_updated,
+        "Message": maint._message_updated,
     }
 
     for ch in maint.get_channels():
@@ -136,19 +138,20 @@ def isara_maint():
 
 
 class CallbackTracker:
-    """
-    allows tests to wait until signal callback is invoked
-    """
-
     def __init__(self):
-        self._cb_received = Event()
+        self._received_callbacks = Queue()
 
     def callback(self, *a, **k):
-        self._cb_received.set()
+        self._received_callbacks.put((a, k))
 
     def wait_for_callback(self):
-        self._cb_received.wait()
-        self._cb_received.clear()
+        return self._received_callbacks.get()
+
+    def wait_until(self, condition: Callable):
+        while received_callback := self.wait_for_callback():
+            if condition(received_callback):
+                # specified condition is fulfilled
+                return
 
 
 def test_power_on_home(isara_maint: ISARAMaint):
@@ -201,6 +204,13 @@ def test_power_off(isara_maint: ISARAMaint):
     """
     test running 'power off' command
     """
+
+    def power_is_off(callback_args):
+        data, _ = callback_args
+        state, _ = data
+
+        return state["PowerOn"]
+
     cb_tracker = CallbackTracker()
 
     isara_maint.connect("globalStateChanged", cb_tracker.callback)
@@ -211,7 +221,9 @@ def test_power_off(isara_maint: ISARAMaint):
 
     # issue 'power off' command
     isara_maint.send_command("PowerOff")
-    cb_tracker.wait_for_callback()
+
+    # wait until command 'propagates'
+    cb_tracker.wait_until(power_is_off)
 
     #
     # check that commands state is correct
@@ -238,6 +250,21 @@ def test_change_positions(isara_maint: ISARAMaint):
     using commands
     """
 
+    def get_state(callback_args):
+        data, _ = callback_args
+        state, _ = data
+
+        return state
+
+    def is_in_soak(callback_args):
+        return not get_state(callback_args)["soak"]
+
+    def is_in_dry(callback_args):
+        return not get_state(callback_args)["dry"]
+
+    def is_in_home(callback_args):
+        return not get_state(callback_args)["home"]
+
     cb_tracker = CallbackTracker()
 
     isara_maint.connect("globalStateChanged", cb_tracker.callback)
@@ -256,7 +283,7 @@ def test_change_positions(isara_maint: ISARAMaint):
     # move to 'soak' position
     #
     isara_maint.send_command("soak")
-    cb_tracker.wait_for_callback()
+    cb_tracker.wait_until(is_in_soak)
 
     # check that the state of commands is correct 'soak' position
     _, commands_state, _ = isara_maint.get_global_state()
@@ -268,7 +295,7 @@ def test_change_positions(isara_maint: ISARAMaint):
     # move to 'dry' position
     #
     isara_maint.send_command("dry")
-    cb_tracker.wait_for_callback()
+    cb_tracker.wait_until(is_in_dry)
 
     # check that the state of commands is correct 'dry' position
     _, commands_state, _ = isara_maint.get_global_state()
@@ -280,7 +307,7 @@ def test_change_positions(isara_maint: ISARAMaint):
     # move to 'home' position
     #
     isara_maint.send_command("home")
-    cb_tracker.wait_for_callback()
+    cb_tracker.wait_until(is_in_home)
 
     # check that the state of commands is correct 'home' position
     _, commands_state, _ = isara_maint.get_global_state()


### PR DESCRIPTION
When setting up polling of the tango attributes, check that it possible to read them. If there are issues, log it and run in a 'fault' mode.

This way the hardware object can handle situations when ISARA's tango device is unavailable or reports issues. For example if the sample changer robot is turned off.

Without this checks, it was problematic to run MXCuBE, if the robot is unavailable.