### PR TITLE
ESS: Add NICOS classes (for connection, actuator and motor)

### DIFF
--- a/mxcubecore/HardwareObjects/ESS/NICOSActuator.py
+++ b/mxcubecore/HardwareObjects/ESS/NICOSActuator.py
@@ -15,38 +15,38 @@ Example of config file:
 </object>
 """
 
-from gevent import monkey
-monkey.patch_all()
-
 import time
+
 import gevent
+from gevent import monkey
 
 from mxcubecore.HardwareObjects.abstract import AbstractActuator
 
 from .nicos_connection import connect_to_nicos
 
+monkey.patch_all()
+
 
 class NICOSActuator(AbstractActuator.AbstractActuator):
     """NICOS Actuator class
-    
+
     Controls a NICOS EpicsAnalogMoveable device."""
 
     def __init__(self, name):
         super().__init__(name)
         self.__wait_actuator_task = None
-        self._nominal_limits = (-1E4, 1E4)
+        self._nominal_limits = (-1e4, 1e4)
         self.last_target_value = None
         self.ERROR_READBACK = 0
 
     def init(self):
-        """ Initialization method """
+        """Initialization method"""
         super(NICOSActuator, self).init()
 
-        host = self.get_property("host") # Create NICOS connection using the config
+        host = self.get_property("host")  # Create NICOS connection using the config
         port = self.get_property("port")
         user = self.get_property("user")
-        pw = self.get_property("password") # TODO: Improve this to be safer.
-        self.nicos_cli = connect_to_nicos(host, port, user, pw)
+        pw = self.get_property("password")  # Improve this to be safer.
         self.device_name = self.get_property("device_name")
         self.nicos_cli = connect_to_nicos(host, port, user, pw)
 
@@ -64,7 +64,7 @@ class NICOSActuator(AbstractActuator.AbstractActuator):
         self.update_state(self.STATES.READY)
 
     def _watch(self):
-        """ Watch actuator current value and update it on the UI."""
+        """Watch actuator current value and update it on the UI."""
         while True:
             time.sleep(0.3)
             self.update_value()
@@ -80,22 +80,22 @@ class NICOSActuator(AbstractActuator.AbstractActuator):
     def _wait_actuator(self):
         """Wait actuator to be at target."""
         self.MOVING = 1
-        while (not self.done_movement()):
+        while not self.done_movement():
             time.sleep(0.3)
         self.update_specific_state(None)
         self.MOVING = 0
 
     def get_value(self):
-        """ Override AbstractActuator method."""
+        """Override AbstractActuator method."""
         readback_val = self.nicos_cli.get_dev_param_value(self.device_name)
         if readback_val is None:
             self.ERROR_READBACK = 1
             return 0
         self.ERROR_READBACK = 0
         return readback_val
-    
+
     def _set_value(self, value):
-        """ Override AbstractActuator method."""
+        """Override AbstractActuator method."""
         self.last_target_value = value
         self.update_state(self.STATES.BUSY)
 
@@ -103,28 +103,28 @@ class NICOSActuator(AbstractActuator.AbstractActuator):
         self.nicos_cli.process_command(line)
 
         self.__wait_actuator_task = gevent.spawn(self._wait_actuator)
-        
+
     def abort(self):
         """Override HardwareObject method."""
         super().abort()
         line = "stop('{}')".format(self.device_name)
-        ret = self.nicos_cli.process_command(line)
+        self.nicos_cli.process_command(line)
         self.MOVING = 0
         self.reset()  # Clean state on NICOS
 
         if self.__wait_actuator_task is not None:
             self.__wait_actuator_task.kill()
         self.update_state(self.STATES.READY)
-    
+
     def done_movement(self):
-        """ Return whether actuator is at target position or not."""
+        """Return whether actuator is at target position or not."""
         if self.get_value() == self.last_target_value:
             self.reset()
             return True
         return False
 
     def reset(self):
-        """Reset NICOS device. This can be useful to be sure the device is in 
+        """Reset NICOS device. This can be useful to be sure the device is in
         a health state on the NICOS side."""
         line = "reset('{}')".format(self.device_name)
         self.nicos_cli.process_command(line)

--- a/mxcubecore/HardwareObjects/ESS/NICOSActuator.py
+++ b/mxcubecore/HardwareObjects/ESS/NICOSActuator.py
@@ -64,27 +64,6 @@ class NICOSActuator(AbstractActuator.AbstractActuator):
         self.ERROR_READBACK = 0
         return readback_val
 
-    def set_value(self, value, timeout=0):
-        """ Override AbstractActuator method."""
-        self.last_target_value = value
-        if self.read_only:
-            raise ValueError("Attempt to set value for read-only Actuator")
-        if self.validate_value(value):
-            self.update_state(self.STATES.BUSY)
-            if timeout or timeout is None:
-                with gevent.Timeout(
-                    timeout, RuntimeError("Motor %s timed out" % self.username)
-                ):
-                    self._set_value(value)
-                    new_value = self._wait_actuator(value)
-            else:
-                self._set_value(value)
-                self.__wait_actuator_task = gevent.spawn(self._wait_actuator)
-        else:
-            raise ValueError("Invalid value %s; limits are %s"
-                             % (value, self.get_limits())
-                             )
-
     def abort(self):
         """ Imediately halt movement. By default self.stop = self.abort"""
         if self.__wait_actuator_task is not None:
@@ -93,6 +72,11 @@ class NICOSActuator(AbstractActuator.AbstractActuator):
         
     def _set_value(self, value):
         """ Override AbstractActuator method."""
+        self.last_target_value = value
+        self.update_state(self.STATES.BUSY)
+
         line = "move('{}', {})".format(self.device_name, value)
         self.nicos_cli.process_command(line)
