### PR TITLE
Clean up `/docs/conf.py`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,6 @@
+# noqa: INP001  # The parent directory is not meant to be imported as a package.
+
+
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:
@@ -16,7 +19,7 @@ PROJECT_PACKAGE_METADATA = importlib.metadata.metadata(PROJECT_PACKAGE_NAME)
 
 project = "MXCuBE-Core"
 author = PROJECT_PACKAGE_METADATA["Author"]
-copyright = (f"{datetime.datetime.today().year}, {author}",)
+project_copyright = f"{datetime.datetime.now(tz=datetime.timezone.utc).year}, {author}"
 
 version = PROJECT_PACKAGE_METADATA["Version"]
 release = version

--- a/ruff.toml
+++ b/ruff.toml
@@ -38,11 +38,6 @@ convention = "google"
 "test/Test*.py" = [
     "S101",  # Allow uses of the `assert` keyword
 ]
-"docs/conf.py" = [
-    "A001",
-    "DTZ002",
-    "INP001",  # `implicit-namespace-package`: `conf.py` is not meant to be imported
-]
 "mxcubecore/BaseHardwareObjects.py" = [
     "A001",
     "ARG002",


### PR DESCRIPTION
`copyright` is a built-in Python variable. From Sphinx's point of view, `project_copyright` is an alias of `copyright`.

The parent directory `/docs` is not meant to be an importable package.