### PR TITLE
Add MAXIV custom Beamline hardware objects

### DIFF
--- a/mxcubecore/HardwareObjects/MAXIV/MicroMAX/beamline.py
+++ b/mxcubecore/HardwareObjects/MAXIV/MicroMAX/beamline.py
@@ -1,0 +1,51 @@
+"""Custom MicroMAX Beamline object.
+
+Adds support for `sample_delivery` configurable, which
+specifies the sample delivery mode for MXCuBE.
+
+Following sample delivery modes are supported:
+
+* osc - Oscillation sample delivery
+* hve - HVE (injector) sample delivery
+
+Example of `sample_delivery` configuration::
+
+  configuration:
+    sample_delivery: osc
+"""
+
+from enum import Enum
+
+import mxcubecore.HardwareObjects.MAXIV.beamline
+
+
+class SampleDelivery(Enum):
+    osc = "osc"
+    hve = "hve"
+
+
+class Beamline(mxcubecore.HardwareObjects.MAXIV.beamline.Beamline):
+    def __init__(self, name):
+        super().__init__(name)
+
+        # 'cached' Sample Delivery mode config
+        self._sample_delivery = None
+
+    #
+    # 'sample_delivery' config
+    #
+
+    def _load_sample_delivery(self):
+        val = self.get_property("sample_delivery", SampleDelivery.osc.value)
+        self._sample_delivery = SampleDelivery(val)
+
+    @property
+    def sample_delivery(self) -> SampleDelivery:
+        if self._sample_delivery is None:
+            self._load_sample_delivery()
+
+        return self._sample_delivery
+
+    def is_hve_sample_delivery(self) -> bool:
+        """True when HVE sample delivery mode is configured."""
+        return self.sample_delivery == SampleDelivery.hve

--- a/mxcubecore/HardwareObjects/MAXIV/beamline.py
+++ b/mxcubecore/HardwareObjects/MAXIV/beamline.py
@@ -1,0 +1,28 @@
+"""Custom MAXIV Beamline object.
+
+Adds support for ``emulate`` configurable, which allows to specify
+features to be emulated at the beamline.
+
+Emulation of following features are supported:
+
+* safety_shutter - emulate safety shutter opening
+* detector_cover - emulate detector cover opening
+* detector_motion - emulate detector distance moves
+
+Example of ``emulate`` configuration::
+
+  configuration:
+    emulate:
+      safety_shutter: true
+      detector_cover: true
+      detector_motion: true
+"""
+
+import mxcubecore.HardwareObjects.Beamline
+
+
+class Beamline(mxcubecore.HardwareObjects.Beamline.Beamline):
+    def emulate(self, feature: str) -> bool:
+        """Check if some feature should be emulated."""
+        emulate = self.get_property("emulate", {})
+        return emulate.get(feature, False)

--- a/test/test_hwo_maxiv_beamline.py
+++ b/test/test_hwo_maxiv_beamline.py
@@ -1,0 +1,39 @@
+from mxcubecore.HardwareObjects.MAXIV.beamline import Beamline
+
+
+def _setup_beamline_obj(config: dict):
+    beamline = Beamline("dummy")
+    beamline._config = Beamline.HOConfig(**config)  # noqa: SLF001
+
+    return beamline
+
+
+def test_emulate_default():
+    """Test the `emulate()` method when no
+    `emulate` config have been specified.
+    """
+    beamline = _setup_beamline_obj({})
+
+    assert not beamline.emulate("feature1")
+    assert not beamline.emulate("feature2")
+
+
+def test_emulate_enabled():
+    """Test the `emulate()` method when
+    some feature have been configured to be emulated.
+    """
+
+    beamline = _setup_beamline_obj(
+        {
+            "emulate": {
+                "feature1": True,
+                "feature2": False,
+            },
+        }
+    )
+
+    assert beamline.emulate("feature1")
+    assert not beamline.emulate("feature2")
+    # this feature is not included into the config,
+    # it must default to false
+    assert not beamline.emulate("feature3")

--- a/test/test_hwo_maxiv_micromax_beamline.py
+++ b/test/test_hwo_maxiv_micromax_beamline.py
@@ -1,0 +1,26 @@
+from mxcubecore.HardwareObjects.MAXIV.MicroMAX.beamline import Beamline, SampleDelivery
+
+
+def _setup_beamline_obj(config: dict):
+    beamline = Beamline("dummy")
+    beamline._config = Beamline.HOConfig(**config)  # noqa: SLF001
+
+    return beamline
+
+
+def test_sample_delivery_osc():
+    """test 'OSC' sample delivery mode"""
+
+    beamline = _setup_beamline_obj({"sample_delivery": "osc"})
+
+    assert not beamline.is_hve_sample_delivery()
+    assert beamline.sample_delivery == SampleDelivery.osc
+
+
+def test_sample_delivery_hve():
+    """test 'HVE' sample delivery mode"""
+
+    beamline = _setup_beamline_obj({"sample_delivery": "hve"})
+
+    assert beamline.is_hve_sample_delivery()
+    assert beamline.sample_delivery == SampleDelivery.hve


### PR DESCRIPTION
Adds Beamline hardware objects used at MAXIV beamlines.

These custom hardware objects extend standard Beamline with support for beamline configuration properties `emulate` and `sample_delivery`.