### PR TITLE
update MAXIV MicroMAX beamline actions

### DIFF
--- a/mxcubecore/HardwareObjects/MAXIV/MicroMAX/beamline_actions.py
+++ b/mxcubecore/HardwareObjects/MAXIV/MicroMAX/beamline_actions.py
@@ -1,6 +1,9 @@
 import logging
 
+from tango import DeviceProxy
+
 from mxcubecore import HardwareRepository as HWR
+from mxcubecore.utils.units import kev_to_ev
 
 log = logging.getLogger("user_level_log")
 
@@ -55,6 +58,41 @@ class PrepareOpenHutch:
             # Explicitly add raised exception into the log message,
             # so that it is shown to the user in the beamline action UI log.
             log.exception("Error preparing to open hutch.\nError was: '%s'", str(ex))  # noqa: TRY401
+
+
+class CheckBeam:
+    def __call__(self):
+        """
+        Check beam stability
+        """
+        xbpms = {
+            "DM3": DeviceProxy("b312a-o06/dia/xbpm-01"),
+            "DM4": DeviceProxy("b312a-e01/dia/xbpm-01"),
+            "BCU XBPM1": DeviceProxy("b312a-e04/dia/xbpm-01"),
+            "BCU XBPM2": DeviceProxy("b312a-e04/dia/xbpm-02"),
+        }
+        energy = kev_to_ev(HWR.beamline.energy.get_value())
+        transmission = HWR.beamline.transmission.get_value()
+        for name, xbpm in xbpms.items():
+            total_current = xbpm.S
+            flux = total_current * (
+                -0.534515 * energy**4
+                - 43197.6 * energy**3
+                + 5.13449e09 * energy**2
+                - 4.39169e13 * energy
+                + 1.14591e17
+            )
+            log.info(
+                f"XBPM: {name}, total current: {total_current * 1e6:.2f} uA, "
+                f"estimated flux at sample position: {flux:.2e} ph/s"
+            )
+
+            if "BCU" in name:
+                full_flux = flux * 100.0 / transmission
+                log.info(
+                    f"Current transmission: {transmission:.2f}%, "
+                    f"estimated full flux at sample position: {full_flux:.2e} ph/s"
+                )
 
 
 class MeasureFlux:

--- a/mxcubecore/HardwareObjects/MAXIV/MicroMAX/beamline_actions.py
+++ b/mxcubecore/HardwareObjects/MAXIV/MicroMAX/beamline_actions.py
@@ -12,25 +12,38 @@ class PrepareOpenHutch:
 
     - close safety shutter
     - close detector cover
+    - close fast shutter
     - move detector to a safe position
