### PR TITLE
Reinstate GenericDiffractometer.zoom property

### DIFF
--- a/mxcubecore/HardwareObjects/GenericDiffractometer.py
+++ b/mxcubecore/HardwareObjects/GenericDiffractometer.py
@@ -610,6 +610,22 @@ class GenericDiffractometer(HardwareObject):
         """
         return self.motor_hwobj_dict.get("phiz")
 
+    @property
+    def zoom(self):
+        """zoom motor object
+
+        NBNB TBD This is supposedly now living in AbstractSampleView,
+        And the property was removed in an earlier PR (20251021, 15:24 Elmir Jagudin)
+        BUT 1) there does not seem to be any mechanism to set it from config there
+        2) it is configured on the diffractometer according to available config files
+        3) accessing diffractometer.zoom is all through the code
+        This needs global refactoring, but meanwhile this property should remain
+
+        Returns:
+            AbstractActuator
+        """
+        return self.motor_hwobj_dict.get("zoom")
+
     def is_ready(self):
         """
         Detects if device is ready

--- a/mxcubecore/HardwareObjects/Gphl/GphlMessages.py
+++ b/mxcubecore/HardwareObjects/Gphl/GphlMessages.py
@@ -1310,7 +1310,8 @@ class SampleCentred(Payload):
             self._wavelengths = tuple((data_model.wavelengths[0],))
             # if data_model.wftype != "diffractcal":
             #     self._detectorSetting = data_model.detector_setting
-        self._detectorSetting = data_model.detector_setting
+        if data_model.wftype != "diffractcal":
+            self._detectorSetting = data_model.detector_setting
 
     @property
     def imageWidth(self):

--- a/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
+++ b/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
@@ -844,6 +844,7 @@ class GphlWorkflow(HardwareObject):
         HWR.beamline.gphl_connection.open_connection()
 
         if data_model.wftype == "transcal":
+            self._workflow_queue = gevent.queue.Queue()
             return
         elif data_model.automation_mode:
             params = data_model.auto_acq_parameters[0]


### PR DESCRIPTION
Currently the QtGraphicsManager.zoom property is broken, because it delegates to GenericDiffractometer.zoom,, which was removed months ago. The entire issue of how and where the zoom motor should be configured needs fixing (see mxcubecore issue #1404), but meanwhile this change does not hurt and allows existing code to work, also in the Qt branch.