+
+        self.__wait_actuator_task = gevent.spawn(self._wait_actuator)
         

--- a/mxcubecore/HardwareObjects/ESS/NICOSActuator.py
+++ b/mxcubecore/HardwareObjects/ESS/NICOSActuator.py
@@ -50,6 +50,15 @@ class NICOSActuator(AbstractActuator.AbstractActuator):
         self.device_name = self.get_property("device_name")
         self.nicos_cli = connect_to_nicos(host, port, user, pw)
 
+        if not self.nicos_cli.is_connected():
+            self.print_log(
+                msg=f"Failed to connect to NICOS server ({host}, {self.device_name})."
+            )
+            return
+        self.print_log(
+            msg=f"Successfully connected to NICOS server ({host}, {self.device_name})."
+        )
+
         self.MOVING = 0
         self.__watch_task = gevent.spawn(self._watch)
         self.update_state(self.STATES.READY)

--- a/mxcubecore/HardwareObjects/ESS/NICOSActuator.py
+++ b/mxcubecore/HardwareObjects/ESS/NICOSActuator.py
@@ -11,7 +11,7 @@ Example of config file:
     <port>1234</port>
     <user>myuser</user>
     <password>mypassword</password>
-    <device_name>my_nicos_device</device_name>
+    <device_name>my_nicos_moveable_device</device_name>
 </object>
 """
 
@@ -19,7 +19,6 @@ from gevent import monkey
 monkey.patch_all()
 
 import time
-import copy
 import gevent
 
 from mxcubecore.HardwareObjects.abstract import AbstractActuator
@@ -28,9 +27,9 @@ from .nicos_connection import connect_to_nicos
 
 
 class NICOSActuator(AbstractActuator.AbstractActuator):
-    """NICOS actuator class
+    """NICOS Actuator class
     
-    This class is based on LNLS.EPICSActuator."""
+    Controls a NICOS EpicsAnalogMoveable device."""
 
     def __init__(self, name):
         super().__init__(name)
@@ -51,31 +50,31 @@ class NICOSActuator(AbstractActuator.AbstractActuator):
         self.device_name = self.get_property("device_name")
         self.nicos_cli = connect_to_nicos(host, port, user, pw)
 
-        self.moving = 0
+        self.MOVING = 0
         self.__watch_task = gevent.spawn(self._watch)
         self.update_state(self.STATES.READY)
 
     def _watch(self):
-        """ Watch motor current value and update it on the UI."""
+        """ Watch actuator current value and update it on the UI."""
         while True:
             time.sleep(0.3)
             self.update_value()
-            # Manage motor ui state
+            # Manage ui state
             if self.ERROR_READBACK:
                 self.update_state(self.STATES.FAULT)
-            elif self.moving:
+            elif self.MOVING:
                 self.update_state(self.STATES.BUSY)
                 self.update_specific_state(self.SPECIFIC_STATES.MOVING)
             else:
                 self.update_state(self.STATES.READY)
 
     def _wait_actuator(self):
-        """Override NICOSActuator method."""
-        self.moving = 1
+        """Wait actuator to be at target."""
+        self.MOVING = 1
         while (not self.done_movement()):
             time.sleep(0.3)
         self.update_specific_state(None)
-        self.moving = 0
+        self.MOVING = 0
 
     def get_value(self):
         """ Override AbstractActuator method."""
@@ -91,8 +90,8 @@ class NICOSActuator(AbstractActuator.AbstractActuator):
         super().abort()
         line = "stop('{}')".format(self.device_name)
         ret = self.nicos_cli.process_command(line)
-        self.moving = 0
-        self.reset()  # Clean state at NICOS if needed
+        self.MOVING = 0
+        self.reset()  # Clean state on NICOS
 
         if self.__wait_actuator_task is not None:
             self.__wait_actuator_task.kill()
@@ -117,7 +116,6 @@ class NICOSActuator(AbstractActuator.AbstractActuator):
 
     def reset(self):
         """Reset NICOS device. This can be useful to be sure the device is in 
-        a health state."""
+        a health state on the NICOS side."""
         line = "reset('{}')".format(self.device_name)
         self.nicos_cli.process_command(line)
-        

