### PR TITLE
removed invalied organization permission

### DIFF
--- a/.github/workflows/discussions.yml
+++ b/.github/workflows/discussions.yml
@@ -24,7 +24,6 @@ jobs:
     permissions:
       discussions: write
       contents: read
-      organization: read
     steps:
       # First generate the app token for authentication
       - name: Get GitHub App token


### PR DESCRIPTION
It seems that, github threw errors for invalid permission settings in the workflow that handles notifications on topics being opened in the discussion section. 

After further inspection the permission `organization` does not exist on the official [list of permissions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions) supported by GitHub. Anyways, it should also be the app that was made for this workflow, that handles organization wide permissions, not the workflow itself. 