### PR TITLE
[Fix] `_set_loaded_sample` (AbstractSampleChanger) doesn't work

### DIFF
--- a/mxcubecore/HardwareObjects/abstract/AbstractSampleChanger.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractSampleChanger.py
@@ -816,22 +816,14 @@ class SampleChanger(Container, HardwareObject):
         self._trigger_loaded_sample_changed_event(None)
 
     def _set_loaded_sample(self, sample):
-        previous_loaded = None
-
-        for smp in self.get_sample_list():
-            if smp.is_loaded():
-                previous_loaded = smp
-                break
-
-        for smp in self.get_sample_list():
-            if smp != sample:
-                smp._set_loaded(False)
+        for s in self.get_sample_list():
+            if s != sample:
+                s._set_loaded(False)
             else:
-                if self.get_loaded_sample() == smp:
-                    smp._set_loaded(True)
+                if self.get_loaded_sample() != s:
+                    s._set_loaded(True)
 
-        if previous_loaded != self.get_loaded_sample():
-            self._trigger_loaded_sample_changed_event(sample)
+        self._trigger_loaded_sample_changed_event(sample)
 
     def _set_selected_sample(self, sample):
         cur = self.get_selected_sample()


### PR DESCRIPTION
I noticed an issue in the `_set_loaded_sample` method of the `AbstractSampleChanger` HWO
https://github.com/mxcube/mxcubecore/blob/d17aef2a22fa203081f4f9fe5621fd853710da76/mxcubecore/HardwareObjects/abstract/AbstractSampleChanger.py#L818-L834
I expected `_set_loaded_sample` to set the given sample as loaded and then trigger the corresponding event, but that didn’t happen.

After looking into the method, I think I found the problem, the following condition https://github.com/mxcube/mxcubecore/blob/d17aef2a22fa203081f4f9fe5621fd853710da76/mxcubecore/HardwareObjects/abstract/AbstractSampleChanger.py#L830-L831 is only satisfied when the currently mounted sample is the same as the one you’re trying to mount.
So it seems the sample is never marked as loaded when the passed sample is different.

### Changes

I modified the method as follows:
```diff
def _set_loaded_sample(self, sample):

    previous_loaded = None

-   for smp in self.get_sample_list():
-       if smp.is_loaded():
-          previous_loaded = smp
-          break

    for smp in self.get_sample_list():
        if smp != sample:
            smp._set_loaded(False)
        else:
-           if self.get_loaded_sample() == smp:
+           if self.get_loaded_sample() != smp:
                smp._set_loaded(True)
+               self._trigger_loaded_sample_changed_event(sample)
                
-   if previous_loaded != self.get_loaded_sample():
-       self._trigger_loaded_sample_changed_event(sample)
```
This change seems to fix the problem.

### Notes
In the past the implementation was very similar to mine, except for the signal trigger, but there was this commit 6f82279 which introduced the current logic, so maybe I’m missing something...