--- a/mxcubecore/HardwareObjects/ESS/NICOSActuator.py
+++ b/mxcubecore/HardwareObjects/ESS/NICOSActuator.py
@@ -1,0 +1,100 @@
+"""
+Superclass for NICOS actuators.
+
+Should be put as the first superclass,
+e.g. class NICOSMotor(NICOSActuator, AbstractMotor):
+
+Example of config file:
+
+<object class="ESS.NICOSActuator">
+    <host>my-nicos-server-hostname</host>
+    <port>1234</port>
+    <user>myuser</user>
+    <password>mypassword</password>
+    <device_name>my_nicos_device</device_name>
+    <username>Kappa</username>
+    <motor_name>Kappa</motor_name>
+</object>
+"""
+
+from gevent import monkey
+monkey.patch_all()
+
+import time
+import copy
+import gevent
+
+from mxcubecore.HardwareObjects.abstract import AbstractActuator
+
+from .nicos_connection import connect_to_nicos
+
+
+class NICOSActuator(AbstractActuator.AbstractActuator):
+    """NICOS actuator class
+    
+    This class is based on LNLS.EPICSActuator."""
+
+    def __init__(self, name):
+        super(NICOSActuator, self).__init__(name)
+        self.__wait_actuator_task = None
+        self._nominal_limits = (-1E4, 1E4)
+        self.last_target_value = None
+        self.ERROR_READBACK = 0
+
+    def init(self):
+        """ Initialization method """
+        super(NICOSActuator, self).init()
+        host = self.get_property("host") # Create NICOS connection using the config
+        port = self.get_property("port")
+        user = self.get_property("user")
+        pw = self.get_property("password") # TODO: Improve this to be safer.
+        self.nicos_cli = connect_to_nicos(host, port, user, pw)
+        self.device_name = self.get_property("device_name")
+        self.update_state(self.STATES.READY)
+
+    def _wait_actuator(self):
+        """ Wait actuator to be ready."""
+        time.sleep(0.3)
+        self.update_state(self.STATES.READY)
+
+    def get_value(self):
+        """ Override AbstractActuator method."""
+        readback_val = self.nicos_cli.get_dev_param_value(self.device_name)
+        if readback_val is None:
+            self.ERROR_READBACK = 1
+            return 0
+        self.ERROR_READBACK = 0
+        return readback_val
+
+    def set_value(self, value, timeout=0):
+        """ Override AbstractActuator method."""
+        self.last_target_value = value
+        if self.read_only:
+            raise ValueError("Attempt to set value for read-only Actuator")
+        if self.validate_value(value):
+            self.update_state(self.STATES.BUSY)
+            if timeout or timeout is None:
+                with gevent.Timeout(
+                    timeout, RuntimeError("Motor %s timed out" % self.username)
+                ):
+                    self._set_value(value)
+                    new_value = self._wait_actuator(value)
+            else:
+                self._set_value(value)
+                self.__wait_actuator_task = gevent.spawn(self._wait_actuator)
+        else:
+            raise ValueError("Invalid value %s; limits are %s"
+                             % (value, self.get_limits())
+                             )
+
+    def abort(self):
+        """ Imediately halt movement. By default self.stop = self.abort"""
+        if self.__wait_actuator_task is not None:
+            self.__wait_actuator_task.kill()
+        self.update_state(self.STATES.READY)
+        
+    def _set_value(self, value):
+        """ Override AbstractActuator method."""
+        line = "move('{}', {})".format(self.device_name, value)
+        self.nicos_cli.process_command(line)
+        

--- a/mxcubecore/HardwareObjects/ESS/NICOSActuator.py
+++ b/mxcubecore/HardwareObjects/ESS/NICOSActuator.py
@@ -42,18 +42,40 @@ class NICOSActuator(AbstractActuator.AbstractActuator):
     def init(self):
         """ Initialization method """
         super(NICOSActuator, self).init()
+
         host = self.get_property("host") # Create NICOS connection using the config
         port = self.get_property("port")
         user = self.get_property("user")
         pw = self.get_property("password") # TODO: Improve this to be safer.
         self.nicos_cli = connect_to_nicos(host, port, user, pw)
         self.device_name = self.get_property("device_name")
+        self.nicos_cli = connect_to_nicos(host, port, user, pw)
+
+        self.moving = 0
+        self.__watch_task = gevent.spawn(self._watch)
         self.update_state(self.STATES.READY)
 
+    def _watch(self):
+        """ Watch motor current value and update it on the UI."""
+        while True:
+            time.sleep(0.3)
+            self.update_value()
+            # Manage motor ui state
+            if self.ERROR_READBACK:
+                self.update_state(self.STATES.FAULT)
+            elif self.moving:
+                self.update_state(self.STATES.BUSY)
+                self.update_specific_state(self.SPECIFIC_STATES.MOVING)
+            else:
+                self.update_state(self.STATES.READY)
+
     def _wait_actuator(self):
-        """ Wait actuator to be ready."""
-        time.sleep(0.3)
-        self.update_state(self.STATES.READY)
+        """Override NICOSActuator method."""
+        self.moving = 1
+        while (not self.done_movement()):
+            time.sleep(0.3)
+        self.update_specific_state(None)
+        self.moving = 0
 
     def get_value(self):
         """ Override AbstractActuator method."""
@@ -63,9 +85,15 @@ class NICOSActuator(AbstractActuator.AbstractActuator):
             return 0
         self.ERROR_READBACK = 0
         return readback_val
-
+    
     def abort(self):
-        """ Imediately halt movement. By default self.stop = self.abort"""
+        """Override HardwareObject method."""
+        super().abort()
+        line = "stop('{}')".format(self.device_name)
+        ret = self.nicos_cli.process_command(line)
+        self.moving = 0
+        self.reset()  # Clean state at NICOS if needed
+
         if self.__wait_actuator_task is not None:
             self.__wait_actuator_task.kill()
         self.update_state(self.STATES.READY)
@@ -79,4 +107,17 @@ class NICOSActuator(AbstractActuator.AbstractActuator):
         self.nicos_cli.process_command(line)
 
         self.__wait_actuator_task = gevent.spawn(self._wait_actuator)
+    
+    def done_movement(self):
+        """ Return whether actuator is at target position or not."""
+        if self.get_value() == self.last_target_value:
+            self.reset()
+            return True
+        return False
+
+    def reset(self):
+        """Reset NICOS device. This can be useful to be sure the device is in 
+        a health state."""
+        line = "reset('{}')".format(self.device_name)
+        self.nicos_cli.process_command(line)
         

--- a/mxcubecore/HardwareObjects/ESS/NICOSActuator.py
+++ b/mxcubecore/HardwareObjects/ESS/NICOSActuator.py
@@ -12,8 +12,6 @@ Example of config file:
     <user>myuser</user>
     <password>mypassword</password>
     <device_name>my_nicos_device</device_name>
-    <username>Kappa</username>
-    <motor_name>Kappa</motor_name>
 </object>
 """
 
@@ -35,7 +33,7 @@ class NICOSActuator(AbstractActuator.AbstractActuator):
     This class is based on LNLS.EPICSActuator."""
 
     def __init__(self, name):
