### PR TITLE
prevent sonarqube from running on forks or pushes other than develop

### DIFF
--- a/.github/workflows/bandit_sonar.yaml
+++ b/.github/workflows/bandit_sonar.yaml
@@ -82,7 +82,7 @@ jobs:
         with:
           args: >
             -Dsonar.organization=mxcubeweb
-            -Dsonar.projectKey=mxcube_mxcubeweb
+            -Dsonar.projectKey=mxcube_mxcubecore
             -Dsonar.coverage.exclusions=**
             -Dsonar.cpd.exclusions=**
             -Dsonar.cpd.skip=true

--- a/.github/workflows/bandit_sonar.yaml
+++ b/.github/workflows/bandit_sonar.yaml
@@ -4,7 +4,8 @@ name: Bandit and SonarQube
 
 "on":
   pull_request: null
-  push: null
+  push:
+    branches: [develop]
   workflow_dispatch: null
 
 jobs:
@@ -57,8 +58,10 @@ jobs:
       contents: read
       security-events: write
       actions: read
-    if: >
-      github.repository == 'mxcube/mxcubecore'
+    if: |
+      (github.event_name == 'push' && github.repository == 'mxcube/mxcubecore') ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.base.repo.full_name == 'mxcube/mxcubecore')
     steps:
       - uses: actions/checkout@v4
       - name: Set up Java


### PR DESCRIPTION
It seems that sonarqube is still running on PRs made from fork and failing since the secret is only set on the main repository (as can be seen in #1287 for example). 

There were some recent changes in the latest PRs, To summarize:
- #1338 introduced the workflow. The workflow only ran on manual triggers, pushes and pull_requests (PRs had to been from one repo to the same repo)   -> problem: A commit on an open Repo triggers a push event which then executed the workflow from the fork

- #1343 tried to fix this by checking if the `github.repository == mxcube/mxcubecore`. -> problem : GitHub sets the target repository to `github.repository`. Hence, a PR from a fork to the main repo will still trigger the workflow but fail, because it has no access to the secret.

This PR will add the following changes:
- Restrict the trigger from push events to only develop branch -> This allows to have a final check after merge, without the fails on every commit on the PRs as in the first version
- On `push` events further check if it is on the main repo -> This prevents the workflow to be triggered on forks, that might have not configured a secret, but still want to make changes to their own `develop` branch
- On `pull_request` triggers: make sure that the repo from which the PR originates from is the main repo


In theory, I think this should cover our use cases. I apologize for the problems that this workflow might have caused, it is quite difficult to test these kind of workflows 