### PR TITLE
Remove value_changed call at init

### DIFF
--- a/mxcubecore/Command/Epics.py
+++ b/mxcubecore/Command/Epics.py
@@ -75,9 +75,7 @@ class EpicsCommand(CommandObject):
         time.sleep(0.1)
         self.pv_connected = self.pv.connect(timeout=0.1)
 
-        if self.pv_connected:
-            self.value_changed(self.pv.get(as_string=self.read_as_str, timeout=0.1))
-        else:
+        if not self.pv_connected:
             logging.getLogger("HWR").error(
                 "EpicsCommand: Error connecting to pv %s.", self.pv_name
             )


### PR DESCRIPTION
This was done because this function will always break, as the self.__value_changed_callback_ref will only be set in the poll function. This was discovered due to the log added by Marcus some weeks ago.