-        super(NICOSActuator, self).__init__(name)
+        super().__init__(name)
         self.__wait_actuator_task = None
         self._nominal_limits = (-1E4, 1E4)
         self.last_target_value = None

--- a/mxcubecore/HardwareObjects/ESS/NICOSActuator.py
+++ b/mxcubecore/HardwareObjects/ESS/NICOSActuator.py
@@ -85,6 +85,16 @@ class NICOSActuator(AbstractActuator.AbstractActuator):
         self.ERROR_READBACK = 0
         return readback_val
     
+    def _set_value(self, value):
+        """ Override AbstractActuator method."""
+        self.last_target_value = value
+        self.update_state(self.STATES.BUSY)
+
+        line = "move('{}', {})".format(self.device_name, value)
+        self.nicos_cli.process_command(line)
+
+        self.__wait_actuator_task = gevent.spawn(self._wait_actuator)
+        
     def abort(self):
         """Override HardwareObject method."""
         super().abort()
@@ -96,16 +106,6 @@ class NICOSActuator(AbstractActuator.AbstractActuator):
         if self.__wait_actuator_task is not None:
             self.__wait_actuator_task.kill()
         self.update_state(self.STATES.READY)
-        
-    def _set_value(self, value):
-        """ Override AbstractActuator method."""
-        self.last_target_value = value
-        self.update_state(self.STATES.BUSY)
-
-        line = "move('{}', {})".format(self.device_name, value)
-        self.nicos_cli.process_command(line)
-
-        self.__wait_actuator_task = gevent.spawn(self._wait_actuator)
     
     def done_movement(self):
         """ Return whether actuator is at target position or not."""

--- a/mxcubecore/HardwareObjects/ESS/NICOSMotor.py
+++ b/mxcubecore/HardwareObjects/ESS/NICOSMotor.py
@@ -19,7 +19,7 @@ from mxcubecore.HardwareObjects.ESS.NICOSActuator import NICOSActuator
 
 class NICOSMotor(NICOSActuator, AbstractMotor):
     """NICOS Motor class
-    
+
     Behaves just like a NICOS Actuator, but adapted to be a Motor in MXCuBE UI."""
 
     def __init__(self, name):

--- a/mxcubecore/HardwareObjects/ESS/NICOSMotor.py
+++ b/mxcubecore/HardwareObjects/ESS/NICOSMotor.py
@@ -1,0 +1,84 @@
+"""
+NICOS implementation of AbstractMotor.
+
+Example of xml file:
+
+<object class="ESS.NICOSMotor">
+    <host>my-nicos-server-hostname</host>
+    <port>1234</port>
+    <user>myuser</user>
+    <password>mypassword</password>
+    <device_name>virtual_motor_2</device_name>
+    <username>Kappa</username>
+    <motor_name>Kappa</motor_name>
+    <default_limits>(-10, 43)</default_limits>
+</object>
+"""
+
+import logging
+import time
+import gevent
+
+from mxcubecore.HardwareObjects.abstract.AbstractMotor import AbstractMotor
+from mxcubecore.HardwareObjects.ESS.NICOSActuator import NICOSActuator
+
+
+class NICOSMotor(NICOSActuator, AbstractMotor):
+    """NICOS Motor class
+    
+    This class is based on LNLS.EPICSMotor."""
+
+    def __init__(self, name):
+        super().__init__(name)
+        self._wrap_range = None
+
+    def init(self):
+        """ Initialization method."""
+        super().init()
+        self.__watch_task = gevent.spawn(self._watch)
+        self.update_state(self.STATES.READY)
+        self.moving = 0
+    
+    def _watch(self):
+        """ Watch motor current value and update it on the UI."""
+        while True:
+            time.sleep(0.3)
+            self.update_value()
+            # Manage motor ui state
+            if self.ERROR_READBACK:
+                self.update_state(self.STATES.FAULT)
+            elif self.moving:
+                self.update_state(self.STATES.BUSY)
+                self.update_specific_state(self.SPECIFIC_STATES.MOVING)
+            else:
+                self.update_state(self.STATES.READY)
+
+    def _wait_actuator(self):
+        """Override NICOSActuator method."""
+        self.moving = 1
+        while (not self.done_movement()):
+            time.sleep(0.3)
+        self.update_specific_state(None)
+        self.moving = 0
+    
+    def reset(self):
+        """Reset NICOS device. This can be useful to be sure the device is in 
+        a health state."""
+        line = "reset('{}')".format(self.device_name)
+        ret = self.nicos_cli.process_command(line)
+
+    def abort(self):
+        """Override NICOSActuator method."""
+        line = "stop('{}')".format(self.device_name)
+        ret = self.nicos_cli.process_command(line)
+        self.moving = 0
+        self.reset() 
+        super().abort()
+    
+    def done_movement(self):
+        """ Return whether motor finished movement or not."""
+        if self.get_value() == self.last_target_value:
+            self.reset()
+            return True
+        return False
+

--- a/mxcubecore/HardwareObjects/ESS/NICOSMotor.py
+++ b/mxcubecore/HardwareObjects/ESS/NICOSMotor.py
@@ -1,21 +1,17 @@
 """
 NICOS implementation of AbstractMotor.
 
-Example of xml file:
+Example of config file:
 
 <object class="ESS.NICOSMotor">
     <host>my-nicos-server-hostname</host>
     <port>1234</port>
     <user>myuser</user>
     <password>mypassword</password>
-    <device_name>virtual_motor_2</device_name>
+    <device_name>my_nicos_motor_device</device_name>
     <default_limits>(-10, 43)</default_limits>
 </object>
 """
-
-import logging
-import time
-import gevent
 
 from mxcubecore.HardwareObjects.abstract.AbstractMotor import AbstractMotor
 from mxcubecore.HardwareObjects.ESS.NICOSActuator import NICOSActuator
