### PR TITLE
1437 Remove hard-coded endpoints

### DIFF
--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -1070,10 +1070,8 @@ class ICATLIMS(AbstractLims):
             Optional[SampleInformation]: Returns a SampleInformation object or None.
         """
         try:
-            result = self.icatClient.get_sample_files_information_by(
-                sample_id=sample_id
-            )
-            SampleInformation.parse_obj(result)
+            result = self.icatClient.get_sample_files_information_by(sample_id)
+            return SampleInformation.parse_obj(result)
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404:
                 logger.info("Sample %s not found (404)", sample_id)

--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -8,6 +8,7 @@ from typing import Any, List, Optional
 from zoneinfo import ZoneInfo
 
 import requests
+from pydantic import ValidationError
 from pyicat_plus.client.main import IcatClient
 
 from mxcubecore import HardwareRepository as HWR
@@ -1069,21 +1070,19 @@ class ICATLIMS(AbstractLims):
             Optional[SampleInformation]: Returns a SampleInformation object or None.
         """
         try:
-            token = self.icat_session["sessionId"]
-            url = f"{self.url}/catalogue/{token}/files?sampleId={sample_id}"
-            response = requests.get(url, timeout=3)
-            response.raise_for_status()  # Raise an exception for bad status codes
-            return SampleInformation(
-                **response.json(),
-            )  # Parse the response into a SampleInformation model
+            result = self.icatClient.get_sample_files_information_by(
+                sample_id=sample_id
+            )
+            SampleInformation.parse_obj(result)
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404:
                 logger.info("Sample %s not found (404)", sample_id)
             else:
                 logger.exception("HTTP error for sample %s", sample_id)
-
         except requests.exceptions.RequestException:
             logger.exception("Request error for sample %s", sample_id)
+        except ValidationError:
+            logger.exception("Invalid response format for sample %s", sample_id)
         return None
 
     def _download_resources(
@@ -1112,21 +1111,19 @@ class ICATLIMS(AbstractLims):
             )  # Make sure the folder exists
 
             try:
-                token = self.icat_session["sessionId"]
-                url = f"{self.url}/catalogue/{token}/files/download?sampleId={sample_id}&resourceId={resource.id}"
-                response = requests.get(url, stream=True, timeout=30)
-                response.raise_for_status()
-
-                file_path = resource_folder / resource.filename
-                with file_path.open("wb") as file:
-                    for chunk in response.iter_content(
-                        chunk_size=8192,
-                    ):  # Efficient chunked download
-                        file.write(chunk)
+                result = self.icatClient.download_file_by(
+                    sample_id=sample_id,
+                    resource_id=resource.id,
+                    use_chunks=True,
+                    chunk_size=8192,
+                )
+                output_path = Path(resource_folder / resource.filename)
+                with output_path.open("wb") as f:
+                    f.write(result)
 
                 # Create a new Download instance with updated path
                 downloaded = Download(
-                    path=str(file_path),
+                    path=str(output_path),
                     filename=resource.filename,
                     groupName=resource.groupName,
                 )

--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -4,14 +4,11 @@ import shutil
 from collections import defaultdict
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import Any, List, Optional
 from zoneinfo import ZoneInfo
 
 import requests
 from pyicat_plus.client.main import IcatClient
-
-if TYPE_CHECKING:
-    from pyicat_plus.client.models.session import Session as ICATSession
 
 from mxcubecore import HardwareRepository as HWR
 from mxcubecore.BaseHardwareObjects import HardwareObject
@@ -60,7 +57,7 @@ class ICATLIMS(AbstractLims):
         ]
 
     def _create_icat_session(self, user_name: str, password: str):
