### PR TITLE
Make it possible to resume skipped collections

### DIFF
--- a/mxcubecore/queue_entry/base_queue_entry.py
+++ b/mxcubecore/queue_entry/base_queue_entry.py
@@ -764,6 +764,16 @@ class SampleQueueEntry(BaseQueueEntry):
         BaseQueueEntry.post_execute(self)
         params = []
 
+        # We want to make the sample entry enabled if it contains
+        # any skipped collections, so that the user can restart them
+        has_executable_child = False
+        for child_queue_entry in self._queue_entry_list:
+            if child_queue_entry.is_enabled():
+                has_executable_child = True
+                break
+        self.set_enabled(has_executable_child)
+        self.get_data_model().set_enabled(has_executable_child)
+
         # Start grouped processing, get information from each collection
         # and call autoproc with grouped processing option
         for child in self.get_data_model().get_children():


### PR DESCRIPTION
Currently BaseQueueEntry sets `_enabled` property set to `False` in the `post_execute` hook. If this property is set to True, then the queue entry is treated as "executable".
This makes it so that, SampleQueueEntry is not executable after stoppiing the queue, even if some child collections have not been executed yet.

The current behaviour causes a silent crash when trying to run queue, after stopping it, here:
https://github.com/mxcube/mxcubeweb/blob/develop/mxcubeweb/core/components/queue.py#L1847-L1853

The new strategy is to deem SampleQueueEntry as executable as long as any of child collections are executable

Note: It has been tested at BioMAX beamline and it seems to work fine :)

To reproduce the original bug one can do the following steps:
1. Add few tasks
2. Press `Run Queue`
3. Press `Stop`
4. Press `Run Queue` again

Nothing will happen.

(Note, when reproducing this bug, I've found another one: https://github.com/mxcube/mxcubecore/issues/1372)
