### PR TITLE
Remove unused `MANIFEST.in` file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-#https://packaging.python.org/guides/using-manifest-in/
-recursive-include mxcubecore/configuration *.xml *.yml *.jpg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = [
 
 [tool.poetry]
 requires-poetry = "2.1.3"  # Keep in sync with `.pre-commit-config.yaml`
-# Exclude some files from being added to *sdist* and * wheel* distribution packages
+# Exclude some files from being added to *sdist* and *wheel* distribution packages
 exclude = [
     "mxcubecore/configuration",
 ]


### PR DESCRIPTION
The `MANIFEST.in`file is used by `setuptools` (and `distutils`) to influence the content of built distributions (*sdist*  and *wheel*). In this case it was meant to add files from `mxcubecore/configuration`.

But this project now uses Poetry as build backend and `mxcubecore/configuration` is explicitly excluded.

Commit 47b50f2a14bdca11bd63604543bed5449077a226 migrated to Poetry as the build backend.

Commit 0b11fa43c4f65edd4fb020db5b410b4b2cb92527 excluded `mxcubecore/configuration` from built distributions.