### PR TITLE
Fix get_object_by_role avoiding __objects attribute

### DIFF
--- a/mxcubecore/BaseHardwareObjects.py
+++ b/mxcubecore/BaseHardwareObjects.py
@@ -202,6 +202,40 @@ class ConfiguredObject:
         """
         return list(self._hwobj_by_role.keys())
 
+    def get_object_by_role(self, role: str) -> Union["HardwareObject", None]:
+        """Get hardware object by role.
+
+        Args:
+            role (str): Role.
+
+        Returns:
+            Union[HardwareObject, None]: Hardware object.
+        """
+        role = str(role).lower()
+        result = self.objects_by_role.get(role)
+
+        if result is None:
+            # Does breadth-first search of all contained HWO to look for any HWO
+            # that has the right role name
+            # This entire block is deprecated.
+            #
+            # NB if this block is removed, the entire function can be removed
+            # and replaced by self.objects_by_role.get(role)
+            objects = list(self.objects_by_role.values())
+            for obj in objects:
+                objs_by_role = obj.objects_by_role
+                result = objs_by_role.get(role)
+                if result is None:
+                    objects.extend(objs_by_role.values())
+                else:
+                    warnings.warn(
+                        "%s.%s: get_object_by_role for nested objects is Deprecated."
+                        "Avoid"
+                        % (self.__class__.__name__, role)
+                    )
+                    break
+        return result
+
     def print_log(
         self,
         log_type: str = "HWR",
@@ -489,32 +523,6 @@ class HardwareObjectNode:
         else:
             for obj in self.__objects[index]:
                 yield obj
-
-    def get_object_by_role(self, role: str) -> Union["HardwareObject", None]:
-        """Get hardware object by role.
-
-        Args:
-            role (str): Role.
-
-        Returns:
-            Union[HardwareObject, None]: Hardware object.
-        """
-        role = str(role).lower()
-        result = self._hwobj_by_role.get(role)
-
-        if result is None:
-            # Can we not get rid of this at some point? Please?
-            #
-            # Does breadth-first search of all contained HWO to look for any HWO
-            # that has the right role name
-            objects = list(self._hwobj_by_role.values())
-            for obj in objects:
-                result = obj.get_object_by_role(role)
-                if result is None:
-                    objects.extend(obj._hwobj_by_role.values())
-                else:
-                    break
-        return result
 
     def _objects_names(self) -> List[Union[str, None]]:
         """Return hardware object names.

--- a/mxcubecore/BaseHardwareObjects.py
+++ b/mxcubecore/BaseHardwareObjects.py
@@ -230,8 +230,7 @@ class ConfiguredObject:
                 else:
                     warnings.warn(
                         "%s.%s: get_object_by_role for nested objects is Deprecated."
-                        "Avoid"
-                        % (self.__class__.__name__, role)
+                        "Avoid" % (self.__class__.__name__, role)
                     )
                     break
         return result

--- a/mxcubecore/BaseHardwareObjects.py
+++ b/mxcubecore/BaseHardwareObjects.py
@@ -500,35 +500,18 @@ class HardwareObjectNode:
             Union[HardwareObject, None]: Hardware object.
         """
         role = str(role).lower()
-        #
-        # A hack to emulate get_object_by_role() for objects loaded from YAML config
-        # files.
-        #
-        # When HWOBJ is loaded from YAML, we don't populate it's '_objects_by_role'
-        # dictionary, thus that normal code path to look-up and object by role does
-        # not work.
-        #
-        # However, objects are attached to the parents _hwobj_by_role object via
-        # assignment. Try accessing using that attribute.
-        #
-        if hasattr(self, "_hwobj_by_role"):
-            obj = self._hwobj_by_role.get(role, None)
+        result = self._hwobj_by_role.get(role)
 
-            if obj is not None:
-                return obj
-
-        #
-        # Look-up object by role the old way.
-        #
-        objects = [self]
-
-        for curr in objects:
-            result = curr._objects_by_role.get(role)
-            if result is None:
-                objects.extend(obj for obj in curr if obj)
-
-            else:
-                return result
+        if result is None:
+            # Can we not get rid of this at some point? Please?
+            #
+            # Does depth-first search of all contained HWO to look for any HWO
+            # that has the right role name
+            for obj in self._hwobj_by_role.values():
+                result = obj.get_object_by_role(role)
+                if result is not None:
+                    return result
+        return result
 
     def _objects_names(self) -> List[Union[str, None]]:
         """Return hardware object names.

--- a/mxcubecore/BaseHardwareObjects.py
+++ b/mxcubecore/BaseHardwareObjects.py
@@ -505,12 +505,15 @@ class HardwareObjectNode:
         if result is None:
             # Can we not get rid of this at some point? Please?
             #
-            # Does depth-first search of all contained HWO to look for any HWO
+            # Does breadth-first search of all contained HWO to look for any HWO
             # that has the right role name
-            for obj in self._hwobj_by_role.values():
+            objects = list(self._hwobj_by_role.values())
+            for obj in objects:
                 result = obj.get_object_by_role(role)
-                if result is not None:
-                    return result
+                if result is None:
+                    objects.extend(obj._hwobj_by_role.values())
+                else:
+                    break
         return result
 
     def _objects_names(self) -> List[Union[str, None]]:


### PR DESCRIPTION
This should have the same effect as PR #1377, but avoids using the __objects attribute, removes some obsolete code and comments, and moves the code base a step towards yaml configuration instead of sticking with xml-based attributes.

This would be a good time to simplify the structure of BaseHardwareObject inheritance - all HardwareObjects are subtypes of ConfiguredObject, HardwareObjectNode, and HardwareObjectMixin so they ought to be merged (and this would get rid of a warning from using ConfiguredObject._hwobj_by_role in a function defined in HardwareObjectNode). But for now let us just do this fix.