### PR TITLE
beamline actions improvement

### DIFF
--- a/mxcubecore/HardwareObjects/BeamlineActions.py
+++ b/mxcubecore/HardwareObjects/BeamlineActions.py
@@ -15,6 +15,8 @@ from mxcubecore.CommandContainer import (
 from mxcubecore.TaskUtils import task
 from mxcubecore.utils.conversion import camel_to_snake
 
+hwr_log = logging.getLogger("HWR")
+
 
 class ControllerCommand(CommandObject):
     def __init__(self, name, cmd=None, username=None, klass=None):
@@ -53,9 +55,7 @@ class ControllerCommand(CommandObject):
                 res = cmd_execution.get()
                 res = res if res else ""
             except Exception:
-                logging.getLogger("HWR").exception(
-                    "%s: execution failed", str(self.name())
-                )
+                hwr_log.exception("%s: execution failed", str(self.name()))
                 self.emit("commandFailed", (str(self.name()),))
             else:
                 if isinstance(res, gevent.GreenletExit):
@@ -187,41 +187,51 @@ class BeamlineActions(HardwareObject):
         return _cls
 
     def init(self):
-        command_list = ast.literal_eval(
-            self.get_property("commands").strip().replace("\n", "")
-        )
+        command_list = self.get_property("commands")
+        if isinstance(command_list, str):
+            command_list = ast.literal_eval(command_list.strip().replace("\n", ""))
 
         for command in command_list:
-            attrname = camel_to_snake(command["command"].split(".")[-1])
+            action = command["command"].split(".")[-1]
+            attrname = camel_to_snake(action)
+            if command.get("disabled", False):
+                hwr_log.warning(f"Action {attrname} is disabled in the configuration.")
+                continue
 
             if hasattr(self, attrname):
-                msg = (
-                    "Command with name %s already exists"
-                    % command["command"].split(".")[-1]
-                )
-                logging.getLogger("HWR").warning(msg)
+                msg = f"Action {action} already exists"
+                hwr_log.warning(msg)
                 continue
 
             if command["type"] == "annotated":
-                _cls = self._get_command_object_class(command["command"])
+                try:
+                    _cls = self._get_command_object_class(command["command"])
+                except:
+                    hwr_log.exception(f"failed to load annotated action {action}")
                 fname = camel_to_snake(_cls.__name__)
                 _cls_inst = _cls(self, fname.replace("_", " ").title(), fname)
 
                 self._annotated_command_dict[fname] = _cls_inst
                 setattr(self, attrname, getattr(_cls_inst, fname))
                 self._exports_config_list.append(attrname)
+
             elif command["type"] == "controller":
                 try:
                     cmd = operator.attrgetter(command["command"])(self)
                     _cmd_obj = ControllerCommand(command["name"], cmd, command["name"])
                 except AttributeError:
-                    _cls = self._get_command_object_class(command["command"])
-                    _cmd_obj = ControllerCommand(
-                        command["name"], None, command["name"], klass=_cls
-                    )
+                    try:
+                        _cls = self._get_command_object_class(command["command"])
+                        _cmd_obj = ControllerCommand(
+                            command["name"], None, command["name"], klass=_cls
+                        )
+                    except Exception:
+                        hwr_log.exception(f"failed to load controller action {action}")
+                        continue
 
                 self._command_list.append(_cmd_obj)
                 setattr(self, attrname, _cmd_obj)
+
             elif command["type"] == "actuator":
                 try:
                     cmd = operator.attrgetter(command["command"])
@@ -292,9 +302,7 @@ class BeamlineActions(HardwareObject):
         try:
             result = greenlet.get()
         except Exception:
-            logging.getLogger("HWR").exception(
-                "%s: execution failed", self._current_command.cmd_name
-            )
+            hwr_log.exception("%s: execution failed", self._current_command.cmd_name)
             cmd_obj.emit("commandFailed", (self._current_command.cmd_name,))
         else:
             self._current_command.set_last_result(result)


### PR DESCRIPTION
beamline actions improvement

- readability
  - shorten logging lines
  - refactor long values into variables

- feature: disabled directive
  - at times, we may want to temporarily disable
    and action so a `disabled` directive has been added
  - the directive does not need to be present
  - the `disabled` directive is *false* by default so
    it does not modify existing behavior

- feature: read a pure `yaml` configuration file
  - allow for the configuration file to be 100% yaml

Example of a pure YAML config file:
```yaml
configuration:
  commands:
    - type: controller
      name: Open Safety Shutter
      command: HardwareObjects.MAXIV.BioMAX.beamline_actions.OpenSafetyShutter
      disabled: False # new feature

    - type: controller
      name: Close Safety Shutter
      command: HardwareObjects.MAXIV.BioMAX.beamline_actions.CloseSafetyShutter
      disabled: False

    - type: controller
      name: Prepare Open Hutch
      command: HardwareObjects.MAXIV.BioMAX.beamline_actions.PrepareOpenHutch
      disabled: False
```
