### PR TITLE
MAXIV MicroMAX: add support for 'Fixed-target' sample delivery method

### DIFF
--- a/mxcubecore/HardwareObjects/MAXIV/MicroMAX/beamline.py
+++ b/mxcubecore/HardwareObjects/MAXIV/MicroMAX/beamline.py
@@ -22,6 +22,7 @@ import mxcubecore.HardwareObjects.MAXIV.beamline
 class SampleDelivery(Enum):
     osc = "osc"
     hve = "hve"
+    fixed_target = "fixed-target"
 
 
 class Beamline(mxcubecore.HardwareObjects.MAXIV.beamline.Beamline):
@@ -49,3 +50,7 @@ class Beamline(mxcubecore.HardwareObjects.MAXIV.beamline.Beamline):
     def is_hve_sample_delivery(self) -> bool:
         """True when HVE sample delivery mode is configured."""
         return self.sample_delivery == SampleDelivery.hve
+
+    def is_fixed_target_sample_delivery(self) -> bool:
+        """True when Fixed-target sample delivery mode is configured."""
+        return self.sample_delivery == SampleDelivery.fixed_target

--- a/test/test_hwo_maxiv_micromax_beamline.py
+++ b/test/test_hwo_maxiv_micromax_beamline.py
@@ -14,6 +14,7 @@ def test_sample_delivery_osc():
     beamline = _setup_beamline_obj({"sample_delivery": "osc"})
 
     assert not beamline.is_hve_sample_delivery()
+    assert not beamline.is_fixed_target_sample_delivery()
     assert beamline.sample_delivery == SampleDelivery.osc
 
 
@@ -23,4 +24,15 @@ def test_sample_delivery_hve():
     beamline = _setup_beamline_obj({"sample_delivery": "hve"})
 
     assert beamline.is_hve_sample_delivery()
+    assert not beamline.is_fixed_target_sample_delivery()
     assert beamline.sample_delivery == SampleDelivery.hve
+
+
+def test_sample_delivery_fixed_target():
+    """test 'Fixed-target' sample delivery mode"""
+
+    beamline = _setup_beamline_obj({"sample_delivery": "fixed-target"})
+
+    assert not beamline.is_hve_sample_delivery()
+    assert beamline.is_fixed_target_sample_delivery()
+    assert beamline.sample_delivery == SampleDelivery.fixed_target


### PR DESCRIPTION
Make it possible to enable 'Fixed-target' sample delivery method at MAXIV's MicroMAX beamline.