### PR TITLE
Create LNLSLIMS for LNLS Authentication

### DIFF
--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -59,6 +59,9 @@ class ICATLIMS(AbstractLims):
             Lims(name="DRAC", description="Data Repository for Advancing open sCience"),
         ]
 
+    def _create_icat_session(self, user_name: str, password: str):
+        self.icat_session: ICATSession = self.icatClient.do_log_in(password)
+
     def login(
         self,
         user_name: str,
@@ -68,7 +71,7 @@ class ICATLIMS(AbstractLims):
         msg = f"authenticate {user_name}"
         logger.debug(msg)
 
-        self.icat_session: ICATSession = self.icatClient.do_log_in(password)
+        self._create_icat_session(user_name=user_name, password=password)
 
         if self.icatClient is None or self.icatClient is None:
             msg = "Error initializing icatClient: "

--- a/mxcubecore/HardwareObjects/LNLS/LNLSLIMS.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSLIMS.py
@@ -19,3 +19,23 @@ class LNLSLIMS(ICATLIMS):
             metadata_urls=["10.39.50.51"],
             reschedule_investigation_urls=["10.39.50.51"],
         )
+        
+    def is_single_session_available(self):
+        """
+        True if there is no active session and there is
+        a single session available
+        """
+        return (
+            self.session_manager.active_session is None
+            and len(self.session_manager.sessions) == 1
+        )
+    
+    def login(self, user_name, token, is_local_host=False):
+        session_manager, lims_username, sessions = super().login(user_name, token, self.session_manager)
+        self.session_manager = session_manager
+        self.add_user_and_shared_sessions(lims_username, sessions)
+        if self.is_single_session_available():
+            single_session = self.session_manager.sessions[0]
+            self.set_active_session_by_id(single_session.session_id)
+
+        return session_manager

--- a/mxcubecore/HardwareObjects/LNLS/LNLSLIMS.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSLIMS.py
@@ -2,22 +2,22 @@
 A client for ISPyB Webservices.
 """
 
-from mxcubecore.HardwareObjects.ICATLIMS import ICATLIMS
 from pyicat_plus.client.main import IcatClient
+
+from mxcubecore.HardwareObjects.ICATLIMS import ICATLIMS
 
 
 class LNLSLIMS(ICATLIMS):
-
     def init(self):
         self.url = self.get_property("ws_root")
         self.ingesters = self.get_property("queue_urls")
         self.investigations = []
         self.samples = []
-        
+
         self.icatClient = IcatClient(
             icatplus_restricted_url="https://icat-plus.cnpem.br"
         )
-        
+
     def is_single_session_available(self):
         """
         True if there is no active session and there is
@@ -27,12 +27,15 @@ class LNLSLIMS(ICATLIMS):
             self.session_manager.active_session is None
             and len(self.session_manager.sessions) == 1
         )
-    
+
     def _create_icat_session(self, user_name: str, password: str):
         self.icat_session = self.icatClient.do_log_in(user_name, password)
 
-    def login(self, user_name, token, is_local_host=False):
-        session_manager, lims_username, sessions = super().login(user_name, token, self.session_manager)
+    def login(self, user_name, token, is_local_host):
+        self.is_local_host = is_local_host
+        session_manager, lims_username, sessions = super().login(
+            user_name, token, self.session_manager
+        )
         self.session_manager = session_manager
         self.add_user_and_shared_sessions(lims_username, sessions)
         if self.is_single_session_available():

--- a/mxcubecore/HardwareObjects/LNLS/LNLSLIMS.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSLIMS.py
@@ -9,9 +9,13 @@ from pyicat_plus.client.main import IcatClient
 class LNLSLIMS(ICATLIMS):
 
     def init(self):
-        super().init()
+        self.url = self.get_property("ws_root")
+        self.ingesters = self.get_property("queue_urls")
+        self.investigations = []
+        self.samples = []
+        
         self.icatClient = IcatClient(
-            icatplus_restricted_url=self.url,
-            metadata_urls=["bcu-mq-01:61613"],
-            reschedule_investigation_urls=["bcu-mq-01:61613"],
+            icatplus_restricted_url="https://icat-plus.cnpem.br",
+            metadata_urls=["10.39.50.51"],
+            reschedule_investigation_urls=["10.39.50.51"],
         )

--- a/mxcubecore/HardwareObjects/LNLS/LNLSLIMS.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSLIMS.py
@@ -16,8 +16,8 @@ class LNLSLIMS(ICATLIMS):
         
         self.icatClient = IcatClient(
             icatplus_restricted_url="https://icat-plus.cnpem.br",
-            metadata_urls=["10.39.50.51"],
-            reschedule_investigation_urls=["10.39.50.51"],
+            metadata_urls=["https://icat-plus.cnpem.br"],
+            reschedule_investigation_urls=["https://icat-plus.cnpem.br"],
         )
         
     def is_single_session_available(self):
@@ -30,6 +30,9 @@ class LNLSLIMS(ICATLIMS):
             and len(self.session_manager.sessions) == 1
         )
     
+    def _create_icat_session(self, user_name: str, password: str):
+        self.icat_session = self.icatClient.do_log_in(user_name, password)
+
     def login(self, user_name, token, is_local_host=False):
         session_manager, lims_username, sessions = super().login(user_name, token, self.session_manager)
         self.session_manager = session_manager

--- a/mxcubecore/HardwareObjects/LNLS/LNLSLIMS.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSLIMS.py
@@ -15,9 +15,7 @@ class LNLSLIMS(ICATLIMS):
         self.samples = []
         
         self.icatClient = IcatClient(
-            icatplus_restricted_url="https://icat-plus.cnpem.br",
-            metadata_urls=["https://icat-plus.cnpem.br"],
-            reschedule_investigation_urls=["https://icat-plus.cnpem.br"],
+            icatplus_restricted_url="https://icat-plus.cnpem.br"
         )
         
     def is_single_session_available(self):

--- a/mxcubecore/HardwareObjects/LNLS/LNLSLIMS.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSLIMS.py
@@ -1,0 +1,17 @@
+"""
+A client for ISPyB Webservices.
+"""
+
+from mxcubecore.HardwareObjects.ICATLIMS import ICATLIMS
+from pyicat_plus.client.main import IcatClient
+
+
+class LNLSLIMS(ICATLIMS):
+
+    def init(self):
+        super().init()
+        self.icatClient = IcatClient(
+            icatplus_restricted_url=self.url,
+            metadata_urls=["bcu-mq-01:61613"],
+            reschedule_investigation_urls=["bcu-mq-01:61613"],
+        )


### PR DESCRIPTION
- Implement ICATLIMS fix in order to authenticate with both username and password. This was done because the pyicat plus used in the LNLS needs both username and password for the login.
- Implement LNLSLIMS