### PR TITLE
changed beamline.yaml to beamline_config.yaml

### DIFF
--- a/mxcubecore/HardwareRepository.py
+++ b/mxcubecore/HardwareRepository.py
@@ -83,7 +83,7 @@ beamline = None
 # Supported beamline configuration filenames.
 # The first name in the list takes precedence.
 #
-BEAMLINE_CONFIG_FILES = ["beamline.yaml", "beamline_config.yml"]
+BEAMLINE_CONFIG_FILES = ["beamline_config.yaml", "beamline_config.yml"]
 
 
 def load_from_yaml(


### PR DESCRIPTION
@elmjag  in your previous PR you've changed beamline_config to beamline. Was this for purpose? I find it better with _config, as indeed it describes the configuration of the beamline, not the beamline itself.