### PR TITLE
Specify logging style for code that is not a part of a HWO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,10 +287,12 @@ one can run a command like this: `poetry run ruff check --fix`.
 
 #### Logging
 
+##### Hardware objects code
+
 When logging hardware object messages, use the `self.log` or `self.user_log` attributes.
 
 These attributes refer to logger objects from the standard `logging` module.
-`self.log` sends messages to `HWR` log, `user_log` to `user_level_log` log.
+`self.log` sends messages to `HWR` log, `self.user_log` to `user_level_log` log.
 The `self.log` will prefix log entries with the hardware object's class name.
 
 Below is an example of logging in a hardware object.
@@ -306,6 +308,33 @@ class MyHardwareObject(HardwareObject):
         self.user_log.info("an information level message")
         self.user_log.error("an error have been encountered")
 ```
+
+##### Non-hardware object code
+
+When logging messages from the code that is not part of a hardware object,
+there is no access to `self.log` and `self.user_log` attributes.
+
+Instead use `hwr_log` and `user_log` objects provided by the `mxcubecore.log` module.
+These are instances of logger objects from the standard `logging` module.
+`hwr_log` sends messages to `HWR` log, `user_log` to `user_level_log` log.
+
+Below is an example of logging from the code that is not part of a hardware object.
+
+```python
+from mxcubecore.log import hwr_log, user_log
+
+
+def my_function():
+    # log messages to 'HWR' log
+    hwr_log.info("an information level message")
+    hwr_log.warning("a warning message")
+
+    # log message to 'user_level_log' log
+    user_log.info("an information level message")
+    user_log.error("an error have been encountered")
+```
+
+##### Logging exceptions
 
 When logging a caught exception, consider using `self.log.exception()`.
 The `exception()` method adds raised exception's type, message and traceback to the log entry.

--- a/mxcubecore/BaseHardwareObjects.py
+++ b/mxcubecore/BaseHardwareObjects.py
@@ -56,6 +56,7 @@ from typing_extensions import (
 from types import MappingProxyType
 from mxcubecore.CommandContainer import CommandContainer
 from mxcubecore.dispatcher import dispatcher
+from mxcubecore.log import hwr_log, user_log
 
 if TYPE_CHECKING:
     from logging import Logger
@@ -642,8 +643,8 @@ class HardwareObjectMixin(CommandContainer):
         # List of member names (methods) to be exported (Set at configuration stage)
         self._exports_config_list = []
 
-        self.log: "Logger" = logging.getLogger("HWR").getChild(self.__class__.__name__)
-        self.user_log: "Logger" = logging.getLogger("user_level_log")
+        self.log: "Logger" = hwr_log.getChild(self.__class__.__name__)
+        self.user_log: "Logger" = user_log
 
     def __bool__(self) -> Literal[True]:
         return True

--- a/mxcubecore/log.py
+++ b/mxcubecore/log.py
@@ -1,0 +1,12 @@
+"""Provides standard loggers.
+
+Defines MXCuBE-core standard loggers.
+
+  `hwr_log` for logging to HWR log
+  `user_log` for logging to user_level_log log
+"""
+
+from logging import getLogger
+
+hwr_log = getLogger("HWR")
+user_log = getLogger("user_level_log")


### PR DESCRIPTION
Since a while ago, there is recommended style for [logging](https://mxcubecore.readthedocs.io/en/stable/dev/contributing.html#logging) when writing hardware object code.

However, that style does not work for code that is not a part of a hardware object implementation. Currently, there is a lot of different styles used.

I think we should agree on one style and try to stick to it, to make our code more uniform.

I suggest following style:

```
from mxcubecore.log import hwr_log, user_log

def my_function():

    # log messages to 'HWR' log
    hwr_log.info("an information level message")
    hwr_log.warning("a warning message")

    # log message to 'user_level_log' log
    user_log.info("an information level message")
    user_log.error("an error have been encountered")
```

This PR adds support and documentation for this logging style.

Putting this into draft, as we perhaps want to discuss this a bit first.