### PR TITLE
fix the poetry version in the create-tag.yml file

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -13,39 +13,45 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.CI_TOKEN }}
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+
+      - name: Set up Conda environment with Micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          python-version: "3.10"
+          cache-environment: true
+          create-args: >-
+            python=3.10
+          environment-file: conda-environment-dev.yml
+          post-cleanup: all
 
       - name: Update version
         id: update-version
         run: |
-            pip install --upgrade pip
-            pip install poetry
-            poetry version minor
+            ${MAMBA_EXE} run --name mxcubecore poetry version minor
             git config --global user.email "oscarsso@esrf.fr"
             git config --global user.name "Marcus Oskarsson"
             git add -A
             git commit -m "[skip ci] Bumped minor version"
             git push -f
-            poetry build
+            ${MAMBA_EXE} run --name mxcubecore poetry build
+
       - name: Publish package to PyPI
         id: publish-pacakge
+        # yamllint disable rule:line-length
         run: |
-          poetry config pypi-token.pypi ${{ secrets.PYPI }}
-          poetry publish
+          ${MAMBA_EXE} run --name mxcubecore poetry config pypi-token.pypi ${{ secrets.PYPI }}
+          ${MAMBA_EXE} run --name mxcubecore poetry publish
+        # yamllint enable rule:line-length
+
       - name: Read package version
         id: set-tag
         # yamllint disable rule:line-length
         run: |
           pip install --upgrade pip
           pip install toml
-          pip install poetry
-          echo "tag_name=v$(poetry version -s)" >> $GITHUB_ENV
+          echo "tag_name=v$(${MAMBA_EXE} run --name mxcubecore poetry version -s)" >> $GITHUB_ENV
         # yamllint enable rule:line-length
 
       - name: Check tag exists


### PR DESCRIPTION
There seems to be a mismatch between the poetry version used in the `create-tag` workflow and the one we fix with conda. This will cause an error, when the workflow tries to bump the version. 

This PR is fixing the version to the same value as in conda, lock and pre-commit files.