### PR TITLE
tango command: use `attribute_query()` to check if attribute exists

### DIFF
--- a/mxcubecore/Command/Tango.py
+++ b/mxcubecore/Command/Tango.py
@@ -143,6 +143,23 @@ class E:
         self.event = event
 
 
+def _device_has_attribute(device: DeviceProxy, attribute_name: str) -> bool:
+    """Check if a tango device has an attribute."""
+
+    try:
+        device.attribute_query(attribute_name)
+    except PyTango.DevFailed as ex:
+        if ex.args[0].reason == "API_AttrNotFound":
+            # query failed with 'attribute not found' error
+            return False
+
+        # unexpected exception, re-raise
+        raise
+
+    # attribute query was successful, thus we know the attribute exits
+    return True
+
+
 class TangoChannel(ChannelObject):
     _tangoEventsQueue = queue.Queue()
     _eventReceivers = {}
@@ -246,9 +263,7 @@ class TangoChannel(ChannelObject):
                 self.device.set_timeout_millis(self.timeout)
 
                 # check that the attribute exists (to avoid Abort in PyTango grrr)
-                if not self.attribute_name.lower() in [
-                    attr.name.lower() for attr in self.device.attribute_list_query()
-                ]:
+                if not _device_has_attribute(self.device, self.attribute_name):
                     logging.getLogger("HWR").error(
                         "no attribute %s in Tango device %s",
                         self.attribute_name,

--- a/ruff.toml
+++ b/ruff.toml
@@ -171,7 +171,6 @@ convention = "google"
     "ARG002",
     "B904",
     "E501",
-    "E713",
     "FBT003",
     "FIX002",
     "ICN001",

--- a/test/test_setup_commands_channels.py
+++ b/test/test_setup_commands_channels.py
@@ -18,31 +18,6 @@ from mxcubecore.protocols_config import setup_commands_channels
 
 
 @dataclass
-class _MockedAttribute:
-    name: str
-
-
-class _MockedDeviceProxy:
-    def __init__(self, _name):
-        pass
-
-    def ping(self):
-        pass
-
-    def set_timeout_millis(self, _timeout):
-        pass
-
-    def attribute_list_query(self):
-        return [
-            _MockedAttribute("simple"),
-            _MockedAttribute("tango_attr"),
-            _MockedAttribute("red"),
-            _MockedAttribute("green"),
-            _MockedAttribute("cyan"),
-        ]
-
-
-@dataclass
 class _MockedEpicsCommand:
     pv_name: str
     arg_list = None
@@ -163,7 +138,7 @@ def test_tango_commands_channels(test_hwo):
 
     config = _parse_yaml_config("tango_commands_channels.yaml")
 
-    with mock.patch("mxcubecore.Command.Tango.DeviceProxy", _MockedDeviceProxy):
+    with mock.patch("mxcubecore.Command.Tango.DeviceProxy"):
         setup_commands_channels(test_hwo, config)
 
     expected_channels = {
@@ -186,7 +161,7 @@ def test_tango_commands(test_hwo):
 
     config = _parse_yaml_config("tango_commands.yaml")
 
-    with mock.patch("mxcubecore.Command.Tango.DeviceProxy", _MockedDeviceProxy):
+    with mock.patch("mxcubecore.Command.Tango.DeviceProxy"):
         setup_commands_channels(test_hwo, config)
 
     # there should be no channels
@@ -207,7 +182,7 @@ def test_tango_channels(test_hwo):
 
     config = _parse_yaml_config("tango_channels.yaml")
 
-    with mock.patch("mxcubecore.Command.Tango.DeviceProxy", _MockedDeviceProxy):
+    with mock.patch("mxcubecore.Command.Tango.DeviceProxy"):
         setup_commands_channels(test_hwo, config)
 
     # there should be no commands
@@ -232,7 +207,7 @@ def test_tango_duo(test_hwo):
 
     config = _parse_yaml_config("tango_duo.yaml")
 
-    with mock.patch("mxcubecore.Command.Tango.DeviceProxy", _MockedDeviceProxy):
+    with mock.patch("mxcubecore.Command.Tango.DeviceProxy"):
         setup_commands_channels(test_hwo, config)
 
     expected_channels = {


### PR DESCRIPTION
When setting up a TangoChannel use `DeviceProxy.attribute_query()` method to check if an attribute exist. This way, we don't need look in the list of all device attributes. This list can potentially be quite long.

Move the code for checking if an attribute exists to it's own dedicated function, to improve code readability.