### PR TITLE
Handle image mode from camera's get_last_image

### DIFF
--- a/mxcubecore/HardwareObjects/SampleView.py
+++ b/mxcubecore/HardwareObjects/SampleView.py
@@ -138,20 +138,27 @@ class SampleView(AbstractSampleView):
 
         self._last_oav_image = path
 
-    def take_snapshot(self, overlay_data=None, bw=False):
+    def take_snapshot(self, overlay_data=None, bw=False) -> Image:
         """
         Get snapshot with overlaid data.
 
         Args:
-            overlay_data (str): base64 encoded image to lay over camera image
-            bw (bool): return grayscale image
+            overlay_data: base64 encoded image to lay over camera image
+            bw: return black and white image
 
         Returns:
-            (Image) rgb or grayscale image
+            RGB or black and white image
         """
-        data, width, height = self.camera.get_last_image()
 
-        img = Image.frombytes("RGB", (width, height), data)
+        last_image = self.camera.get_last_image()
+
+        if len(last_image) == 3:
+            data, width, height = last_image
+            mode = "RGB"
+        elif len(last_image) == 4:
+            data, width, height, mode = last_image
+
+        img = Image.frombytes(mode, (width, height), data)
 
         if overlay_data:
             overlay_data = base64.b64decode(overlay_data)


### PR DESCRIPTION
The `take_snapshot` method of the `SampleView` hardware object calls the `get_last_image` method of the camera hardware object and assumes the result is always RGB.

There are some cases where the camera returns grayscale data (`L` mode). So this change allows `get_last_image` to optionally return image mode.