### PR TITLE
tests: fix deprecated warnings in beamline tests

### DIFF
--- a/test/test_beamline_ho_id.py
+++ b/test/test_beamline_ho_id.py
@@ -38,11 +38,9 @@ class TestBeamlineHoId:
     def test_beamline_id(self, test_object):
         # Test if we can retrieve a object located directly on
         # the beamline object
-        ho = test_object.get_hardware_object("diffractometer")
-        ho_id = test_object.get_id(ho)
-        assert "diffractometer" == ho_id
+        ho = test_object.get_by_id("diffractometer")
+        assert "diffractometer" == ho.id
 
         # Test if we can get an object further down the structure
-        ho = test_object.get_hardware_object("diffractometer.sampx")
-        ho_id = test_object.get_id(ho)
-        assert "diffractometer.sampx" == ho_id
+        ho = test_object.get_by_id("diffractometer.sampx")
+        assert "diffractometer.sampx" == ho.id


### PR DESCRIPTION
Use `hwobj.id` attribute and `get_by_id()` method in the tests.

This fixes these warnings:

```
test/test_beamline_ho_id.py::TestBeamlineHoId::test_beamline_id
  /<...>/mxcube/core/test/test_beamline_ho_id.py:46:
    UserWarning: Beamline.get_hardware_object is Deprecated.
    Use get_by_id instead
    ho = test_object.get_hardware_object("diffractometer.sampx")

test/test_beamline_ho_id.py::TestBeamlineHoId::test_beamline_id
  /<...>/mxcube/core/test/test_beamline_ho_id.py:47:
    UserWarning: Beamline.get_id is Deprecated.
    Use hwobj.id instead
    ho_id = test_object.get_id(ho)
```