-    - put MD3 into 'Transfer' phase
+    - put MD3 into 'Transfer' phase in case of OSC delivery mode
+    - move MD3's `BeamstopPosition` and `CapillaryPosition` to `PARK` in case of HVE
     - if jungfrau is used, take pedestal
     """
 
     def __call__(self):
         try:
+            # Ensure laser is stopped before opening the hutch
+            laser = HWR.beamline.get_object_by_role("laser")
+            laser.disarm()
+
             collect = HWR.beamline.collect
             diffractometer = HWR.beamline.diffractometer
             detector = HWR.beamline.detector
 
             log.info("Preparing experimental hutch for door opening.")
 
+            collect.close_fast_shutter()
             collect.close_safety_shutter()
             collect.close_detector_cover()
 
-            log.info("Setting diffractometer to transfer phase.")
             diffractometer.wait_device_ready()
-            diffractometer.set_phase("Transfer")
+            if HWR.beamline.is_hve_sample_delivery():
+                # This is 'equivalent' of Transfer phase for HVE experiments
+                log.info("Setting diffractometer to 'equivalent' of Transfer phase.")
+                diffractometer.channel_dict["BeamstopPosition"].set_value("PARK")
+                diffractometer.channel_dict["CapillaryPosition"].set_value("PARK")
+            else:
+                log.info("Setting diffractometer to Transfer phase.")
+                diffractometer.set_phase("Transfer")
 
             log.info("Moving detector to safe position.")
             collect.move_detector_to_safe_position()

--- a/mxcubecore/HardwareObjects/MAXIV/MicroMAX/beamline_actions.py
+++ b/mxcubecore/HardwareObjects/MAXIV/MicroMAX/beamline_actions.py
@@ -112,3 +112,14 @@ class SaveMD3Position:
 class MoveToMD3SavedPosition:
     def __call__(self):
         HWR.beamline.diffractometer.goto_centered_position()
+
+
+class EmptyMount:
+    def __call__(self):
+        isara = HWR.beamline.sample_changer
+
+        log.info("Performing empty mount recovery sequence.")
+
+        isara.execute_command("Reset")
+
+        log.info("Recovery sequence completed.")

--- a/mxcubecore/HardwareObjects/MAXIV/MicroMAX/beamline_actions.py
+++ b/mxcubecore/HardwareObjects/MAXIV/MicroMAX/beamline_actions.py
@@ -1,7 +1,6 @@
 import logging
 
 from mxcubecore import HardwareRepository as HWR
-from mxcubecore.HardwareObjects.MAXIV.MAXIVMD3 import NoPositionBookmarkedError
 
 log = logging.getLogger("user_level_log")
 
@@ -69,12 +68,9 @@ class MeasureFlux:
 
 class SaveMD3Position:
     def __call__(self):
-        HWR.beamline.diffractometer.bookmark_position()
+        HWR.beamline.diffractometer.save_centered_position()
 
 
 class MoveToMD3SavedPosition:
     def __call__(self):
-        try:
-            HWR.beamline.diffractometer.goto_bookmarked_position()
-        except NoPositionBookmarkedError:
-            log.warning("No MD3 position saved.")
+        HWR.beamline.diffractometer.goto_centered_position()

--- a/test/test_hwo_maxiv_micromax_beamline_actions.py
+++ b/test/test_hwo_maxiv_micromax_beamline_actions.py
@@ -1,0 +1,171 @@
+from unittest.mock import Mock, call, patch
+
+import pytest
+
+from mxcubecore.HardwareObjects.MAXIV.MicroMAX.beamline import SampleDelivery
+from mxcubecore.HardwareObjects.MAXIV.MicroMAX.beamline_actions import (
+    MeasureFlux,
+    MoveToMD3SavedPosition,
+    PrepareOpenHutch,
+    SaveMD3Position,
+)
+
+
+def _assert_open_hutch_calls(hwr, laser, log):
+    """Checks that expected standard calls for 'prepare open hutch' where made."""
+
+    hwr.beamline.get_object_by_role.assert_called_once_with("laser")
+    laser.disarm.assert_called_once()
+
+    # check calls on collect hardware object
+    collect = hwr.beamline.collect
+    collect.close_safety_shutter.assert_called_once()
+    collect.close_detector_cover.assert_called_once()
+    collect.close_fast_shutter.assert_called_once()
+    collect.move_detector_to_safe_position.assert_called_once()
+
+    # check calls on diffractometer hardware object
+    diffractometer = hwr.beamline.diffractometer
+    diffractometer.wait_device_ready.assert_called_once()
+    if hwr.beamline.is_hve_sample_delivery():
+        diffractometer.channel_dict[
+            "BeamstopPosition"
+        ].set_value.assert_called_once_with("PARK")
+        diffractometer.channel_dict[
+            "CapillaryPosition"
+        ].set_value.assert_called_once_with("PARK")
+        log.info.assert_has_calls(
+            [
+                call("Preparing experimental hutch for door opening."),
+                call("Setting diffractometer to 'equivalent' of Transfer phase."),
+                call("Moving detector to safe position."),
+            ],
+        )
+    else:
+        diffractometer.set_phase.assert_called_once_with("Transfer")
+        # check logging calls
+        log.info.assert_has_calls(
+            [
+                call("Preparing experimental hutch for door opening."),
+                call("Setting diffractometer to Transfer phase."),
+                call("Moving detector to safe position."),
+            ],
+        )
+
+
+@pytest.mark.parametrize("sample_delivery", [SampleDelivery.osc, SampleDelivery.hve])
+def test_prepare_open_hutch_eiger(sample_delivery: SampleDelivery):
+    """Test PrepareOpenHutch beamline action with Eiger detector."""
+
+    hwr = Mock()
+    hwr.beamline.detector.get_property.return_value = "Eiger"
+    hwr.beamline.sample_delivery = sample_delivery
+    hwr.beamline.diffractometer.channel_dict = {
+        "BeamstopPosition": Mock(),
+        "CapillaryPosition": Mock(),
+    }
+    laser = Mock()
+    hwr.beamline.get_object_by_role.return_value = laser
+    log = Mock()
+
+    with (
+        patch("mxcubecore.HardwareObjects.MAXIV.MicroMAX.beamline_actions.HWR", hwr),
+        patch("mxcubecore.HardwareObjects.MAXIV.MicroMAX.beamline_actions.log", log),
+    ):
+        bl_action = PrepareOpenHutch()
+        bl_action()
+
+    _assert_open_hutch_calls(hwr, laser, log)
+    # take pedestal should not be called for Eiger
+    hwr.beamline.detector.pedestal.assert_not_called()
+
+
+@pytest.mark.parametrize("sample_delivery", [SampleDelivery.osc, SampleDelivery.hve])
+def test_prepare_open_hutch_jungfrau(sample_delivery: SampleDelivery):
+    """Test PrepareOpenHutch beamline action with Jungfrau detector."""
+
+    hwr = Mock()
+    hwr.beamline.detector.get_property.return_value = "JUNGFRAU"
+    hwr.beamline.sample_delivery = sample_delivery
+    hwr.beamline.diffractometer.channel_dict = {
+        "BeamstopPosition": Mock(),
+        "CapillaryPosition": Mock(),
+    }
+    laser = Mock()
+    hwr.beamline.get_object_by_role.return_value = laser
+    log = Mock()
+
+    with (
+        patch("mxcubecore.HardwareObjects.MAXIV.MicroMAX.beamline_actions.HWR", hwr),
+        patch("mxcubecore.HardwareObjects.MAXIV.MicroMAX.beamline_actions.log", log),
+    ):
+        bl_action = PrepareOpenHutch()
+        bl_action()
+
+    _assert_open_hutch_calls(hwr, laser, log)
+
+    # check take pedestal operation was invoked
+    hwr.beamline.detector.pedestal.assert_called_once()
+
+
+def test_prepare_open_hutch_error():
+    """Test a case where PrepareOpenHutch beamline action fails."""
+
+    hwr = Mock()
+    hwr.beamline.collect.close_safety_shutter.side_effect = Exception("dummy")
+    laser = Mock()
+    hwr.beamline.get_object_by_role.return_value = laser
+    log = Mock()
+
+    with (
+        patch("mxcubecore.HardwareObjects.MAXIV.MicroMAX.beamline_actions.HWR", hwr),
+        patch("mxcubecore.HardwareObjects.MAXIV.MicroMAX.beamline_actions.log", log),
+    ):
+        bl_action = PrepareOpenHutch()
+        bl_action()
+
+    hwr.beamline.get_object_by_role.assert_called_once_with("laser")
+    laser.disarm.assert_called_once()
+    log.exception.assert_called_with(
+        "Error preparing to open hutch.\nError was: '%s'",
+        "dummy",
+    )
+
+
+def test_measure_flux():
+    """Test MeasureFlux beamline action."""
+
+    hwr = Mock()
+    hwr.beamline.collect.get_instant_flux.return_value = 0.42
+
+    log = Mock()
+
+    with (
+        patch("mxcubecore.HardwareObjects.MAXIV.MicroMAX.beamline_actions.HWR", hwr),
+        patch("mxcubecore.HardwareObjects.MAXIV.MicroMAX.beamline_actions.log", log),
+    ):
+        bl_action = MeasureFlux()
+        bl_action()
+    log.info.assert_called_once_with("Flux at sample position is %.2e ph/s", 0.42)
+
+
+def test_save_md3_position():
+    """Test SaveMD3Position beamline action."""
+
+    hwr = Mock()
+    with patch("mxcubecore.HardwareObjects.MAXIV.MicroMAX.beamline_actions.HWR", hwr):
+        bl_action = SaveMD3Position()
+        bl_action()
+
+    hwr.beamline.diffractometer.save_centered_position.assert_called_once()
+
+
+def test_move_to_md3_saved_position_ok():
+    """Test the successful run of MoveToMD3SavedPosition beamline action."""
+    hwr = Mock()
+
+    with patch("mxcubecore.HardwareObjects.MAXIV.MicroMAX.beamline_actions.HWR", hwr):
+        bl_action = MoveToMD3SavedPosition()
+        bl_action()
+
+    hwr.beamline.diffractometer.goto_centered_position.assert_called_once()


### PR DESCRIPTION
Updating beamline actions used at MAXIV's MicroMAX beamline.

* update 'prepare open hutch' beamline action 
* new implementation of 'save / restore MD3 position' beamline action
* add 'check beam' beamline action
* add 'empty mount' beamline actions
* add tests on some beamline actins