-        self.icat_session: ICATSession = self.icatClient.do_log_in(password)
+        self.icat_session: dict = self.icatClient.do_log_in(password)
 
     def login(
         self,

--- a/poetry.lock
+++ b/poetry.lock
@@ -527,6 +527,39 @@ files = [
 ]
 
 [[package]]
+name = "esrf-ontologies"
+version = "1.1.0"
+description = "ESRF Ontologies"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "esrf_ontologies-1.1.0-py3-none-any.whl", hash = "sha256:c48789eab516d2bc4090b27471d5904e600358e80e14b72b94572705dfe88165"},
+    {file = "esrf_ontologies-1.1.0.tar.gz", hash = "sha256:d3fab908a148e54b0314abc44cb81d87662d37bbd37d7a57e48326b4d42b4259"},
+]
+
+[package.extras]
+dev = ["black (>=22)", "esrf-ontologies[test]", "flake8 (>=4)", "owlready2"]
+doc = ["esrf-ontologies[test]", "pydata-sphinx-theme", "sphinx (>=4.5)", "sphinx-autodoc-typehints (>=1.16)"]
+test = ["pytest (>=7)"]
+
+[[package]]
+name = "esrf-pathlib"
+version = "0.6.0"
+description = "A drop-in pathlib clone with ESRF-specific path utilities"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "esrf_pathlib-0.6.0.tar.gz", hash = "sha256:d8589936e8407a606210fed324e2ee97ab7896cf9314f67c06064ecb000d7687"},
+]
+
+[package.extras]
+dev = ["black (>=22)", "esrf-pathlib[test]", "flake8 (>=4.0)", "isort"]
+doc = ["esrf-pathlib[test]", "pydata-sphinx-theme", "sphinx (>=6.0)", "sphinx-autodoc-typehints"]
+test = ["pytest (>=7.0)"]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.1.1"
 description = "Backport of PEP 654 (exception groups)"
@@ -1957,16 +1990,18 @@ plugins = ["importlib-metadata ; python_version < \"3.8\""]
 
 [[package]]
 name = "pyicat-plus"
-version = "0.6.0"
+version = "0.11.0"
 description = "Python client to ICAT+"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "pyicat_plus-0.6.0.tar.gz", hash = "sha256:3b727b4b227c789ea629ca52a6cab745e692611b13c49ce0a58b0a5582d918a6"},
+    {file = "pyicat_plus-0.11.0.tar.gz", hash = "sha256:f8e9f78bb2db267311576918e7b2c47b62d5fe7d9c3e77ed99029d4a0051b008"},
 ]
 
 [package.dependencies]
+esrf-ontologies = "*"
+esrf-pathlib = "*"
 h5py = "*"
 icat-esrf-definitions = "*"
 numpy = "*"
@@ -1977,8 +2012,8 @@ tqdm = "*"
 
 [package.extras]
 bliss = ["blissdata[beacon]"]
-dev = ["black (>=25)", "flake8 (>=4)", "pyicat-plus[test]"]
-doc = ["pydata-sphinx-theme (<0.15)", "pyicat-plus[test]", "sphinx (>=4.5)", "sphinx-autodoc-typehints (>=1.16)"]
+dev = ["black (>=25)", "flake8 (>=4)", "isort", "pep8-naming", "pyicat-plus[test]"]
+doc = ["pydata-sphinx-theme", "pyicat-plus[test]", "sphinx (>=4.5)", "sphinx-autodoc-typehints (>=1.16)", "sphinx-copybutton"]
 test = ["coilmq", "h5py (>=3.5)", "numpy (>=1.15)", "psutil", "pyicat-plus[bliss]", "pytest (>=7)", "pytest-timeout (>=2.1)", "stomp.py (>=7)", "xmltodict"]
 
 [[package]]
@@ -2900,4 +2935,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "c1f2b461307031393da7729822679b36a52f286bf8f9b80f814505b9d2af711d"
+content-hash = "8f20c3df74d031c448fb7a8b0612f8d3cd59f00f668772395a385be09c789ec5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ PyTango = "^9.3.6"
 python-ldap = "^3.4.0"
 requests = "^2.31.0"
 colorama = "^0.4.6"
-pyicat-plus = {version = "^0.6.0", optional = true}
+pyicat-plus = {version = "^0.11.0", optional = true}
 mxcube-video-streamer = ">=1.8.3"
 defusedxml = "0.7.1"
 


### PR DESCRIPTION
- use `pyicat-plus` library instead of hard-coded endpoints
- upgrade pyicat-plus version
- remove `ICATSession`, it is defined as a dict in pyicat-plus

=> this changes require an upgrade of `pyicat-plus` library to 0.11.0