### PR TITLE
Added beamline_name and scheduled_beamline_name

### DIFF
--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -883,19 +883,29 @@ class ICATLIMS(AbstractLims):
         # name of the beamline where the experiment was scheduled
         scheduled_beamline_name = HWR.beamline.session.beamline_name
         try:
-                scheduled_beamline_name = self._get_scheduled_beamline()
-                msg += f"Current Beamline={HWR.beamline.session.beamline_name}"
-                logger.info(msg)
+            scheduled_beamline_name = self._get_scheduled_beamline()
+            msg += f"Current Beamline={HWR.beamline.session.beamline_name}"
+            logger.info(msg)
         except RuntimeError as err:
-                msg = f"Failed to get _get_scheduled_beamline {err}"
-                logger.warning(msg)                    
+            msg = f"Failed to get _get_scheduled_beamline {err}"
+            logger.warning(msg)
+
+        investigation_id = None
+        investigation_name = None
+        if self.session_manager.active_session.session_id:
+            investigation_id = self.session_manager.active_session.session_id
+            session = self.get_session_by_id(investigation_id)
+            if session is not None:
+                investigation_name = session.proposal_name
 
         return {
             "sampleId": sample_id,
             "Sample_name": sample_name,
             "startDate": start_time,
             "endDate": end_time,
+            "investigation_id": investigation_id,
             "beamline_name": beamline_name,
+            "proposal": investigation_name,
             "scheduled_beamline_name": scheduled_beamline_name,
             "MX_beamShape": shape.value,
             "MX_beamSizeAtSampleX": bsx,
@@ -1224,13 +1234,6 @@ class ICATLIMS(AbstractLims):
                 }
             )
 
-            # This forces the ingester to associate the dataset
-            # to the experiment by ID
-            if self.session_manager.active_session.session_id:
-                metadata["investigationId"] = (
-                    self.session_manager.active_session.session_id
-                )
-
             metadata["SampleTrackingContainer_type"] = "UNIPUCK"
             metadata["SampleTrackingContainer_capacity"] = "16"
             (position, sample_position) = self._get_sample_position()
@@ -1310,7 +1313,7 @@ class ICATLIMS(AbstractLims):
                             logger.debug(msg)
                             shutil.copy(snapshot_path, gallery_path)
             except RuntimeError as e:
-                logger.warning("Failed to create gallery. %s", e)            
+                logger.warning("Failed to create gallery. %s", e)
 
             self.icatClient.store_dataset(
                 beamline=beamline,

--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -878,11 +878,25 @@ class ICATLIMS(AbstractLims):
 
         machine_info = HWR.beamline.machine_info.get_value()
 
+        # name of the beamline where the experiment is being conducted
+        beamline_name = HWR.beamline.session.beamline_name
+        # name of the beamline where the experiment was scheduled
+        scheduled_beamline_name = HWR.beamline.session.beamline_name
+        try:
+                scheduled_beamline_name = self._get_scheduled_beamline()
+                msg += f"Current Beamline={HWR.beamline.session.beamline_name}"
+                logger.info(msg)
+        except RuntimeError as err:
+                msg = f"Failed to get _get_scheduled_beamline {err}"
+                logger.warning(msg)                    
+
         return {
             "sampleId": sample_id,
             "Sample_name": sample_name,
             "startDate": start_time,
             "endDate": end_time,
+            "beamline_name": beamline_name,
+            "scheduled_beamline_name": scheduled_beamline_name,
             "MX_beamShape": shape.value,
             "MX_beamSizeAtSampleX": bsx,
             "MX_beamSizeAtSampleY": bsy,
@@ -1296,28 +1310,7 @@ class ICATLIMS(AbstractLims):
                             logger.debug(msg)
                             shutil.copy(snapshot_path, gallery_path)
             except RuntimeError as e:
-                logger.warning("Failed to create gallery. %s", e)
-
-            try:
-                beamline = self._get_scheduled_beamline()
-                msg = f"Dataset Beamline={beamline} "
-                msg += f"Current Beamline={HWR.beamline.session.beamline_name}"
-                logger.info(msg)
-            except RuntimeError as err:
-                msg = f"Failed to get _get_scheduled_beamline {err}"
-                logger.warning(msg)
-
-            # __actualInstrument is a dataset parameter that indicates
-            # where the dataset has been actually collected
-            # only filled when it does not match the scheduled beamline
-            try:
-                if (
-                    self.active_session is None
-                    or not self.active_session.is_scheduled_beamline
-                ):
-                    metadata["__actualInstrument"] = HWR.beamline.session.beamline_name
-            except RuntimeError as e:
-                logger.warning("Failed to set __actualInstrument. %s", e)
+                logger.warning("Failed to create gallery. %s", e)            
 
             self.icatClient.store_dataset(
                 beamline=beamline,


### PR DESCRIPTION
Added two new metadata fields  to track the scheduled and the actual beamline where the experiment is conducted/scheduled.
@olofsvensson does it work like this for you?