### PR TITLE
Prevent SonarQube to run om PRs made from forks

### DIFF
--- a/.github/workflows/bandit_sonar.yaml
+++ b/.github/workflows/bandit_sonar.yaml
@@ -61,7 +61,7 @@ jobs:
     if: |
       (github.event_name == 'push' && github.repository == 'mxcube/mxcubecore') ||
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.base.repo.full_name == 'mxcube/mxcubecore')
+       github.event.pull_request.head.repo.full_name == 'mxcube/mxcubecore')
     steps:
       - uses: actions/checkout@v4
       - name: Set up Java


### PR DESCRIPTION
Prevent SonarQube to run om PRs made from forks

I think we need to check `head` and not `base`. I think the base is always `mxcubecore` and head is whatever repo the PR is made from.