### PR TITLE
Rename / bug fix for get_full_path function

### DIFF
--- a/mxcubecore/HardwareObjects/ESRF/ESRFSession.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFSession.py
@@ -27,7 +27,7 @@ class ESRFSession(Session.Session):
                 archive_base_directory, archive_folder
             )
 
-    def get_full_path(self, subdir: str, tag: str) -> Tuple[str, str]:
+    def get_full_paths(self, subdir: str, tag: str) -> Tuple[str, str]:
         """
         Returns the full path to both image and processed data.
         The path(s) returned will follow the convention:

--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -325,31 +325,30 @@ class ICATLIMS(AbstractLims):
                     self.__get_sample_information_by(sample_sheet_id)
                 )
                 if sample_information is not None:
-                    if len(HWR.beamline.session.get_full_path("", "")) > 0:
-                        destination_folder = (
-                            HWR.beamline.session.get_base_process_directory()
-                        )
-                        msg = "Download restource: "
-                        msg += f"sample_sheet_id={sample_sheet_id} "
-                        msg += f"destination_folder={destination_folder}"
-                        logger.debug(msg)
-                        downloads = self._download_resources(
-                            sample_sheet_id,
-                            sample_information.resources,
-                            destination_folder,
-                            sample_name,
-                        )
-                        msg = f"downloaded {len(downloads)} resources"
-                        logger.debug(msg)
-                        if len(downloads) > 0:
-                            try:
-                                self.__add_download_path_to_processing_plan(
-                                    processing_plan, downloads
-                                )
-                            except RuntimeError:
-                                logger.exception(
-                                    "Failed __add_download_path_to_processing_plan"
-                                )
+                    destination_folder = (
+                        HWR.beamline.session.get_base_process_directory()
+                    )
+                    msg = "Download restource: "
+                    msg += f"sample_sheet_id={sample_sheet_id} "
+                    msg += f"destination_folder={destination_folder}"
+                    logger.debug(msg)
+                    downloads = self._download_resources(
+                        sample_sheet_id,
+                        sample_information.resources,
+                        destination_folder,
+                        sample_name,
+                    )
+                    msg = f"downloaded {len(downloads)} resources"
+                    logger.debug(msg)
+                    if len(downloads) > 0:
+                        try:
+                            self.__add_download_path_to_processing_plan(
+                                processing_plan, downloads
+                            )
+                        except RuntimeError:
+                            logger.exception(
+                                "Failed __add_download_path_to_processing_plan"
+                            )
 
                 processing_plan = {
                     item["key"]: item["value"] for item in processing_plan

--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -328,7 +328,7 @@ class ICATLIMS(AbstractLims):
                     destination_folder = (
                         HWR.beamline.session.get_base_process_directory()
                     )
-                    msg = "Download restource: "
+                    msg = "Download resource: "
                     msg += f"sample_sheet_id={sample_sheet_id} "
                     msg += f"destination_folder={destination_folder}"
                     logger.debug(msg)

--- a/mxcubecore/HardwareObjects/Native/__init__.py
+++ b/mxcubecore/HardwareObjects/Native/__init__.py
@@ -106,9 +106,9 @@ def queue_update_result(server_hwobj, node_id, html_report):
     return result
 
 
-def queue_get_full_path(server_hwobj, subdir, tag):
+def queue_get_full_paths(server_hwobj, subdir, tag):
     """ """
-    return HWR.beamline.session.get_full_path(subdir, tag)
+    return HWR.beamline.session.get_full_paths(subdir, tag)
 
 
 def queue_get_model_code(server_hwobj):

--- a/mxcubecore/HardwareObjects/Session.py
+++ b/mxcubecore/HardwareObjects/Session.py
@@ -262,7 +262,7 @@ class Session(HardwareObject):
 
         return f"{directory}/"
 
-    def get_full_path(self, subdir: str = "", tag: str = "") -> Tuple[str, str]:
+    def get_full_paths(self, subdir: str = "", tag: str = "") -> Tuple[str, str]:
         """
         Returns the full path to both image and processed data.
         The path(s) returned will follow the convention:


### PR DESCRIPTION
Clean-up / rename, changing get_full_path to get_full_paths. The function returns two paths, so the name ought to be plural.
Also includes apparent bug fix in ICATLims.__to_sample
Coupled with parallel PR in mxcubeweb

The autotest fails, but it does not look like the failure has anything to do with the changes in the PR.