### PR TITLE
Added missing method _emit_status

### DIFF
--- a/mxcubecore/HardwareObjects/mockup/DetectorMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/DetectorMockup.py
@@ -65,3 +65,6 @@ class DetectorMockup(AbstractDetector):
         self.update_state(HardwareObjectState.BUSY)
         time.sleep(2)
         self.update_state(HardwareObjectState.READY)
+
+    def _emit_status(self):
+        return


### PR DESCRIPTION
Added the missing method `_emit_status` to `AbstractDetector`

Closes #1355 

Thanks @olofsvensson 