### PR TITLE
beamline actions improvement

### DIFF
--- a/mxcubecore/HardwareObjects/BeamlineActions.py
+++ b/mxcubecore/HardwareObjects/BeamlineActions.py
@@ -207,8 +207,9 @@ class BeamlineActions(HardwareObject):
                     _cls = self._get_command_object_class(command["command"])
                 except:
                     self.log.exception(f"failed to load annotated action {action}")
-                fname = camel_to_snake(_cls.__name__)
-                _cls_inst = _cls(self, fname.replace("_", " ").title(), fname)
+                else:
+                    fname = camel_to_snake(_cls.__name__)
+                    _cls_inst = _cls(self, fname.replace("_", " ").title(), fname)
 
                 self._annotated_command_dict[fname] = _cls_inst
                 setattr(self, attrname, getattr(_cls_inst, fname))

--- a/mxcubecore/HardwareObjects/BeamlineActions.py
+++ b/mxcubecore/HardwareObjects/BeamlineActions.py
@@ -205,7 +205,7 @@ class BeamlineActions(HardwareObject):
             if command["type"] == "annotated":
                 try:
                     _cls = self._get_command_object_class(command["command"])
-                except:
+                except Exception:
                     self.log.exception(f"failed to load annotated action {action}")
                 else:
                     fname = camel_to_snake(_cls.__name__)

--- a/mxcubecore/HardwareObjects/BeamlineActions.py
+++ b/mxcubecore/HardwareObjects/BeamlineActions.py
@@ -19,6 +19,7 @@ from mxcubecore.utils.conversion import camel_to_snake
 class ControllerCommand(CommandObject):
     def __init__(self, name, cmd=None, username=None, klass=None):
         CommandObject.__init__(self, name, username)
+        self.log = logging.getLogger("HWR")
 
         if not cmd:
             self._cmd = klass()
@@ -185,23 +186,27 @@ class BeamlineActions(HardwareObject):
         return _cls
 
     def init(self):
-        command_list = ast.literal_eval(
-            self.get_property("commands").strip().replace("\n", "")
-        )
+        command_list = self.get_property("commands")
+        if isinstance(command_list, str):
+            command_list = ast.literal_eval(command_list.strip().replace("\n", ""))
 
         for command in command_list:
-            attrname = camel_to_snake(command["command"].split(".")[-1])
+            action = command["command"].split(".")[-1]
+            attrname = camel_to_snake(action)
+            if command.get("disabled", False):
+                self.log.warning(f"Action {attrname} is disabled in the configuration.")
+                continue
 
             if hasattr(self, attrname):
-                msg = (
-                    "Command with name %s already exists"
-                    % command["command"].split(".")[-1]
-                )
+                msg = f"Action {action} already exists"
                 self.log.warning(msg)
                 continue
 
             if command["type"] == "annotated":
-                _cls = self._get_command_object_class(command["command"])
+                try:
+                    _cls = self._get_command_object_class(command["command"])
+                except:
+                    self.log.exception(f"failed to load annotated action {action}")
                 fname = camel_to_snake(_cls.__name__)
                 _cls_inst = _cls(self, fname.replace("_", " ").title(), fname)
 
@@ -213,13 +218,18 @@ class BeamlineActions(HardwareObject):
                     cmd = operator.attrgetter(command["command"])(self)
                     _cmd_obj = ControllerCommand(command["name"], cmd, command["name"])
                 except AttributeError:
-                    _cls = self._get_command_object_class(command["command"])
-                    _cmd_obj = ControllerCommand(
-                        command["name"], None, command["name"], klass=_cls
-                    )
+                    try:
+                        _cls = self._get_command_object_class(command["command"])
+                        _cmd_obj = ControllerCommand(
+                            command["name"], None, command["name"], klass=_cls
+                        )
+                    except Exception:
+                        self.log.exception(f"failed to load controller action {action}")
+                        continue
 
                 self._command_list.append(_cmd_obj)
                 setattr(self, attrname, _cmd_obj)
+
             elif command["type"] == "actuator":
                 try:
                     cmd = operator.attrgetter(command["command"])

--- a/mxcubecore/HardwareObjects/BeamlineActions.py
+++ b/mxcubecore/HardwareObjects/BeamlineActions.py
@@ -185,7 +185,7 @@ class BeamlineActions(HardwareObject):
 
         return _cls
 
-    def init(self):
+    def init(self): # noqa: C901
         command_list = self.get_property("commands")
         if isinstance(command_list, str):
             command_list = ast.literal_eval(command_list.strip().replace("\n", ""))

--- a/mxcubecore/HardwareObjects/BeamlineActions.py
+++ b/mxcubecore/HardwareObjects/BeamlineActions.py
@@ -185,7 +185,7 @@ class BeamlineActions(HardwareObject):
 
         return _cls
 
-    def init(self): # noqa: C901
+    def init(self):  # noqa: C901
         command_list = self.get_property("commands")
         if isinstance(command_list, str):
             command_list = ast.literal_eval(command_list.strip().replace("\n", ""))


### PR DESCRIPTION
beamline actions improvement

- readability
  - shorten logging lines
  - refactor long values into variables

- feature: disabled directive
  - at times, we may want to temporarily disable and action so a `disabled` directive has been added
  - the directive does not need to be present
  - the `disabled` directive is *false* by default so it does not modify existing behavior

- feature: read a pure `yaml` configuration file
  - allow for the configuration file to be 100% yaml

Example of a pure YAML config file:
```yaml
configuration:
  commands:
    - type: controller
      name: Open Safety Shutter
command:
HardwareObjects.MAXIV.BioMAX.beamline_actions.OpenSafetyShutter
      disabled: False # new feature

    - type: controller
      name: Close Safety Shutter
command:
HardwareObjects.MAXIV.BioMAX.beamline_actions.CloseSafetyShutter
      disabled: False

    - type: controller
      name: Prepare Open Hutch
command:
HardwareObjects.MAXIV.BioMAX.beamline_actions.PrepareOpenHutch
      disabled: False
```