### PR TITLE
Removed inroccrect `exception` log statement

### DIFF
--- a/mxcubecore/HardwareObjects/XMLRPCServer.py
+++ b/mxcubecore/HardwareObjects/XMLRPCServer.py
@@ -689,7 +689,7 @@ class XMLRPCServer(HardwareObject):
                         module_name + "." + sub_module[1], recurse=False, prefix=prefix
                     )
                 except StopIteration:
-                    logging.getLogger("HWR").exception("")
+                    pass
 
     def set_token(self, token):
         SecureXMLRpcRequestHandler.setReferenceToken(token)


### PR DESCRIPTION
The `exception` log statement was added by mistake to a `StopIteration` case where it should not be ;)