### PR TITLE
Remove DataCollectionQueueEntry unused attributes

### DIFF
--- a/mxcubecore/queue_entry/data_collection.py
+++ b/mxcubecore/queue_entry/data_collection.py
@@ -50,8 +50,6 @@ class DataCollectionQueueEntry(BaseQueueEntry):
 
         self.collect_task = None
         self.centring_task = None
-        self.enable_take_snapshots = True
-        self.enable_store_in_lims = True
         self.in_queue = False
 
     def __setstate__(self, d):


### PR DESCRIPTION
These two attributes seem completely unused.

Looking through the related commits in the git log, it seems like these were added with some specific purpose in mind, but was never fully implemented and then never fully cleaned up either.

GitHub: https://github.com/mxcube/mxcubecore/issues/1345