### PR TITLE
Fix: no emit signal after updating the attribute.

### DIFF
--- a/mxcubecore/HardwareObjects/mockup/ExporterNStateMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/ExporterNStateMockup.py
@@ -107,7 +107,7 @@ class ExporterNStateMockup(AbstractNState):
             else:
                 value = value.value
 
-        self._nominal_value = self.value_to_enum(value)
+        self.update_value(self.value_to_enum(value))
         self.update_state(self.STATES.READY)
 
     def get_value(self):


### PR DESCRIPTION
Now emit `hardware_object_value_changed` is called after emitting `valueChanged` within `update_value` method. If `_nominal_value` was changed by assigning new `value` to it, the signals would not be emitted in the following steps because `_nominal_value` would be already equal to the `value` when checking.

Although, I'm not sure if that changes something in case of mockup Exporter. I found it inconsistent with regular Exporter classes.