@@ -24,10 +20,7 @@ from mxcubecore.HardwareObjects.ESS.NICOSActuator import NICOSActuator
 class NICOSMotor(NICOSActuator, AbstractMotor):
     """NICOS Motor class
     
-    This class is based on LNLS.EPICSMotor."""
+    Behaves just like a NICOS Actuator, but adapted to be a Motor in MXCuBE UI."""
 
     def __init__(self, name):
         super().__init__(name)
-        
-
-

--- a/mxcubecore/HardwareObjects/ESS/NICOSMotor.py
+++ b/mxcubecore/HardwareObjects/ESS/NICOSMotor.py
@@ -9,8 +9,6 @@ Example of xml file:
     <user>myuser</user>
     <password>mypassword</password>
     <device_name>virtual_motor_2</device_name>
-    <username>Kappa</username>
-    <motor_name>Kappa</motor_name>
     <default_limits>(-10, 43)</default_limits>
 </object>
 """
@@ -65,7 +63,7 @@ class NICOSMotor(NICOSActuator, AbstractMotor):
         """Reset NICOS device. This can be useful to be sure the device is in 
         a health state."""
         line = "reset('{}')".format(self.device_name)
-        ret = self.nicos_cli.process_command(line)
+        self.nicos_cli.process_command(line)
 
     def abort(self):
         """Override NICOSActuator method."""

--- a/mxcubecore/HardwareObjects/ESS/NICOSMotor.py
+++ b/mxcubecore/HardwareObjects/ESS/NICOSMotor.py
@@ -28,55 +28,6 @@ class NICOSMotor(NICOSActuator, AbstractMotor):
 
     def __init__(self, name):
         super().__init__(name)
-        self._wrap_range = None
+        
 
-    def init(self):
-        """ Initialization method."""
-        super().init()
-        self.__watch_task = gevent.spawn(self._watch)
-        self.update_state(self.STATES.READY)
-        self.moving = 0
-    
-    def _watch(self):
-        """ Watch motor current value and update it on the UI."""
-        while True:
-            time.sleep(0.3)
-            self.update_value()
-            # Manage motor ui state
-            if self.ERROR_READBACK:
-                self.update_state(self.STATES.FAULT)
-            elif self.moving:
-                self.update_state(self.STATES.BUSY)
-                self.update_specific_state(self.SPECIFIC_STATES.MOVING)
-            else:
-                self.update_state(self.STATES.READY)
-
-    def _wait_actuator(self):
-        """Override NICOSActuator method."""
-        self.moving = 1
-        while (not self.done_movement()):
-            time.sleep(0.3)
-        self.update_specific_state(None)
-        self.moving = 0
-    
-    def reset(self):
-        """Reset NICOS device. This can be useful to be sure the device is in 
-        a health state."""
-        line = "reset('{}')".format(self.device_name)
-        self.nicos_cli.process_command(line)
-
-    def abort(self):
-        """Override NICOSActuator method."""
-        line = "stop('{}')".format(self.device_name)
-        ret = self.nicos_cli.process_command(line)
-        self.moving = 0
-        self.reset() 
-        super().abort()
-    
-    def done_movement(self):
-        """ Return whether motor finished movement or not."""
-        if self.get_value() == self.last_target_value:
-            self.reset()
-            return True
-        return False
 

--- a/mxcubecore/HardwareObjects/ESS/nicos_connection.py
+++ b/mxcubecore/HardwareObjects/ESS/nicos_connection.py
@@ -1,15 +1,25 @@
-import time, copy
+import copy
+import time
 
-from nicos.clients.base import ConnectionData, NicosClient
-from nicos.protocols.daemon import STATUS_IDLE, STATUS_IDLEEXC
-from nicos.utils.loggers import ACTION, INPUT
+from nicos.clients.base import (
+    ConnectionData,
+    NicosClient,
+)
+from nicos.protocols.daemon import (
+    STATUS_IDLE,
+    STATUS_IDLEEXC,
+)
+from nicos.utils.loggers import (
+    ACTION,
+    INPUT,
+)
 
-EVENTMASK = ('watch', 'datapoint', 'datacurve', 'clientexec')
+EVENTMASK = ("watch", "datapoint", "datacurve", "clientexec")
 
 
 class NICOSConnection(NicosClient):
-    """ NICOSConnection Class 
-    
+    """NICOSConnection Class
+
     NICOSConnection class is based on the ones at
     nicos/clients/ipython/nicos.py, but with the IPython layer dependency
     removed. This way, NICOS commands can be called more directly.
@@ -19,8 +29,8 @@ class NICOSConnection(NicosClient):
     """
 
     livedata = {}
-    status = 'idle'
-    
+    status = "idle"
+
     def __init__(self):
         self.message_queue = []
         super().__init__(self.log)
@@ -29,40 +39,40 @@ class NICOSConnection(NicosClient):
         self.message_queue.append((name, txt))
 
     def print_queue(self):
-        """ For debugging."""
+        """For debugging."""
         for msg in self.message_queue:
             print(msg[1])
         self.message_queue = []
-    
+
     def signal(self, name, data=None, exc=None):
-        """ Has to be implemented."""
-        accept = ['message', 'processing', 'done']
+        """Has to be implemented."""
+        accept = ["message", "processing", "done"]
         if name in accept:
             self.log_func(name, data)
-        elif name == 'livedata':
+        elif name == "livedata":
             converted_data = []
-            for desc, ardata in zip(data['datadescs'], exc):
-                npdata = np.frombuffer(ardata, dtype=desc['dtype'])
-                npdata = npdata.reshape(desc['shape'])
+            for desc, ardata in zip(data["datadescs"], exc):
+                npdata = np.frombuffer(ardata, dtype=desc["dtype"])
+                npdata = npdata.reshape(desc["shape"])
                 converted_data.append(npdata)
-            self.livedata[data['det'] + '_live'] = converted_data
-        elif name == 'status':
+            self.livedata[data["det"] + "_live"] = converted_data
+        elif name == "status":
             status, _ = data
             if status == STATUS_IDLE or status == STATUS_IDLEEXC:
-                self.status = 'idle'
+                self.status = "idle"
             else:
-                self.status = 'run'
+                self.status = "run"
         else:
-            if name != 'cache':
+            if name != "cache":
                 pass
-    
+
     def _do_command(self, line):
         com = "%s" % line.strip()
-        if self.status == 'idle':
+        if self.status == "idle":
             self.run(com)
             return com
         return None
-    
+
     def _do_connect(self, conndata, eventmask=None):
         NicosClient.connect(self, conndata, eventmask)
 
@@ -70,11 +80,11 @@ class NICOSConnection(NicosClient):
         """Try to connect to NICOS."""
         data = line.split()
         if len(data) < 5:
-            print('Not enough data to connect, need host port user password')
+            print("Not enough data to connect, need host port user password")
             return
         con = ConnectionData(data[1], data[2], data[3], data[4])
         self._do_connect(con, eventmask=EVENTMASK)
-    
+
     def is_connected(self):
         return self.isconnected
 
@@ -82,13 +92,13 @@ class NICOSConnection(NicosClient):
         return self.status
 
     def process_command(self, line):
-        """ Process a NICOS command line and return the result."""
+        """Process a NICOS command line and return the result."""
         start_detected = False
         ignore = [ACTION, INPUT]
         reqID = None
         testcom = self._do_command(line)
         if not testcom:
-            return 'NICOS is busy, cannot send commands'
+            return "NICOS is busy, cannot send commands"
         output_msg = None
         while True:
             time.sleep(1)
@@ -98,18 +108,18 @@ class NICOSConnection(NicosClient):
                 self.message_queue = []
                 for name, message in work_queue:
                     # print('name, message = {}, {}'.format(name, message)) # debug messages
-                    if name == 'processing':
-                        if message['script'] == testcom:
+                    if name == "processing":
+                        if message["script"] == testcom:
                             start_detected = True
-                            reqID = message['reqid']
+                            reqID = message["reqid"]
                         continue
-                    if name == 'done' and message['reqid'] == reqID:
+                    if name == "done" and message["reqid"] == reqID:
                         return output_msg
                     if type(message) == list:
                         if message[2] in ignore:
                             continue
-                        if message[0] != 'nicos':
-                            messagetxt = message[0] + ' ' + message[3]
+                        if message[0] != "nicos":
+                            messagetxt = message[0] + " " + message[3]
                         else:
                             messagetxt = message[3]
                     if start_detected and reqID == message[-1]:
@@ -118,23 +128,24 @@ class NICOSConnection(NicosClient):
                         if "status" in line:
                             output_msg = messagetxt
 
-    def get_dev_param_value(self, dev_name, param_name='value'):
-        """ Return the value of a device parameter. The default parameter
+    def get_dev_param_value(self, dev_name, param_name="value"):
+        """Return the value of a device parameter. The default parameter
         name is 'value'."""
-        par = dev_name + '.' + param_name
+        par = dev_name + "." + param_name
         # Check for livedata first
         if par in self.livedata:
             return self.livedata[par]
 
         # Now check for scan data
-        if par == 'scandata':
+        if par == "scandata":
             xs, ys, _, names = self.eval(
-                '__import__("nicos").commands.analyze._getData()[:4]')
+                '__import__("nicos").commands.analyze._getData()[:4]'
+            )
             return xs, ys, names
 
         # Try get device data from NICOS
-        if par.find('.') > 0:
-            devpar = par.split('.')
+        if par.find(".") > 0:
+            devpar = par.split(".")
             return self.getDeviceParam(devpar[0], devpar[1])
         else:
             return self.getDeviceValue(par)
@@ -142,10 +153,10 @@ class NICOSConnection(NicosClient):
     def end_connection(self):
         self.disconnect()
 
+
 def connect_to_nicos(host, port, user, password):
     """Returns a connection to NICOS."""
     line = "/connect {} {} {} {}".format(host, port, user, password)
     nicos_conn = NICOSConnection()
     nicos_conn.start_connection(line)
     return nicos_conn
-    

--- a/mxcubecore/HardwareObjects/ESS/nicos_connection.py
+++ b/mxcubecore/HardwareObjects/ESS/nicos_connection.py
@@ -1,6 +1,9 @@
 import copy
 import time
+from dataclasses import dataclass
+from typing import ClassVar
 
+import numpy as np
 from nicos.clients.base import (
     ConnectionData,
     NicosClient,
@@ -17,6 +20,16 @@ from nicos.utils.loggers import (
 EVENTMASK = ("watch", "datapoint", "datacurve", "clientexec")
 
 
+@dataclass
+class _CommandState:
+    testcom: str
+    line: str
+    start_detected: bool = False
+    req_id: str | None = None
+    output_msg: str | None = None
+    done: bool = False
+
+
 class NICOSConnection(NicosClient):
     """NICOSConnection Class
 
@@ -28,8 +41,8 @@ class NICOSConnection(NicosClient):
     (get_dev_param_value(), get_status()).
     """
 
-    livedata = {}
-    status = "idle"
+    livedata: ClassVar[dict] = {}
+    status: str = "idle"
 
     def __init__(self):
         self.message_queue = []
@@ -38,12 +51,6 @@ class NICOSConnection(NicosClient):
     def log(self, name, txt):
         self.message_queue.append((name, txt))
 
-    def print_queue(self):
-        """For debugging."""
-        for msg in self.message_queue:
-            print(msg[1])
-        self.message_queue = []
-
     def signal(self, name, data=None, exc=None):
         """Has to be implemented."""
         accept = ["message", "processing", "done"]
@@ -51,20 +58,19 @@ class NICOSConnection(NicosClient):
             self.log_func(name, data)
         elif name == "livedata":
             converted_data = []
-            for desc, ardata in zip(data["datadescs"], exc):
+            for desc, ardata in zip(data["datadescs"], exc, strict=True):
                 npdata = np.frombuffer(ardata, dtype=desc["dtype"])
                 npdata = npdata.reshape(desc["shape"])
                 converted_data.append(npdata)
             self.livedata[data["det"] + "_live"] = converted_data
         elif name == "status":
             status, _ = data
-            if status == STATUS_IDLE or status == STATUS_IDLEEXC:
+            if status in (STATUS_IDLE, STATUS_IDLEEXC):
                 self.status = "idle"
             else:
                 self.status = "run"
-        else:
-            if name != "cache":
-                pass
+        elif name != "cache":
+            pass
 
     def _do_command(self, line):
         com = "%s" % line.strip()
@@ -80,7 +86,6 @@ class NICOSConnection(NicosClient):
         """Try to connect to NICOS."""
         data = line.split()
         if len(data) < 5:
-            print("Not enough data to connect, need host port user password")
             return
         con = ConnectionData(data[1], data[2], data[3], data[4])
         self._do_connect(con, eventmask=EVENTMASK)
@@ -93,40 +98,48 @@ class NICOSConnection(NicosClient):
 
     def process_command(self, line):
         """Process a NICOS command line and return the result."""
-        start_detected = False
-        ignore = [ACTION, INPUT]
-        reqID = None
         testcom = self._do_command(line)
         if not testcom:
             return "NICOS is busy, cannot send commands"
-        output_msg = None
+
+        state = _CommandState(testcom=testcom, line=line)
         while True:
             time.sleep(1)
             if self.message_queue:
-                # Own copy for thread safety
                 work_queue = copy.deepcopy(self.message_queue)
                 self.message_queue = []
                 for name, message in work_queue:
-                    # print('name, message = {}, {}'.format(name, message)) # debug messages
-                    if name == "processing":
-                        if message["script"] == testcom:
-                            start_detected = True
-                            reqID = message["reqid"]
-                        continue
-                    if name == "done" and message["reqid"] == reqID:
-                        return output_msg
-                    if type(message) == list:
-                        if message[2] in ignore:
-                            continue
-                        if message[0] != "nicos":
-                            messagetxt = message[0] + " " + message[3]
-                        else:
-                            messagetxt = message[3]
-                    if start_detected and reqID == message[-1]:
-                        # Capturing the output message here for the NICOS commands
-                        # we need (e.g., get_status()).
-                        if "status" in line:
-                            output_msg = messagetxt
+                    self._handle_message(state, name, message)
+                    if state.done:
+                        return state.output_msg
+
+    def _handle_message(self, state: _CommandState, name: str, message) -> None:
+        """Handle a single message from the queue, mutating state in place."""
+        ignore = [ACTION, INPUT]
+
+        if name == "processing":
+            if message["script"] == state.testcom:
+                state.start_detected = True
+                state.req_id = message["reqid"]
+            return
+
+        if name == "done" and message["reqid"] == state.req_id:
+            state.done = True
+            return
+
+        if type(message) is list:
+            if message[2] in ignore:
+                return
+            messagetxt = (
+                message[3] if message[0] == "nicos" else message[0] + " " + message[3]
+            )
+
+            if (
+                state.start_detected
+                and state.req_id == message[-1]
+                and "status" in state.line
+            ):
+                state.output_msg = messagetxt
 
     def get_dev_param_value(self, dev_name, param_name="value"):
         """Return the value of a device parameter. The default parameter
@@ -147,8 +160,7 @@ class NICOSConnection(NicosClient):
         if par.find(".") > 0:
             devpar = par.split(".")
             return self.getDeviceParam(devpar[0], devpar[1])
-        else:
-            return self.getDeviceValue(par)
+        return self.getDeviceValue(par)
 
     def end_connection(self):
         self.disconnect()

--- a/mxcubecore/HardwareObjects/ESS/nicos_connection.py
+++ b/mxcubecore/HardwareObjects/ESS/nicos_connection.py
@@ -67,17 +67,13 @@ class NICOSConnection(NicosClient):
         NicosClient.connect(self, conndata, eventmask)
 
     def start_connection(self, line):
-        """ Try to connect to NICOS."""
+        """Try to connect to NICOS."""
         data = line.split()
         if len(data) < 5:
             print('Not enough data to connect, need host port user password')
             return
         con = ConnectionData(data[1], data[2], data[3], data[4])
         self._do_connect(con, eventmask=EVENTMASK)
-        if self.is_connected():
-            print('Successfully connected to %s' % data[1])
-        else:
-            print('Failed to connect to %s' % data[1])
     
     def is_connected(self):
         return self.isconnected
@@ -147,9 +143,8 @@ class NICOSConnection(NicosClient):
         self.disconnect()
 
 def connect_to_nicos(host, port, user, password):
-    """ Returns a connection to NICOS."""
-    line = "/connect {} {} {} {}".format(
-        host, port, user, password)
+    """Returns a connection to NICOS."""
+    line = "/connect {} {} {} {}".format(host, port, user, password)
     nicos_conn = NICOSConnection()
     nicos_conn.start_connection(line)
     return nicos_conn

--- a/mxcubecore/HardwareObjects/ESS/nicos_connection.py
+++ b/mxcubecore/HardwareObjects/ESS/nicos_connection.py
@@ -1,0 +1,156 @@
+import time, copy
+
+from nicos.clients.base import ConnectionData, NicosClient
+from nicos.protocols.daemon import STATUS_IDLE, STATUS_IDLEEXC
+from nicos.utils.loggers import ACTION, INPUT
+
+EVENTMASK = ('watch', 'datapoint', 'datacurve', 'clientexec')
+
+
+class NICOSConnection(NicosClient):
+    """ NICOSConnection Class 
+    
+    NICOSConnection class is based on the ones at
+    nicos/clients/ipython/nicos.py, but with the IPython layer dependency
+    removed. This way, NICOS commands can be called more directly.
+
+    Also, unused commands were removed, and some were added
+    (get_dev_param_value(), get_status()).
+    """
+
+    livedata = {}
+    status = 'idle'
+    
+    def __init__(self):
+        self.message_queue = []
+        super().__init__(self.log)
+
+    def log(self, name, txt):
+        self.message_queue.append((name, txt))
+
+    def print_queue(self):
+        """ For debugging."""
+        for msg in self.message_queue:
+            print(msg[1])
+        self.message_queue = []
+    
+    def signal(self, name, data=None, exc=None):
+        """ Has to be implemented."""
+        accept = ['message', 'processing', 'done']
+        if name in accept:
+            self.log_func(name, data)
+        elif name == 'livedata':
+            converted_data = []
+            for desc, ardata in zip(data['datadescs'], exc):
+                npdata = np.frombuffer(ardata, dtype=desc['dtype'])
+                npdata = npdata.reshape(desc['shape'])
+                converted_data.append(npdata)
+            self.livedata[data['det'] + '_live'] = converted_data
+        elif name == 'status':
+            status, _ = data
+            if status == STATUS_IDLE or status == STATUS_IDLEEXC:
+                self.status = 'idle'
+            else:
+                self.status = 'run'
+        else:
+            if name != 'cache':
+                pass
+    
+    def _do_command(self, line):
+        com = "%s" % line.strip()
+        if self.status == 'idle':
+            self.run(com)
+            return com
+        return None
+    
+    def _do_connect(self, conndata, eventmask=None):
+        NicosClient.connect(self, conndata, eventmask)
+
+    def start_connection(self, line):
+        """ Try to connect to NICOS."""
+        data = line.split()
+        if len(data) < 5:
+            print('Not enough data to connect, need host port user password')
+            return
+        con = ConnectionData(data[1], data[2], data[3], data[4])
+        self._do_connect(con, eventmask=EVENTMASK)
+        if self.is_connected():
+            print('Successfully connected to %s' % data[1])
+        else:
+            print('Failed to connect to %s' % data[1])
+    
+    def is_connected(self):
+        return self.isconnected
+
+    def get_status(self):
+        return self.status
+
+    def process_command(self, line):
+        """ Process a NICOS command line and return the result."""
+        start_detected = False
+        ignore = [ACTION, INPUT]
+        reqID = None
+        testcom = self._do_command(line)
+        if not testcom:
+            return 'NICOS is busy, cannot send commands'
+        output_msg = None
+        while True:
+            time.sleep(1)
+            if self.message_queue:
+                # Own copy for thread safety
+                work_queue = copy.deepcopy(self.message_queue)
+                self.message_queue = []
+                for name, message in work_queue:
+                    # print('name, message = {}, {}'.format(name, message)) # debug messages
+                    if name == 'processing':
+                        if message['script'] == testcom:
+                            start_detected = True
+                            reqID = message['reqid']
+                        continue
+                    if name == 'done' and message['reqid'] == reqID:
+                        return output_msg
+                    if type(message) == list:
+                        if message[2] in ignore:
+                            continue
+                        if message[0] != 'nicos':
+                            messagetxt = message[0] + ' ' + message[3]
+                        else:
+                            messagetxt = message[3]
+                    if start_detected and reqID == message[-1]:
+                        # Capturing the output message here for the NICOS commands
+                        # we need (e.g., get_status()).
+                        if "status" in line:
+                            output_msg = messagetxt
+
+    def get_dev_param_value(self, dev_name, param_name='value'):
+        """ Return the value of a device parameter. The default parameter
+        name is 'value'."""
+        par = dev_name + '.' + param_name
+        # Check for livedata first
+        if par in self.livedata:
+            return self.livedata[par]
+
+        # Now check for scan data
+        if par == 'scandata':
+            xs, ys, _, names = self.eval(
+                '__import__("nicos").commands.analyze._getData()[:4]')
+            return xs, ys, names
+
+        # Try get device data from NICOS
+        if par.find('.') > 0:
+            devpar = par.split('.')
+            return self.getDeviceParam(devpar[0], devpar[1])
+        else:
+            return self.getDeviceValue(par)
+
+    def end_connection(self):
+        self.disconnect()
+
+def connect_to_nicos(host, port, user, password):
+    """ Returns a connection to NICOS."""
+    line = "/connect {} {} {} {}".format(
+        host, port, user, password)
+    nicos_conn = NICOSConnection()
+    nicos_conn.start_connection(line)
+    return nicos_conn
+    


### PR DESCRIPTION
Hi all,

Sharing the site-specific classes used at ESS for controlling devices through NICOS framework (see: gitlab.com/nicos-controls). NICOS is the default control layer for the experiments at ESS.

The covered devices (for now) are actuators and motors (with the classes NICOSActuator and NICOSMotor). A common connection class (NICOSConnection) is used by them to communicate with the instrument/beamline NICOS server.

Tested with: mxcubeweb==v4.231.0, mxcubecore==v1.188.0

Feel free to send comments/feedback. Thank you!