### PR TITLE
AbstractDffractometer, AbstractSampleView and inheriting classes

### DIFF
--- a/abstract_diffractometer_breaking_changes.md
+++ b/abstract_diffractometer_breaking_changes.md
@@ -3,16 +3,16 @@ In mxcubecore there are two classes, which could be seen as approximate abstract
 ### A convention has been introduced for the motors of the diffractometer. Thus, the object names change as follows:
 
 - **MiniDiff**:
-    •	phiMotor - omega
-    •	sampleXMotor - sampx
-    •	sampleYMotor - sampy
-    •	phiyMotor - phiy
-    •	phixMotor - phiz
-    •	kappaMotor - kappa
-    •	kappaPhiMotor - kappa_phi
-    •	zoomMotor - zoom, as NState, not as motor
+  • phiMotor - omega
+  • sampleXMotor - sampx
+  • sampleYMotor - sampy
+  • phiyMotor - phiy
+  • phixMotor - phiz
+  • kappaMotor - kappa
+  • kappaPhiMotor - kappa_phi
+  • zoomMotor - zoom, as NState, not as motor
 - **GenericDiffractometer**:
-  •	phi - omega
+  • phi - omega
 
 ### The most notable change is the transfer of all the sample view and centring methods to the sample view objects, including the list of the sample centring motors. This implies that some methods are invoked not as HWR.beamline.diffractometer, but as HWR.beamline.sample_view. The list of these methods is:
 
@@ -28,21 +28,24 @@ In mxcubecore there are two classes, which could be seen as approximate abstract
 
 ### The centring motors are defined in to sample_view and not diffractometer any more. They are defined in the sample_view configuration file, which also defines their directions and the centring_reference_position. The motors have the same roles as the diffractometer and are hold in the centring_motors dictionary. The motors change as follows:
 
-- centringPhi - centring_motors[*omega*]
-- centringPhiy - centring_motors[*phiy*]
-- centringPhiz - centring_motors[*phiz*]
-- centringSamplex - centring_motors[*sampx*]
-- centringSampley - centring_motors[*sampy*]
+- centringPhi - centring_motors\[*omega*\]
+- centringPhiy - centring_motors\[*phiy*\]
+- centringPhiz - centring_motors\[*phiz*\]
+- centringSamplex - centring_motors\[*sampx*\]
+- centringSampley - centring_motors\[*sampy*\]
 
 ### Some methods and global variables, used by the centring and defined in the diffractometer have been removed. Instead, a specific method for each type of centring has been introduced. The relevant method is set by the queue. Thus:
 
 - CENTRING_METHOD_MANUAL - replaced by start_manual_centring()
+
 - C3D_MODE - replaced by start_auto_centring()
 
 - start_centring_method - removed
+
 - cancel_centring_method - removed
 
 ### Methods name change
+
 - move_motors to set_value_motors
 - get_current_phase to get_phase
 - move_omega_relative - removed, use self.omega.set_value_relative

--- a/abstract_diffractometer_breaking_changes.md
+++ b/abstract_diffractometer_breaking_changes.md
@@ -1,0 +1,53 @@
+In mxcubecore there are two classes, which could be seen as approximate abstraction for controlling a diffractometer - ***MiniDiff*** and ***GenericDiffractometer***. These classes handle also some sample view and sample centring functionalities. It exists as well an ***AbstractSampleView*** class, which contains only few methods, used to handle the sample visualisation. The new class **AbstractDiffractometer** and the refactoring of the **AbstractSampleView/SampleView** classes aim to make a standard diffractometer API as well as transfer of all the sample view methods from the dirffractometer to the sample view classes. This intorduces some breaking changes.
+
+### A convention has been introduced for the motors of the diffractometer. Thus, the object names change as follows:
+
+- **MiniDiff**:
+    •	phiMotor - omega
+    •	sampleXMotor - sampx
+    •	sampleYMotor - sampy
+    •	phiyMotor - phiy
+    •	phixMotor - phiz
+    •	kappaMotor - kappa
+    •	kappaPhiMotor - kappa_phi
+    •	zoomMotor - zoom, as NState, not as motor
+- **GenericDiffractometer**:
+  •	phi - omega
+
+### The most notable change is the transfer of all the sample view and centring methods to the sample view objects, including the list of the sample centring motors. This implies that some methods are invoked not as HWR.beamline.diffractometer, but as HWR.beamline.sample_view. The list of these methods is:
+
+- take_snapshot
+- get_centring_status
+- get_positions
+- get_centred_point_from_coord
+- motor_positions_to_screen
+- current_centring_procedure
+- cancel_centring_method
+- accept_centring
+- reject_centring
+
+### The centring motors are defined in to sample_view and not diffractometer any more. They are defined in the sample_view configuration file, which also defines their directions and the centring_reference_position. The motors have the same roles as the diffractometer and are hold in the centring_motors dictionary. The motors change as follows:
+
+- centringPhi - centring_motors[*omega*]
+- centringPhiy - centring_motors[*phiy*]
+- centringPhiz - centring_motors[*phiz*]
+- centringSamplex - centring_motors[*sampx*]
+- centringSampley - centring_motors[*sampy*]
+
+### Some methods and global variables, used by the centring and defined in the diffractometer have been removed. Instead, a specific method for each type of centring has been introduced. The relevant method is set by the queue. Thus:
+
+- CENTRING_METHOD_MANUAL - replaced by start_manual_centring()
+- C3D_MODE - replaced by start_auto_centring()
+
+- start_centring_method - removed
+- cancel_centring_method - removed
+
+### Methods name change
+- move_motors to set_value_motors
+- get_current_phase to get_phase
+- move_omega_relative - removed, use self.omega.set_value_relative
+
+### Some methods have been converted to properties
+
+- in_plate_mode
+- in_kappa_mode

--- a/abstract_diffractometer_breaking_changes.md
+++ b/abstract_diffractometer_breaking_changes.md
@@ -1,20 +1,24 @@
-In mxcubecore there are two classes, which could be seen as approximate abstraction for controlling a diffractometer - ***MiniDiff*** and ***GenericDiffractometer***. These classes handle also some sample view and sample centring functionalities. It exists as well an ***AbstractSampleView*** class, which contains only few methods, used to handle the sample visualisation. The new class **AbstractDiffractometer** and the refactoring of the **AbstractSampleView/SampleView** classes aim to make a standard diffractometer API as well as transfer of all the sample view methods from the dirffractometer to the sample view classes. This intorduces some breaking changes.
+In mxcubecore there are two classes, which could be seen as approximate abstraction for controlling a diffractometer - ***MiniDiff*** and ***GenericDiffractometer***. These classes handle also some sample view and sample centring functionalities. It exists as well an ***AbstractSampleView*** class, which contains only few methods, used to handle the sample visualisation.
 
-### A convention has been introduced for the motors of the diffractometer. Thus, the object names change as follows:
+The new **AbstractDiffractometer** class and the refactoring of the **AbstractSampleView/SampleView** classes aim to make a standard diffractometer API as well as group all the sample viewing methods to the sample view classes. This intorduces some breaking changes.
+
+#### A convention has been introduced for the motors of the diffractometer.
+Thus, the object names change as follows:
 
 - **MiniDiff**:
-  • phiMotor - omega
-  • sampleXMotor - sampx
-  • sampleYMotor - sampy
-  • phiyMotor - phiy
-  • phixMotor - phiz
-  • kappaMotor - kappa
-  • kappaPhiMotor - kappa_phi
-  • zoomMotor - zoom, as NState, not as motor
+  - phiMotor - omega
+  - sampleXMotor - sampx
+  - sampleYMotor - sampy
+  - phiyMotor - phiy
+  - phixMotor - phiz
+  - kappaMotor - kappa
+  - kappaPhiMotor - kappa_phi
+  - zoomMotor - zoom, as NState, not as motor
 - **GenericDiffractometer**:
-  • phi - omega
+  - phi - omega
 
-### The most notable change is the transfer of all the sample view and centring methods to the sample view objects, including the list of the sample centring motors. This implies that some methods are invoked not as HWR.beamline.diffractometer, but as HWR.beamline.sample_view. The list of these methods is:
+#### Transfer of all the sample view and centring methods to the sample view objects, including the list of the sample centring motors.
+This implies that some methods are invoked not as HWR.beamline.diffractometer, but as HWR.beamline.sample_view. Here follows the list of these methods:
 
 - take_snapshot
 - get_centring_status
@@ -26,29 +30,28 @@ In mxcubecore there are two classes, which could be seen as approximate abstract
 - accept_centring
 - reject_centring
 
-### The centring motors are defined in to sample_view and not diffractometer any more. They are defined in the sample_view configuration file, which also defines their directions and the centring_reference_position. The motors have the same roles as the diffractometer and are hold in the centring_motors dictionary. The motors change as follows:
+#### The centring motors are defined in to sample_view and not diffractometer any more.
+They are defined in the sample_view configuration file, which also defines their directions and the centring_reference_position. The motors have the same roles as the diffractometer and are hold in the centring_motors dictionary. The motors change as follows:
 
-- centringPhi - centring_motors\[*omega*\]
-- centringPhiy - centring_motors\[*phiy*\]
-- centringPhiz - centring_motors\[*phiz*\]
-- centringSamplex - centring_motors\[*sampx*\]
-- centringSampley - centring_motors\[*sampy*\]
+- centringPhi - centring_motors\["omega"\]
+- centringPhiy - centring_motors\["phiy"\]
+- centringPhiz - centring_motors\["phiz"\]
+- centringSamplex - centring_motors\["sampx"\]
+- centringSampley - centring_motors\["sampy"\]
 
-### Some methods and global variables, used by the centring and defined in the diffractometer have been removed. Instead, a specific method for each type of centring has been introduced. The relevant method is set by the queue. Thus:
+#### Some methods and global variables, used by the centring and defined in the diffractometer have been removed.
+Instead, a specific method for each type of centring has been introduced. The relevant method is set by the queue. Thus:
 
 - CENTRING_METHOD_MANUAL - replaced by start_manual_centring()
-
 - C3D_MODE - replaced by start_auto_centring()
-
 - start_centring_method - removed
-
 - cancel_centring_method - removed
 
-### Methods name change
+#### Methods name change
 
-- move_motors to set_value_motors
-- get_current_phase to get_phase
-- move_omega_relative - removed, use self.omega.set_value_relative
+- *set_value_motors* replaces move_motors
+- *get_phase* replaces get_current_phase
+- *self.omega.set_value_relative* replaces move_omega_relative
 
 ### Some methods have been converted to properties
 

--- a/abstract_diffractometer_breaking_changes.md
+++ b/abstract_diffractometer_breaking_changes.md
@@ -1,4 +1,4 @@
-In mxcubecore there are two classes, which could be seen as approximate abstraction for controlling a diffractometer - ***MiniDiff*** and ***GenericDiffractometer***. These classes handle also some sample view and sample centring functionalities. It exists as well an ***AbstractSampleView*** class, which contains only few methods, used to handle the sample visualisation.
+In mxcubecore there are two classes, which could be seen as approximate abstractions for controlling a diffractometer - ***MiniDiff*** and ***GenericDiffractometer***. These classes handle also some sample view and sample centring functionalities. There is also an ***AbstractSampleView*** class, which contains only few methods, used to handle the sample visualisation.
 
 The new **AbstractDiffractometer** class and the refactoring of the **AbstractSampleView/SampleView** classes aim to make a standard diffractometer API as well as group all the sample viewing methods to the sample view classes. This intorduces some breaking changes.
 

--- a/abstract_diffractometer_breaking_changes.md
+++ b/abstract_diffractometer_breaking_changes.md
@@ -32,7 +32,7 @@ This implies that some methods are invoked not as HWR.beamline.diffractometer, b
 - accept_centring
 - reject_centring
 
-#### The centring motors are defined in to sample_view and not diffractometer any more.
+#### The centring motors are defined in sample_view and not diffractometer any more.
 
 They are defined in the sample_view configuration file, which also defines their directions and the centring_reference_position. The motors have the same roles as the diffractometer and are hold in the centring_motors dictionary. The motors change as follows:
 

--- a/abstract_diffractometer_breaking_changes.md
+++ b/abstract_diffractometer_breaking_changes.md
@@ -3,6 +3,7 @@ In mxcubecore there are two classes, which could be seen as approximate abstract
 The new **AbstractDiffractometer** class and the refactoring of the **AbstractSampleView/SampleView** classes aim to make a standard diffractometer API as well as group all the sample viewing methods to the sample view classes. This intorduces some breaking changes.
 
 #### A convention has been introduced for the motors of the diffractometer.
+
 Thus, the object names change as follows:
 
 - **MiniDiff**:
@@ -18,6 +19,7 @@ Thus, the object names change as follows:
   - phi - omega
 
 #### Transfer of all the sample view and centring methods to the sample view objects, including the list of the sample centring motors.
+
 This implies that some methods are invoked not as HWR.beamline.diffractometer, but as HWR.beamline.sample_view. Here follows the list of these methods:
 
 - take_snapshot
@@ -31,15 +33,17 @@ This implies that some methods are invoked not as HWR.beamline.diffractometer, b
 - reject_centring
 
 #### The centring motors are defined in to sample_view and not diffractometer any more.
+
 They are defined in the sample_view configuration file, which also defines their directions and the centring_reference_position. The motors have the same roles as the diffractometer and are hold in the centring_motors dictionary. The motors change as follows:
 
-- centringPhi - centring_motors\["omega"\]
-- centringPhiy - centring_motors\["phiy"\]
-- centringPhiz - centring_motors\["phiz"\]
-- centringSamplex - centring_motors\["sampx"\]
-- centringSampley - centring_motors\["sampy"\]
+- centringPhi - centring_motors["omega"]
+- centringPhiy - centring_motors["phiy"]
+- centringPhiz - centring_motors["phiz"]
+- centringSamplex - centring_motors["sampx"]
+- centringSampley - centring_motors["sampy"]
 
 #### Some methods and global variables, used by the centring and defined in the diffractometer have been removed.
+
 Instead, a specific method for each type of centring has been introduced. The relevant method is set by the queue. Thus:
 
 - CENTRING_METHOD_MANUAL - replaced by start_manual_centring()

--- a/diffractometer.md
+++ b/diffractometer.md
@@ -1,6 +1,6 @@
 Within the concept of the AbstractDiffractometer there are certain number of roles, which are fixed and define a corresponding motor or nstate actuator object.
 
-This allows to use them in a standard way by the MXCuBE application (web or Qt).
+This allows them to be used in a standard way by the MXCuBE application (web or Qt).
 
 We also introduce a convention about the direction of the alignment and centring motors:
 

--- a/diffractometer.md
+++ b/diffractometer.md
@@ -19,7 +19,7 @@ Here follows the list of the fixed roles and the description of the correspondin
 - **phiy** - alignment table y axis
 - **phiz** - alignment table z axis
 - **sample_horizontal** - x axis, combination of sampx and sampy. Equivalent to sampx at omega=0 and sampy for omega=90.
-- **samle_vertical** - y axis, combination of sampx and sampy. Equivalent to sampy at omega=0 and sampx for omega=90.
+- **sample_vertical** - y axis, combination of sampx and sampy. Equivalent to sampy at omega=0 and sampx for omega=90.
 - **backlight** - adjust the intensity of the back light
 - **frontlight** - adjust the intensity of the front light
 

--- a/diffractometer.md
+++ b/diffractometer.md
@@ -1,0 +1,39 @@
+Within the concept of the AbstractDiffractometer there are certain number of roles, which are fixed and define a corresponding motor or nstate actuator object.
+
+This allows to use them in a standard way by the MXCuBE application (web or Qt).
+
+We also introduce a convention about the direction of the alignment and centring motors:
+
+- x axis is parallel to the beam. Positive direction is from right to left.
+- y axis is perpendicular to the beam, parallel to the ground. Positive direction is from left to right, facing the beam.
+- z axis is perpendicular to the floor. Positive direction is top down.
+
+Here follows the list of the fixed roles and the description of the corresponding objects, accessible via beamline.diffractometer hardware object.
+
+1\. Motor objects (roles) and their functionality:
+
+- **omega** - the rotation axis, independent of the orientation (up, down or side). Positive direction is clockwise
+- **sampx** - centring table x axis
+- **sampy** - centring table y axis
+- **focus** - alignment table x axis
+- **phiy** - alignment table y axis
+- **phiz** - alignment table z axis
+- **sample_horizontal** - x axis, combination of sampx and sampy. Equivalent to sampx at omega=0 and sampy for omega=90.
+- **samle_vertical** - y axis, combination of sampx and sampy. Equivalent to sampy at omega=0 and sampx for omega=90.
+- **backlight** - adjust the intensity of the back light
+- **frontlight** - adjust the intensity of the front light
+
+2\. Discrete (N) state equipment and its functionality:
+
+- **zoom** - zoom levels
+- **fshutter** - fast shutter - allow beam on the sample
+- **beamstop** - put in front of a detector to avoid the direct beam.
+- **capillary** - if present, a tube to reduce the scattering background.
+- **backlightswitch** - move the backlight on the level of the onaxis viewer
+- **frontlightswitch** - switch on/off the front light
+- **fluo_detector** - if present, actuator to move a fluorescence detector close to the sample
+
+Possibly there is equipment physically part of the diffractometer, but not accessed via beamline.diffractometer:
+
+- aperture - Device to define the beam size - beamline.beam.aperture
+- cryostream - beamline.cryo

--- a/mxcubecore/HardwareObjects/Beamline.py
+++ b/mxcubecore/HardwareObjects/Beamline.py
@@ -339,8 +339,8 @@ class Beamline(HardwareObject):
         for tag, val in params.items():
             setattr(acq_parameters, tag, val)
 
-        motor_positions = self.diffractometer.get_positions()
-        osc_start = motor_positions.get("phi")
+        motor_positions = self.diffractometer.get_value_mototrs()
+        osc_start = motor_positions.get("omega")
         if osc_start is None:
             acq_parameters.osc_start = params.get("osc_start")
         else:

--- a/mxcubecore/HardwareObjects/Beamline.py
+++ b/mxcubecore/HardwareObjects/Beamline.py
@@ -339,7 +339,7 @@ class Beamline(HardwareObject):
         for tag, val in params.items():
             setattr(acq_parameters, tag, val)
 
-        motor_positions = self.diffractometer.get_value_mototrs()
+        motor_positions = self.diffractometer.get_value_motors()
         osc_start = motor_positions.get("omega")
         if osc_start is None:
             acq_parameters.osc_start = params.get("osc_start")

--- a/mxcubecore/HardwareObjects/DetectorCover.py
+++ b/mxcubecore/HardwareObjects/DetectorCover.py
@@ -1,0 +1,89 @@
+# encoding: utf-8
+#
+#  Project name: MXCuBE
+#  https://github.com/mxcube
+#
+#  This file is part of MXCuBE software.
+#
+#  MXCuBE is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  MXCuBE is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU General Lesser Public License
+#  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
+"""
+Control the detector cover
+
+Example xml file:
+
+.. code-block:: xml
+
+  <object class="DetectorCover">
+    <object href="/detcover" role="detector_cover"/>
+    <object href="/handle_detcover" role="handle_detector_cover"/>
+  </object>
+
+.. code-block:: yaml
+
+ class DetectorCover.DetectorCover
+ configuration:
+    username: Detector Cover
+ objects:
+    detector_cover: detcover.yaml
+    handle_detector_cover: handle_detcover.yaml
+
+"""
+
+from mxcubecore.HardwareObjects.abstract.AbstractActuator import AbstractActuator
+
+__copyright__ = """ Copyright © by the MXCuBE collaboration """
+__license__ = "LGPLv3+"
+
+
+class DetectorCover(AbstractActuator):
+    """Detector Cover class"""
+
+    def __init__(self, name):
+        super().__init__(name)
+        self.detector_cover = None
+        self.handle_detector_cover = True
+
+    def init(self):
+        """Initialise properties and objects"""
+        super().init()
+        self.detector_cover = self.get_object_by_role("detector_cover")
+        self.handle_detector_cover = self.get_object_by_role("handle_detector_cover")
+
+    def set_value(self, value, timeout: float | None = None):
+        """Set the detector cover. Check if you need to handle it.
+        Args:
+            value: target value.
+            timeout: optional - timeout [s].
+                     If timeout = 0: return at once and do not wait,
+                     if timeout is None: wait forever (default).
+        """
+
+        use = True
+        if self.handle_detector_cover:
+            try:
+                use = self.handle_detector_cover.get_value().value
+            except AttributeError:
+                use = False
+        if use:
+            self.detector_cover.set_value(value, timeout)
+
+    def get_value(self):
+        """Get the values for the detector cover only."""
+        return self.detector_cover.get_value()
+
+    def get_value_handle(self):
+        """Get the handle detector cover option."""
+        if self.handle_detector_cover:
+            return self.handle_detector_cover.get_value()
+        return True

--- a/mxcubecore/HardwareObjects/EMBLFlexHCD.py
+++ b/mxcubecore/HardwareObjects/EMBLFlexHCD.py
@@ -738,9 +738,8 @@ class EMBLFlexHCD(SampleChanger):
                 self._set_loaded_sample(samp)
                 self._set_selected_sample(samp)
             else:
-                samp._set_loaded(False)
-
-        self._set_selected_sample(None)
+                samp._set_loaded(False, False)
+                self._set_selected_sample(None)
 
     def prepare_hutch(self, **kwargs):
         return

--- a/mxcubecore/HardwareObjects/EMBLFlexHCD.py
+++ b/mxcubecore/HardwareObjects/EMBLFlexHCD.py
@@ -214,6 +214,7 @@ class EMBLFlexHCD(SampleChanger):
                     cell, puck, puck_type, puck_barcode, well, sample_barcode, state = [
                         p.strip() for p in entry.split(",")
                     ]
+                    state = "in_puck" if state == "on_gonio" else state
                 except ValueError:
                     self.log.warning("Skipping unexpected sample entry: %s", entry)
                     continue
@@ -231,9 +232,6 @@ class EMBLFlexHCD(SampleChanger):
                     present_sample_list.append(sample)
                     break  # stop inner loop once matched
 
-        self.user_log.info(
-            "Loaded %d samples from Flex Sample Changer", len(present_sample_list)
-        )
         return present_sample_list
 
     @task

--- a/mxcubecore/HardwareObjects/ESRF/ESRFBeam.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFBeam.py
@@ -377,7 +377,9 @@ class ESRFBeam(AbstractBeam):
         Returns:
             ``True`` if beam present, ``False`` otherwise
         """
-        return self._beam_check_obj.is_beam()
+        if self._beam_check_obj:
+            return self._beam_check_obj.is_beam()
+        return True
 
     def wait_for_beam(self, timeout: float | None = None):
         """Wait until beam present.

--- a/mxcubecore/HardwareObjects/ESRF/ESRFMultiCollect.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFMultiCollect.py
@@ -20,6 +20,7 @@ class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):
         self._metadataClient = None
         self.__mesh_steps = None
         self._mesh_range = None
+        self._detector = None
 
     @property
     def _mesh_steps(self):
@@ -92,6 +93,9 @@ class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):
 
         # self._detector.init(HWR.beamline.detector, self)
 
+        self.detector_cover = self.get_object_by_role("detector_cover")
+        self.handle_detector_cover = self.get_object_by_role("handle_detcover")
+
         self.emit("collectConnected", (True,))
         self.emit("collectReady", (True,))
 
@@ -147,7 +151,7 @@ class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):
                     start, end, exptime, number_of_images, wait=False
                 )
 
-            if self.oscillation_task.ready():
+            if self.oscillation_task and self.oscillation_task.ready():
                 self.oscillation_task.get()
         else:
             self.oscil(start, end, exptime, number_of_images)
@@ -186,17 +190,31 @@ class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):
     def queue_finished_cleanup(self):
         logging.getLogger("user_level_log").info("Queue execution finished")
 
-    @task
     def close_fast_shutter(self):
         self.execute_command("close_fast_shutter")
 
-    @task
     def open_fast_shutter(self):
         self.execute_command("open_fast_shutter")
 
+    def _handle_detector_cover(self, value=None, timeout=None):
+        use = True
+        if self.handle_detector_cover:
+            try:
+                use = self.handle_detector_cover.get_value().value
+            except AttributeError:
+                use = False
+        if use:
+            self.detector_cover.set_value(self.detector_cover.VALUES[value], timeout)
+
+    def open_detector_cover(self):
+        self._handle_detector_cover("OPEN")
+
+    def close_detector_cover(self):
+        self._handle_detector_cover("CLOSE")
+
     @task
     def move_motors(self, motor_position_dict):
-        # We do not wnta to modify the input dict
+        # We do not want to modify the input dict
         motor_positions_copy = motor_position_dict.copy()
         for motor in motor_positions_copy.keys():  # iteritems():
             position = motor_positions_copy[motor]
@@ -285,7 +303,7 @@ class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):
             return self._detector.set_detector_filenames(frame_number, start, filename)
 
     def stop_oscillation(self):
-        HWR.beamline.diffractometer.abort_cmd()
+        HWR.beamline.diffractometer.abort()
 
     def start_acquisition(self, exptime, npass, first_frame, shutterless):
         if first_frame:
@@ -309,7 +327,9 @@ class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):
         return self._detector.stop_acquisition()
 
     def reset_detector(self):
-        return self._detector.reset()
+        self._detector.reset()
+        msg = "Problem with detector, aborting ..."
+        raise RuntimeError(msg)
 
     def prepare_input_files(
         self, files_directory, prefix, run_number, process_directory
@@ -409,41 +429,6 @@ class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):
         mosflm_file.write(conn.getresponse().read().decode())
         mosflm_file.close()
         os.chmod(mosflm_input_file, 0o666)
-
-        # also write input file for STAC
-        for stac_om_input_file_name, stac_om_dir in (
-            ("xds.descr", self.xds_directory),
-            ("mosflm.descr", self.mosflm_raw_data_input_file_dir),
-            ("xds.descr", self.raw_data_input_file_dir),
-        ):
-            stac_om_input_file = os.path.join(stac_om_dir, stac_om_input_file_name)
-            conn.request("GET", "/stac.descr/%d" % collection_id)
-            stac_om_file = open(stac_om_input_file, "w")
-            stac_template = conn.getresponse().read().decode()
-            if stac_om_input_file_name.startswith("xds"):
-                om_type = "xds"
-                if stac_om_dir == self.raw_data_input_file_dir:
-                    om_filename = os.path.join(stac_om_dir, "CORRECT.LP")
-                else:
-                    om_filename = os.path.join(
-                        stac_om_dir, "xds_fastproc", "CORRECT.LP"
-                    )
-            else:
-                om_type = "mosflm"
-                om_filename = os.path.join(stac_om_dir, "bestfile.par")
-
-            stac_om_file.write(
-                stac_template.format(
-                    omfilename=om_filename,
-                    omtype=om_type,
-                    phi=HWR.beamline.diffractometer.phiMotor.get_value(),
-                    sampx=HWR.beamline.diffractometer.sampleXMotor.get_value(),
-                    sampy=HWR.beamline.diffractometer.sampleYMotor.get_value(),
-                    phiy=HWR.beamline.diffractometer.phiyMotor.get_value(),
-                )
-            )
-            stac_om_file.close()
-            os.chmod(stac_om_input_file, 0o666)
 
     def get_wavelength(self):
         return HWR.beamline.energy.get_wavelength()

--- a/mxcubecore/HardwareObjects/ESRF/ESRFMultiCollect.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFMultiCollect.py
@@ -94,7 +94,6 @@ class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):
         # self._detector.init(HWR.beamline.detector, self)
 
         self.detector_cover = self.get_object_by_role("detector_cover")
-        self.handle_detector_cover = self.get_object_by_role("handle_detcover")
 
         self.emit("collectConnected", (True,))
         self.emit("collectReady", (True,))
@@ -196,21 +195,11 @@ class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):
     def open_fast_shutter(self):
         self.execute_command("open_fast_shutter")
 
-    def _handle_detector_cover(self, value=None, timeout=None):
-        use = True
-        if self.handle_detector_cover:
-            try:
-                use = self.handle_detector_cover.get_value().value
-            except AttributeError:
-                use = False
-        if use:
-            self.detector_cover.set_value(self.detector_cover.VALUES[value], timeout)
-
     def open_detector_cover(self):
-        self._handle_detector_cover("OPEN")
+        self.detector_cover.set_value(self.detector_cover.detector_cover.VALUES.OPEN)
 
     def close_detector_cover(self):
-        self._handle_detector_cover("CLOSE")
+        self.detector_cover.set_value(self.detector_cover.detector_cover.VALUES.CLOSE)
 
     @task
     def move_motors(self, motor_position_dict):

--- a/mxcubecore/HardwareObjects/ESRF/MD2MultiCollect.py
+++ b/mxcubecore/HardwareObjects/ESRF/MD2MultiCollect.py
@@ -18,11 +18,9 @@ class MD2MultiCollect(ESRFMultiCollect):
         ESRFMultiCollect.data_collection_hook(self, data_collect_parameters)
         self._detector.shutterless = data_collect_parameters["shutterless"]
 
-        try:
+        if hasattr(HWR.beamline.sample_changer, "get_crystal_id"):
             comment = HWR.beamline.sample_changer.get_crystal_id()
             data_collect_parameters["comment"] = comment
-        except Exception:
-            self.log.exception("")
 
     @task
     def get_beam_size(self):
@@ -54,29 +52,14 @@ class MD2MultiCollect(ESRFMultiCollect):
             if tag in motor_positions_copy:
                 del motor_positions_copy[tag]
 
-        diffr.move_sync_motors(motor_positions_copy, wait=True, timeout=200)
+        diffr.set_value_motors(motor_positions_copy, simultaneous=True)
 
     @task
     def take_crystal_snapshots(self, number_of_snapshots, image_path_list=[]):
-        HWR.beamline.diffractometer.take_snapshot(image_path_list)
+        HWR.beamline.sample_view.take_acq_snapshot(image_path_list)
 
     def do_prepare_oscillation(self, *args, **kwargs):
         diffr = HWR.beamline.diffractometer
-
-        # set the detector cover out
-        try:
-            diffr.open_detector_cover()
-        except Exception:
-            self.log.exception("Could not open detector cover")
-        """
-        try:
-            detcover = self.get_object_by_role("controller").detcover
-
-            if detcover.state == "IN":
-                detcover.set_out(10)
-        except:
-            self.log.exception("Could not open detector cover")
-        """
 
         # send again the command as MD2 software only handles one
         # centered position!!
@@ -84,29 +67,26 @@ class MD2MultiCollect(ESRFMultiCollect):
         # diffr.get_command_object("save_centring_positions")()
 
         # switch on the front light
-        front_light_switch = diffr.get_object_by_role("FrontLightSwitch")
-        front_light_switch.set_value(front_light_switch.VALUES.IN)
-        # diffr.get_object_by_role("FrontLight").set_value(2)
+        diffr.frontlightswitch.set_value(diffr.frontlightswitch.VALUES.IN)
+        # diffr.frontlight.set_value(2)
 
         # move to DataCollection phase
         logging.getLogger("user_level_log").info("Moving MD2 to DataCollection")
         # AB next line to speed up the data collection
-        diffr.set_phase("DataCollection", wait=False, timeout=0)
+        diffr.set_phase(diffr.get_phase_enum.COLLECT, timeout=0)
 
     @task
     def data_collection_cleanup(self):
-        HWR.beamline.diffractometer._wait_ready(10)
+        HWR.beamline.diffractometer.wait_status_ready(10)
         self.close_fast_shutter()
 
     @task
     def oscil(self, start, end, exptime, number_of_images, wait=True):
         diffr = HWR.beamline.diffractometer
         # make sure the diffractometer is ready to do the scan
-        diffr.wait_ready(100)
+        diffr.wait_status_ready(100)
         if self.helical:
-            diffr.oscilScan4d(
-                start, end, exptime, number_of_images, self.helical_pos, wait=True
-            )
+            diffr.do_line_scan(start, end, exptime, number_of_images, self.helical_pos)
         elif self.mesh:
             det = HWR.beamline.detector
             latency_time = det.get_property("latecy_time_mesh") or det.get_deadtime()
@@ -119,7 +99,7 @@ class MD2MultiCollect(ESRFMultiCollect):
             else:
                 mesh_total_nb_frames = self.mesh_total_nb_frames
 
-            diffr.oscilScanMesh(
+            diffr.do_mesh_scan(
                 start,
                 end,
                 exptime,
@@ -128,7 +108,6 @@ class MD2MultiCollect(ESRFMultiCollect):
                 mesh_total_nb_frames,
                 self.mesh_center,
                 self.mesh_range,
-                wait=True,
             )
         elif self.fast_characterisation:
             self.nb_frames = 10
@@ -136,17 +115,16 @@ class MD2MultiCollect(ESRFMultiCollect):
             self.angle = 90
             exptime *= 10
             range = (end - start) * 10
-            diffr.characterisation_scan(
+            diffr.do_characterisation_scan(
                 start,
                 range,
                 self.nb_frames,
                 exptime,
                 self.nb_scan,
                 self.angle,
-                wait=True,
             )
         else:
-            diffr.oscilScan(start, end, exptime, number_of_images, wait=True)
+            diffr.do_oscillation_scan(start, end, exptime, number_of_images)
 
     @task
     def prepare_acquisition(

--- a/mxcubecore/HardwareObjects/ExporterMotor.py
+++ b/mxcubecore/HardwareObjects/ExporterMotor.py
@@ -237,13 +237,34 @@ class ExporterMotor(AbstractMotor):
         """
         return self.__get_limits("getMotorDynamicLimits")
 
-    def _set_value(self, value):
+    def _retry_on_ex(self, fun, N, *args, **kwargs):  # noqa: N803
+        """ """
+        for attempt in range(1, N + 1):  # noqa: RET503
+            try:
+                return fun(*args, **kwargs)
+            except Exception as e:  # noqa: PERF203
+                msg = f"Error when moving {self.actuator_name}, re-trying"
+                self.log.exception(msg)
+                if attempt == N:
+                    msg = f"Tried moving {self.actuator_name} {N} times and failed"
+                    raise RuntimeError(msg) from e
+
+                sleep(1)
+
+    def _retry_set_value(self, value):
         """Move motor to absolute value.
         Args:
             value (float): target value
         """
         self.update_state(self.STATES.BUSY)
         self.motor_position_chan.set_value(value)
+
+    def _set_value(self, value):
+        """Move motor to absolute value.
+        Args:
+            value (float): target value
+        """
+        self._retry_on_ex(self._retry_set_value, 5, value)
 
     def abort(self):
         """Stop the motor movement immediately."""
@@ -256,7 +277,7 @@ class ExporterMotor(AbstractMotor):
             timeout (float): optional - timeout [s].
         """
         self._exporter.execute("startHomingMotor", (self.actuator_name,))
-        self.wait_ready(timeout)
+        self._wait_ready(timeout)
 
     def get_max_speed(self):
         """Get the motor maximum speed.

--- a/mxcubecore/HardwareObjects/FlexHCDMaintenance.py
+++ b/mxcubecore/HardwareObjects/FlexHCDMaintenance.py
@@ -4,6 +4,7 @@ FLEX HCD maintenance mockup.
 
 import ast
 
+from mxcubecore import HardwareRepository as HWR
 from mxcubecore.BaseHardwareObjects import HardwareObject
 
 TOOL_FLANGE, TOOL_UNIPUCK, TOOL_SPINE, TOOL_PLATE, TOOL_LASER, TOOL_DOUBLE_GRIPPER = (
@@ -36,7 +37,7 @@ class FlexHCDMaintenance(HardwareObject):
         super().__init__(*args, **kwargs)
 
     def init(self):
-        self._sc = self.get_object_by_role("sample_changer")
+        self._sc = HWR.beamline.sample_changer
 
     def get_current_tool(self):
         return self._sc.get_gripper()

--- a/mxcubecore/HardwareObjects/LimaPilatusDetector.py
+++ b/mxcubecore/HardwareObjects/LimaPilatusDetector.py
@@ -107,6 +107,8 @@ class LimaPilatusDetector(AbstractDetector):
             )
 
             self.get_command_object("prepare_acq").set_device_timeout(10000)
+            if self.status.get("acq_satus") == "READY":
+                self.update_state(HardwareObjectState.READY)
             self._emit_status()
 
         except ConnectionError:

--- a/mxcubecore/HardwareObjects/MicroDiffractometer.py
+++ b/mxcubecore/HardwareObjects/MicroDiffractometer.py
@@ -22,6 +22,7 @@
 
 from gevent import Timeout, sleep
 
+from mxcubecore import HardwareRepository as HWR
 from mxcubecore.Command.Exporter import Exporter
 from mxcubecore.Command.exporter.ExporterStates import ExporterStates
 from mxcubecore.HardwareObjects.abstract.AbstractDiffractometer import (
@@ -348,11 +349,11 @@ class MicroDiffractometer(AbstractDiffractometer):
         start: float,
         end: float,
         exptime: float,
+        dead_time: float,
         nb_lines: int,
         nb_frames_total: int,
         grid_centre: list[tuple[str, float]],
         mesh_range: dict,
-        dead_time: float = 0,
         timeout: float | None = None,
     ):
         """Do a mesh scan.
@@ -361,12 +362,12 @@ class MicroDiffractometer(AbstractDiffractometer):
             start: scan start position.
             end: scan end position.
             exptime: scan exposure time (total).
+            dead_time: Dead time between the pulses. Not used any more.
             nb_lines: Total number of lines.
             nb_frames_total: Total number of frames.
             grid_centre: List of tuples (motor_role, position).
                          representing the centre of the mesh grid.
             mesh_range: Horizontal and vertical range.
-            dead_time: Dead time between the adjust the pulses.
             timeout: optional - timeout [s],
                      if timeout = 0: return at once and do not wait,
                      if timeout is None: wait forever (default).
@@ -377,23 +378,22 @@ class MicroDiffractometer(AbstractDiffractometer):
 
         # enable gate pulses
         self._exporter.write_property("DetectorGatePulseEnabled", value=True)
-        # Adding the servo time to the readout time to avoid any
-        # servo cycle jitter
-        servo_time = 0.110
 
-        self._exporter.write_property(
-            "DetectorGatePulseReadoutTime", (dead_time * 1000 + servo_time)
-        )
+        # dead_time depends on the detector. We transform it to us
+        dead_time = HWR.beamline.detector.get_deadtime() * 1000
+        self._exporter.write_property("DetectorGatePulseReadoutTime", dead_time)
 
-        self.set_values_motors(grid_centre, simultaneous=True, timeout=timeout)
+        grid_centre = grid_centre.as_dict()
+        self.set_value_motors(grid_centre, simultaneous=True, timeout=timeout)
+
         scan_params = f"{(end - start):0.3f}\t"
         scan_params += f"{-mesh_range['horizontal_range']:0.3f}\t"
-        scan_params += f"{-mesh_range['vertical_range']:0.3f}\t"
+        scan_params += f"{mesh_range['vertical_range']:0.3f}\t"
         scan_params += f"{start:0.3f}\t"
         for name in ["phiy", "phiz", "sampx", "sampy"]:
-            for mot in grid_centre:
-                if name == mot[0].name:
-                    scan_params += f"{float(mot[1]):0.3f}\t"
+            for key, val in grid_centre.items():
+                if name == key:
+                    scan_params += f"{float(val):0.3f}\t"
         scan_params += f"{nb_lines}\t"
         scan_params += f"{nb_frames_total / nb_lines}\t"
         scan_params += f"{exptime / nb_lines}\t"

--- a/mxcubecore/HardwareObjects/MicroDiffractometer.py
+++ b/mxcubecore/HardwareObjects/MicroDiffractometer.py
@@ -371,7 +371,7 @@ class MicroDiffractometer(AbstractDiffractometer):
             start: scan start position.
             end: scan end position.
             exptime: scan exposure time (total).
-            dead_time: Dead time between the pulses. Not used any more.
+            dead_time: Dead time between the pulses. Detector dependant.
             nb_lines: Total number of lines.
             nb_frames_total: Total number of frames.
             grid_centre: List of tuples (motor_role, position).
@@ -389,7 +389,7 @@ class MicroDiffractometer(AbstractDiffractometer):
         self._exporter.write_property("DetectorGatePulseEnabled", value=True)
 
         # dead_time depends on the detector. We transform it to us
-        dead_time = HWR.beamline.detector.get_deadtime() * 1000
+        dead_time = dead_time or HWR.beamline.detector.get_deadtime() * 1000
         self._exporter.write_property("DetectorGatePulseReadoutTime", dead_time)
 
         grid_centre = grid_centre.as_dict()

--- a/mxcubecore/HardwareObjects/MicroDiffractometer.py
+++ b/mxcubecore/HardwareObjects/MicroDiffractometer.py
@@ -281,7 +281,12 @@ class MicroDiffractometer(AbstractDiffractometer):
         return True
 
     def do_oscillation_scan(
-        self, start: float, end: float, exptime: float, timeout: float | None = None
+        self,
+        start: float,
+        end: float,
+        exptime: float,
+        number_of_images: int = 1,
+        timeout: float | None = None,
     ):
         """Do an oscillation scan on omega.
 
@@ -289,6 +294,7 @@ class MicroDiffractometer(AbstractDiffractometer):
             start: omega start position.
             end: omega end position.
             exptime: scan exposure time (total).
+            number_of_images: Used if need to set number of frames.
             timeout: optional - timeout [s],
                      if timeout = 0: return at once and do not wait,
                      if timeout is None: wait forever (default).
@@ -299,8 +305,10 @@ class MicroDiffractometer(AbstractDiffractometer):
         """
         # check the scan limits
         self.check_scan_limits(start, end, exptime)
-        # set only one frame
-        self._exporter.write_property("ScanNumberOfFrames", 1)
+        # set the number of frames
+        if not self.get_property("md_set_number_of_frames"):
+            number_of_images = 1
+        self._exporter.write_property("ScanNumberOfFrames", number_of_images)
         scan_params = f"1\t{start:0.3f}\t{(end - start):0.3f}\t{exptime:0.3f}\t1"
         self._exporter.execute("startScanEx", (scan_params,))
         self.wait_status_ready(timeout)
@@ -319,6 +327,7 @@ class MicroDiffractometer(AbstractDiffractometer):
             start: scan start position.
             end: scan end position.
             exptime: scan exposure time (total).
+            number_of_images: Used only if more tahn one frame needed.
             timeout: optional - timeout [s],
                      if timeout = 0: return at once and do not wait,
                      if timeout is None: wait forever (default).

--- a/mxcubecore/HardwareObjects/MicroDiffractometer.py
+++ b/mxcubecore/HardwareObjects/MicroDiffractometer.py
@@ -1,0 +1,484 @@
+# encoding: utf-8
+#
+#  Project name: MXCuBE
+#  https://github.com/mxcube
+#
+#  This file is part of MXCuBE software.
+#
+#  MXCuBE is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  MXCuBE is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU General Lesser Public License
+#  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
+
+"""Micro Diffractometer implementation of the AbstractDiffractometer class."""
+
+from gevent import Timeout, sleep
+
+from mxcubecore.Command.Exporter import Exporter
+from mxcubecore.Command.exporter.ExporterStates import ExporterStates
+from mxcubecore.HardwareObjects.abstract.AbstractDiffractometer import (
+    AbstractDiffractometer,
+    DiffractometerConstraint,
+    DiffractometerHead,
+    DiffractometerPhase,
+)
+
+__copyright__ = """ Copyright © by the MXCuBE collaboration """
+__license__ = "LGPLv3+"
+
+
+class MicroDiffractometer(AbstractDiffractometer):
+    """Microdiff with Exporter implementation of AbstractDiffractometer"""
+
+    def __init__(self, name):
+        super().__init__(name)
+        self._exporter = None
+
+    def init(self):
+        """Initialise the device"""
+        super().init()
+        exporter_address = self.get_property("exporter_address")
+        _host, _port = exporter_address.split(":")
+        self._exporter = Exporter(_host, int(_port))
+        self.head_type = self._get_head_type
+
+        # add the custom commands
+        for nam, cmd in self.get_property("commands").items():
+            _cmd = {
+                "type": "exporter",
+                "exporter_address": exporter_address,
+                "name": nam,
+            }
+            setattr(self, nam, self.add_command(_cmd, cmd))
+
+        # add the custom channels
+        for nam, attr in self.get_property("channels").items():
+            _attr = {
+                "type": "exporter",
+                "exporter_address": exporter_address,
+                "name": nam,
+            }
+            setattr(self, nam, self.add_channel(_attr, attr))
+
+        self.update_state()
+
+        # we must have global_state and phase_channel channels configured
+        try:
+            self.phase_channel.connect_signal("update", self.update_phase)
+            self.global_state.connect_signal("update", self._update_state)
+        except AttributeError:
+            self.log.exception("global_state and phase_channel not configured!")
+
+    def abort(self):
+        """Immediately terminate action."""
+        self._exporter.execute("abort")
+
+    @property
+    def _get_hwstate(self) -> str:
+        """Get the hardware state, reported by the MD2 application.
+
+        Returns:
+            The state.
+        """
+        try:
+            return self._exporter.read_property("HardwareState")
+        except AttributeError:
+            return "Ready"
+
+    @property
+    def _get_swstate(self) -> str:
+        """Get the software state, reported by the MD2 application.
+
+        Returns:
+            The state.
+        """
+        return self.global_state.get_value()
+
+    def _update_state(self, value):
+        if isinstance(value, str):
+            self.update_state(self.get_state())
+        else:
+            self.update_state(value)
+
+    def get_state(self):
+        """Get the diffractometer general state.
+
+        Returns:
+            (enum 'HardwareObjectState'): state
+        """
+        try:
+            return ExporterStates[self._get_swstate.upper()].value
+        except ValueError:
+            return self.STATES.UNKNOWN
+
+    @property
+    def _ready(self) -> bool:
+        """Get the "Ready" state - software and hardware.
+
+        Returns:
+            True if both "Ready", False otherwise.
+        """
+        return self._get_swstate == "Ready" and self._get_hwstate == "Ready"
+
+    def wait_status_ready(self, timeout: float | None = None):
+        """Wait timeout seconds until status is ready.
+
+        Args:
+            Timeout [s]. None means infinite timeout.
+        """
+        with Timeout(timeout, RuntimeError("Timeout waiting for status ready")):
+            while not self._ready:
+                sleep(0.5)
+
+    def set_value_motors(
+        self,
+        motors_positions_dict: dict[str, float],
+        simultaneous: bool = True,
+        timeout: float | None = None,
+    ):
+        """Move specified motors to the requested positions.
+
+        Args:
+            motors_positions_dict (dict): Dictionary {motor_role: target_value}.
+            simultaneous: Move the motors simultaneously (True - default) or not.
+            timeout: optional - timeout [s],
+                     if timeout = 0: return at once and do not wait,
+                     if timeout is None: wait forever (default).
+
+        Raises:
+            TimeoutError: Timeout
+            KeyError: The name does not correspond to an existing motor
+        """
+        if not simultaneous:
+            super().set_value_motors(motors_positions_dict, simultaneous, timeout)
+        else:
+            # prepare the command
+            cmd = ""
+            for role, pos in motors_positions_dict.items():
+                name = self.motors_hwobj_dict[role].actuator_name
+                cmd += f"{name}={pos:0.3f};"
+            self._exporter.execute("startSimultaneousMoveMotors", (cmd,))
+            if timeout != 0:
+                self.wait_status_ready(timeout)
+            self.update_state()
+
+    def get_value_motors(self, motors_list: [list | None] = None) -> dict[str, float]:
+        """Get the positions of diffractometer motors. If the motors_list
+           is empty, return the positions of all the availble motors.
+
+        Args:
+            motors_list: List of motor roles.
+
+        Returns:
+            Dictionary {role: position}.
+        """
+        motors_positions_dict = super().get_value_motors(motors_list)
+        if not self.in_kappa_mode:
+            motors_positions_dict.update({"kappa": None, "kappa_phi": None})
+        return motors_positions_dict
+
+    def get_motors(self):
+        """Get the dictionary of all the motors which can be used.
+
+        Returns:
+            Ddctionary {role: hardware_object}.
+        """
+
+        def find_elem(ddict, val):
+            """Find dictionary elemnt from motor actuator_name"""
+            for role, hwobj in ddict.items():
+                if hwobj.actuator_name == val:
+                    return {role: hwobj}
+            return {}
+
+        motors = self._exporter.read_property("MotorStates")
+        motors_dict = {}
+        for mot in motors:
+            mot_stat = mot.split("=")
+            if mot_stat[1] not in ("Disable", "Unknown"):
+                elem = find_elem(self.motors_hwobj_dict, mot_stat[0])
+                motors_dict.update(elem)
+
+        return motors_dict
+
+    @property
+    def _get_head_type(self) -> DiffractometerHead:
+        """Get the head type."""
+        try:
+            self.head_type = DiffractometerHead(
+                self._exporter.read_property("HeadType")
+            )
+        except ValueError:
+            self.head_type = DiffractometerHead.UNKNOWN
+        return self.head_type
+
+    def _set_phase(self, value: DiffractometerPhase):
+        """Specific implementation to set the diffractometer to selected phase.
+
+        Args:
+            value: requested phase.
+        """
+        self._exporter.execute("startSetPhase", (value.value,))
+        self.wait_status_ready(timeout=200)
+
+    def get_phase(self) -> DiffractometerPhase:
+        """Get the current phase."""
+        value = self.phase_channel.get_value()
+        try:
+            self.current_phase = DiffractometerPhase(value)
+        except ValueError:
+            self.current_phase = DiffractometerPhase.UNKNOWN
+        return self.current_phase
+
+    def _set_constraint(self, value: DiffractometerConstraint):
+        """Specific implementation to set the diffractometer to selected constraint
+        Args:
+            value: requested constraint.
+        """
+        self._exporter.execute("startSetMode", (value.value,))
+
+    def get_constraint(self) -> DiffractometerConstraint:
+        """Get the diffrractometer constraint type."""
+        value = self._exporter.read_property("CurrentMode")
+        try:
+            self.current_constraint = DiffractometerConstraint(value)
+        except ValueError:
+            self.current_constraint = DiffractometerConstraint.UNKNOWN
+        return self.current_constraint
+
+    def check_scan_limits(self, start: float, end: float, exptime: float) -> bool:
+        """Check if the scan parameters are within the limits
+
+        Args:
+            start: scan start position.
+            end: scan end position.
+            exptime: scan exposure time (total) [s].
+
+        Returns:
+            True (parameters within the limits), False otherwise.
+        """
+        if self.in_plate_mode:
+            scan_speed = abs(end - start) / exptime
+            llim, hlim = map(
+                float,
+                self._exporter.execute("getOmegaMotorDynamicScanLimits", (scan_speed,)),
+            )
+            if start < llim:
+                msg = f"Scan start below the allowed value {llim}"
+                raise ValueError(msg)
+            if end > hlim:
+                msg = f"Scan end above the allowed value {hlim}"
+                raise ValueError(msg)
+        return True
+
+    def do_oscillation_scan(
+        self, start: float, end: float, exptime: float, timeout: float | None = None
+    ):
+        """Do an oscillation scan on omega.
+
+        Args:
+            start: omega start position.
+            end: omega end position.
+            exptime: scan exposure time (total).
+            timeout: optional - timeout [s],
+                     if timeout = 0: return at once and do not wait,
+                     if timeout is None: wait forever (default).
+
+        Raises:
+            RuntimeError: Timeout waiting for status ready.
+            ValueError: Scan parameters not within limits (if relevant).
+        """
+        # check the scan limits
+        self.check_scan_limits(start, end, exptime)
+        # set only one frame
+        self._exporter.write_property("ScanNumberOfFrames", 1)
+        scan_params = f"1\t{start:0.3f}\t{(end - start):0.3f}\t{exptime:0.3f}\t1"
+        self._exporter.execute("startScanEx", (scan_params,))
+        self.wait_status_ready(timeout)
+
+    def do_line_scan(
+        self,
+        start: float,
+        end: float,
+        exptime: float,
+        number_of_images: int,
+        motors_pos: dict[str, dict],
+        timeout: float | None = None,
+    ):
+        """Do helical (line) scan on omega.
+        Args:
+            start: scan start position.
+            end: scan end position.
+            exptime: scan exposure time (total).
+            timeout: optional - timeout [s],
+                     if timeout = 0: return at once and do not wait,
+                     if timeout is None: wait forever (default).
+            motors_pos: {"1": [centred position], "2": [centred position]}
+
+        Raises:
+            RuntimeError: Timeout waiting for status ready.
+            ValueError: Scan parameters not within limits (if relevant).
+        """
+        # check the scan limits
+        self.check_scan_limits(start, end, exptime)
+        if not self.get_property("md_set_number_of_frames"):
+            number_of_images = 1
+
+        self._exporter.write_property("ScanNumberOfFrames", number_of_images)
+
+        scan_params = f"{start:0.3f}\t{(end - start):0.3f}\t{exptime:0.3f}\t"
+        for name in ["phiy", "phiz", "sampx", "sampy"]:
+            scan_params += f"{motors_pos['1'][name]:0.3f}\t"
+        for name in ["phiy", "phiz", "sampx", "sampy"]:
+            scan_params += f"{motors_pos['2'][name]:0.3f}\t"
+
+        self._exporter.execute("startScan4DEx", (scan_params,))
+        self.wait_status_ready(timeout)
+
+    def do_mesh_scan(
+        self,
+        start: float,
+        end: float,
+        exptime: float,
+        nb_lines: int,
+        nb_frames_total: int,
+        grid_centre: list[tuple[str, float]],
+        mesh_range: dict,
+        dead_time: float = 0,
+        timeout: float | None = None,
+    ):
+        """Do a mesh scan.
+
+        Args:
+            start: scan start position.
+            end: scan end position.
+            exptime: scan exposure time (total).
+            nb_lines: Total number of lines.
+            nb_frames_total: Total number of frames.
+            grid_centre: List of tuples (motor_role, position).
+                         representing the centre of the mesh grid.
+            mesh_range: Horizontal and vertical range.
+            dead_time: Dead time between the adjust the pulses.
+            timeout: optional - timeout [s],
+                     if timeout = 0: return at once and do not wait,
+                     if timeout is None: wait forever (default).
+
+        Raises:
+            RuntimeError: Timeout waiting for status ready.
+        """
+
+        # enable gate pulses
+        self._exporter.write_property("DetectorGatePulseEnabled", value=True)
+        # Adding the servo time to the readout time to avoid any
+        # servo cycle jitter
+        servo_time = 0.110
+
+        self._exporter.write_property(
+            "DetectorGatePulseReadoutTime", (dead_time * 1000 + servo_time)
+        )
+
+        self.set_values_motors(grid_centre, simultaneous=True, timeout=timeout)
+        scan_params = f"{(end - start):0.3f}\t"
+        scan_params += f"{-mesh_range['horizontal_range']:0.3f}\t"
+        scan_params += f"{-mesh_range['vertical_range']:0.3f}\t"
+        scan_params += f"{start:0.3f}\t"
+        for name in ["phiy", "phiz", "sampx", "sampy"]:
+            for mot in grid_centre:
+                if name == mot[0].name:
+                    scan_params += f"{float(mot[1]):0.3f}\t"
+        scan_params += f"{nb_lines}\t"
+        scan_params += f"{nb_frames_total / nb_lines}\t"
+        scan_params += f"{exptime / nb_lines}\t"
+        scan_params += "True\tTrue\tTrue\t"
+        self._exporter.execute("startRasterScanEx", (scan_params,))
+        self.wait_status_ready(timeout)
+
+    def do_still_scan(
+        self,
+        pulse_duration: float,
+        pulse_period: float,
+        nb_pulse: int,
+        timeout: [None | float] = None,
+    ):
+        """Do a zero oscillation acquisition.
+
+        Args:
+            pulse_duration: Duration of the pulse sent to the detector.
+            pulse_period: The period of the pulse sent to the detector.
+            nb_pulse: Number of pulses to be sent.
+            timeout: optional - timeout [s],
+                     if timeout = 0: return at once and do not wait,
+                     if timeout is None: wait forever (default).
+
+        Raises:
+            RuntimeError: Timeout waiting for status ready.
+        """
+        scan_params = f"{pulse_duration:0.6f}\t{pulse_period:0.6f}\t{nb_pulse}"
+        self._exporter.execute("startStillScan", (scan_params,))
+        self.wait_status_ready(timeout)
+
+    def do_characterisation_scan(
+        self,
+        start: float,
+        scan_range: float,
+        nb_frames: int,
+        exptime: float,
+        nb_scans: int,
+        angle: float,
+        timeout: float | None = None,
+    ):
+        """Do fast characterisation.
+        Args:
+            start: Position of omega for the first scan [deg].
+            scan_range: range for each scan [deg].
+            nb_frames: Frame numbers for each scan.
+            exptime: Total exposure time for each scan [s].
+            nb_scans: How many times a scan to be repeated.
+            angle: The angle between each scan [deg]. This number,
+                   added to the last position of each scan and will
+                   be the start position of the following scan.
+            timeout (float): optional - timeout [s],
+                             if timeout = 0: return at once and do not wait,
+                             if timeout is None: wait forever (default).
+
+        Raises:
+            RuntimeError: Timeout waiting for status ready.
+        """
+
+        if self.in_plate_mode:
+            # to see if needed when plates
+            return
+
+        scan_params = f"{nb_frames}\t{start:0.3f}\t{scan_range:0.3f}\t"
+        scan_params += f"{exptime:0.3f}\t{nb_scans}\t{angle:0.3f}"
+        self._exporter.execute("startCharacterisationScanEx", (scan_params,))
+        if timeout:
+            # min timeout is 20 min
+            timeout = max(timeout, 20 * 60)
+
+        self.wait_status_ready(timeout)
+
+    def get_pixels_per_mm(self) -> tuple[int, int]:
+        """Get the pixel/mm values.
+
+        Returns:
+            (x ,y) [pixel/mm]
+        """
+        x_calib = self._exporter.read_property("CoaxCamScaleX")
+        y_calib = self._exporter.read_property("CoaxCamScaleY")
+        return 1.0 / x_calib, 1.0 / y_calib
+
+    def get_beam_position(self) -> tuple:
+        """Get the beam position defined in MD"""
+        return (
+            self.beam_position_horizontal.get_value(),
+            self.beam_position_vertical.get_value(),
+        )

--- a/mxcubecore/HardwareObjects/MicrodiffKappaMotor.py
+++ b/mxcubecore/HardwareObjects/MicrodiffKappaMotor.py
@@ -21,13 +21,19 @@ class MicrodiffKappaMotor(ExporterMotor):
             raise RuntimeError("MicrodiffKappaMotor class is only for kappa motors")
         MicrodiffKappaMotor.motors[self.actuator_name] = self
         if self.actuator_name == "Kappa":
-            MicrodiffKappaMotor.conf["KappaTrans"] = self.stringToList(self.kappaTrans)
+            MicrodiffKappaMotor.conf["KappaTrans"] = self.stringToList(
+                self.get_property("kappaTrans")
+            )
             MicrodiffKappaMotor.conf["KappaTransD"] = self.stringToList(
-                self.kappaTransD
+                self.get_property("kappaTransD")
             )
         elif self.actuator_name == "Phi":
-            MicrodiffKappaMotor.conf["PhiTrans"] = self.stringToList(self.phiTrans)
-            MicrodiffKappaMotor.conf["PhiTransD"] = self.stringToList(self.phiTransD)
+            MicrodiffKappaMotor.conf["PhiTrans"] = self.stringToList(
+                self.get_property("phiTrans")
+            )
+            MicrodiffKappaMotor.conf["PhiTransD"] = self.stringToList(
+                self.get_property("phiTransD")
+            )
         self.sampx = self.get_object_by_role("sampx")
         self.sampy = self.get_object_by_role("sampy")
         self.phiy = self.get_object_by_role("phiy")

--- a/mxcubecore/HardwareObjects/MicrodiffLight.py
+++ b/mxcubecore/HardwareObjects/MicrodiffLight.py
@@ -2,12 +2,8 @@ from mxcubecore.HardwareObjects.ExporterMotor import ExporterMotor
 
 
 class MicrodiffLight(ExporterMotor):
-    def __init__(self, name):
-        ExporterMotor.__init__(self, name)
-        self._motor_pos_suffix = "Level"
-
     def init(self):
-        ExporterMotor.init(self)
+        super().init()
         try:
             _low, _high = self.get_property("limits").split(",")
             self._limits = (float(_low), float(_high))

--- a/mxcubecore/HardwareObjects/MicrodiffScintillator.py
+++ b/mxcubecore/HardwareObjects/MicrodiffScintillator.py
@@ -1,0 +1,59 @@
+# encoding: utf-8
+#
+#  Project name: MXCuBE
+#  https://github.com/mxcube
+#
+#  This file is part of MXCuBE software.
+#
+#  MXCuBE is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  MXCuBE is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU General Lesser Public License
+#  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
+"""
+MicrodiffScintillator.
+
+Example xml file:
+
+.. code-block:: xml
+
+  <object class="MicrodiffScintillator">
+    <username>Scintilator</username>
+    <exporter_address>xxx:9001</exporter_address>
+    <value_channel_name>ScintillatorPosition</value_channel_name>
+    <values>{"IN": "SCINTILLATOR", "OUT": "PARK"}</values>
+    <state_channel_name>HardwareState</state_channel_name>
+  </object>
+"""
+
+from mxcubecore import HardwareRepository as HWR
+from mxcubecore.HardwareObjects.abstract.AbstractDiffractometer import (
+    DiffractometerPhase,
+)
+from mxcubecore.HardwareObjects.ExporterNState import ExporterNState
+
+__copyright__ = """ Copyright © by the MXCuBE collaboration """
+__license__ = "LGPLv3+"
+
+
+class MicrodiffScintillator(ExporterNState):
+    """Microdiff Scintillator class"""
+
+    def _set_value(self, value):
+        """Set device to value
+        Args:
+            value (str, int, float or enum): Value to be set.
+        """
+        # use phase when setting in
+        if value == self.VALUES.IN:
+            # use phase change instead of in
+            HWR.beamline.diffractometer.set_phase(DiffractometerPhase.SEE_BEAM)
+        else:
+            super()._set_value(value)

--- a/mxcubecore/HardwareObjects/MicrodiffScintillator.py
+++ b/mxcubecore/HardwareObjects/MicrodiffScintillator.py
@@ -30,6 +30,7 @@ Example xml file:
     <value_channel_name>ScintillatorPosition</value_channel_name>
     <values>{"IN": "SCINTILLATOR", "OUT": "PARK"}</values>
     <state_channel_name>HardwareState</state_channel_name>
+    <object href="/detector_cover" role="detector_cover"/>
   </object>
 """
 
@@ -55,5 +56,9 @@ class MicrodiffScintillator(ExporterNState):
         if value == self.VALUES.IN:
             # use phase change instead of in
             HWR.beamline.diffractometer.set_phase(DiffractometerPhase.SEE_BEAM)
+            # close the detecor cover
+            detcover = self.get_object_by_role("detector_cover")
+            if detcover:
+                detcover.set_value(detcover.detector_cover.VALUES.CLOSE)
         else:
             super()._set_value(value)

--- a/mxcubecore/HardwareObjects/SampleView.py
+++ b/mxcubecore/HardwareObjects/SampleView.py
@@ -764,27 +764,6 @@ class SampleView(AbstractSampleView):
                 self.log.exception("Setting Alignment reference position failed")
                 raise
 
-    def _set_rotation_axis_position(self, value: float, motor_name="phiz"):
-        if motor_name == "phiz":
-            self.centringPhiz = sample_centring.CentringMotor(
-                self.phizMotor, reference_position=value
-            )
-        elif motor_name == "phiy":
-            self.centringPhiy = sample_centring.CentringMotor(
-                self.phiyMotor, reference_position=value
-            )
-
-        script_name = (
-            "Change_AlignmentZ" if motor_name == "phiz" else "Change_AlignmentY"
-        )
-
-        try:
-            self.log.info("Setting MD Alignment reference position")
-            self.run_script(f"{script_name}, {value}")
-        except:
-            self.log.exception("Setting MD Alignment reference position failed")
-            raise
-
 
 class Shape:
     """
@@ -960,7 +939,7 @@ class Grid(Shape):
 
     def update_position(self, transform):
         phi_pos = HWR.beamline.diffractometer.omega.get_value() % 360
-        _d = abs((self.get_centred_position().phi % 360) - phi_pos)
+        _d = abs((self.get_centred_position().omega % 360) - phi_pos)
 
         if self.user_state == "HIDDEN":
             self.state = "HIDDEN"

--- a/mxcubecore/HardwareObjects/SampleView.py
+++ b/mxcubecore/HardwareObjects/SampleView.py
@@ -17,23 +17,29 @@
 #  You should have received a copy of the GNU General Lesser Public License
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 
-__copyright__ = """2019 by the MXCuBE collaboration """
-__license__ = "LGPLv3+"
 
 import base64
 import copy
+import logging
+import math
+from ast import literal_eval
 from functools import reduce
 from io import BytesIO
 
 import numpy as np
+from gevent import GreenletExit
 from PIL import Image
 
 from mxcubecore import HardwareRepository as HWR
+from mxcubecore.HardwareObjects import sample_centring
 from mxcubecore.HardwareObjects.abstract.AbstractSampleView import (
     AbstractSampleView,
     ShapeState,
 )
-from mxcubecore.model import queue_model_objects
+from mxcubecore.model import queue_model_objects as qmo
+
+__copyright__ = """by the MXCuBE collaboration """
+__license__ = "LGPLv3+"
 
 
 def combine_images(img1, img2):
@@ -61,55 +67,317 @@ def combine_images(img1, img2):
 
 
 class SampleView(AbstractSampleView):
+    """SampleView class"""
+
     def __init__(self, name):
-        AbstractSampleView.__init__(self, name)
-        self._shapes = {}
+        super().__init__(name)
+        self.centring_motors = {}
+        self.current_centring_procedure = None
+        self.current_centring_method = None
+        self.centring_status = {}
+        self.rotation_reference = {}
 
     def init(self):
-        super(SampleView, self).init()
+        super().init()
+
+        centring_motor_roles = literal_eval(self.get_property("centring_motors", []))
+        # need to set the motor names for the centring points
+        qmo.CentredPosition.DIFFRACTOMETER_MOTOR_NAMES = centring_motor_roles
+        centring_ref_position = literal_eval(
+            self.get_property("centring_reference_position", {})
+        )
+        motor_directions = self.get_property("motor_directions", {})
+        if isinstance(motor_directions, str):
+            motor_directions = literal_eval(motor_directions)
+        diffr = HWR.beamline.diffractometer
+
+        for role in centring_motor_roles:
+            if role in diffr.motors_hwobj_dict:
+                motor_obj = diffr.motors_hwobj_dict[role]
+                ref_position = None
+                if role in centring_ref_position:
+                    ref_position = centring_ref_position[role]
+                direction = motor_directions.get(role, 1)
+                self.centring_motors[role] = sample_centring.CentringMotor(
+                    motor_obj, reference_position=ref_position, direction=direction
+                )
+                self.centring_motors[role].motor.connect(
+                    "stateChanged", self._update_shape_positions
+                )
+        self._camera = self.get_object_by_role("camera")
         self._last_oav_image = None
 
         self.hide_grid_threshold = self.get_property("hide_grid_threshold", 5)
-        for motor_name, motor_ho in HWR.beamline.diffractometer.get_motors().items():
-            if motor_ho:
-                motor_ho.connect("stateChanged", self._update_shape_positions)
+        self.centring_status = {"valid": False}
+        rotation_reference = self.get_property("rotation_reference", {})
+        if isinstance(rotation_reference, str):
+            self.rotation_reference = literal_eval(rotation_reference)
+        self.rotation_reference.update(
+            {"motor": self.centring_motors.get(self.rotation_reference.get("name"))}
+        )
 
     def _update_shape_positions(self, *args, **kwargs):
         for shape in self.get_shapes():
-            shape.update_position(HWR.beamline.diffractometer.motor_positions_to_screen)
+            shape.update_position(self.motor_positions_to_screen)
 
         self.emit("shapesChanged")
 
-    @property
-    def shapes(self):
-        return self._shapes
+    def get_positions(self) -> dict[str, float]:
+        """Get motor positions for the centring motors.
 
-    def start_centring(self, tree_click=True):
+        Returns:
+            Centring motor positions as {role: position}
         """
-        Starts centring procedure
-        """
-        pass
+        motors_dict = {}
+        for key, val in self.centring_motors.items():
+            motors_dict.update({key: val.motor.get_value()})
+        return motors_dict
 
-    def cancel_centring(self):
-        """
-        Cancels current centring procedure
-        """
-        pass
+    def get_centred_point_from_coord(self, x, y, return_by_names=None):
+        return self.get_positions()
 
-    def start_auto_centring(self):
-        """
-        Start automatic centring procedure
-        """
-        pass
-
-    def get_snapshot(self, overlay=None, bw=False, return_as_array=False):
-        """
-        Get snapshot(s)
+    def motor_positions_to_screen(
+        self, positions_dict: dict[str, float]
+    ) -> tuple[int, int]:
+        """Get the x,y pixel value according to the calibration.
 
         Args:
-            overlay(str): Image data with shapes and other items to display on the snapshot
-            bw(bool): return grayscale image
-            return_as_array(bool): return as np array
+            positions_dict: Dictionary {role: position}
+        """
+        if not positions_dict:
+            raise RuntimeError("Unknown position")
+        try:
+            diffr = HWR.beamline.diffractometer
+            p_x, p_y = diffr.get_pixels_per_mm()
+            if None in (p_x, p_y):
+                return 0, 0
+            omega_angle = math.radians(-diffr.omega.get_value())
+            sampx = positions_dict.get("sampx") - diffr.sampx.get_value()
+            sampy = positions_dict.get("sampy") - diffr.sampy.get_value()
+            phiy = -(positions_dict.get("phiy") - diffr.phiy.get_value())
+            phiz = positions_dict.get("phiz") - diffr.phiz.get_value()
+
+            rot_matrix = np.matrix(
+                [
+                    [math.cos(omega_angle), -math.sin(omega_angle)],
+                    [math.sin(omega_angle), math.cos(omega_angle)],
+                ]
+            )
+            inv_rot_matrix = np.array(rot_matrix.I)
+            dx, dy = np.dot(np.array([sampx, sampy]), inv_rot_matrix) * p_x
+
+            chi_angle = math.radians(positions_dict.get("chi", 0))
+            chi_rot = np.matrix(
+                [
+                    [math.cos(chi_angle), -math.sin(chi_angle)],
+                    [math.sin(chi_angle), math.cos(chi_angle)],
+                ]
+            )
+            sx, sy = np.dot(np.array([0, dy]), np.array(chi_rot))
+
+            beam_position = HWR.beamline.beam.get_beam_position_on_screen()
+
+            x = sx + (phiy * p_x) + beam_position[0]
+            y = sy + (phiz * p_y) + beam_position[1]
+
+        except AttributeError as err:
+            raise NotImplementedError from err
+        return x, y
+
+    def start_manual_centring(self, nb_click: int = 3):
+        """Do the manual centring procedure.
+
+        Args:
+           nb_click: Number of clicks.
+        """
+        if self.current_centring_procedure is not None:
+            logging.getLogger("HWR").exception("Already centring")
+
+        self.current_centring_method = "Manual"
+        self.emit("centringStarted", ("Manual"))
+        beam_pos = HWR.beamline.beam.get_beam_position_on_screen()
+        diffr = HWR.beamline.diffractometer
+        pixels_per_mm = diffr.get_pixels_per_mm()
+        diffr.wait_status_ready(5)
+
+        self.current_centring_procedure = sample_centring.start(
+            self.centring_motors,
+            pixels_per_mm[0],
+            pixels_per_mm[1],
+            beam_pos[0],
+            beam_pos[1],
+            chi_angle=0.0,
+        )
+
+        self.current_centring_procedure.link(self.manual_centring_done)
+
+    def get_centring_status(self):
+        return copy.deepcopy(self.centring_status)
+
+    def image_clicked(self, x, y):
+        logging.getLogger("user_level_log").info(
+            f"Centring click at x:{int(x)}, y:{int(y)}"
+        )
+        sample_centring.user_click(x, y, wait=True)
+
+    def manual_centring_done(self, manual_centring_procedure):
+        try:
+            motor_pos = manual_centring_procedure.get()
+            if isinstance(motor_pos, GreenletExit):
+                raise motor_pos
+        except Exception:
+            logging.exception("Could not complete manual centring")
+            self.centring_failed()
+        else:
+            self.emit("centringMoving", ())
+            try:
+                sample_centring.end()
+            except Exception:
+                logging.exception("Could not move to centred position")
+                self.centring_failed()
+
+            self.centring_done()
+
+    def centring_done(self):
+        """Execute if centring accepted."""
+        self.centring_status = {"motors": {}, "method": self.current_centring_method}
+        self.centring_status["motors"] = self.get_positions()
+        HWR.beamline.diffractometer.save_centring_positions()
+
+        self.centring_status["valid"] = True
+
+        self.emit(
+            "centringSuccessful",
+            (self.current_centring_method, self.get_centring_status()),
+        )
+        self.current_centring_method = None
+        self.current_centring_procedure = None
+
+    def accept_centring(self):
+        """Accept the current centred position."""
+        self.centring_status["valid"] = True
+        self.emit("centringAccepted", (True, self.get_centring_status()))
+        logging.getLogger("user_level_log").info("Centring successful")
+
+    def reject_centring(self):
+        """Reject the current centred position."""
+        if self.current_centring_procedure:
+            self.current_centring_procedure.kill(block=True)
+        self.centring_status["valid"] = False
+        self.emit("centringAccepted", (False, self.get_centring_status()))
+        logging.getLogger("user_level_log").info("Centring cancelled")
+
+    def cancel_centring(self):
+        """Cancel current centring procedure."""
+        if self.current_centring_procedure:
+            try:
+                self.current_centring_procedure.kill(block=True)
+            except Exception:
+                logging.getLogger("HWR").exception(
+                    "Problem aborting the centring method"
+                )
+
+            logging.getLogger("HWR").exception("Centring canceled")
+        self.centring_failed()
+
+    def centring_failed(self):
+        """Execute if centring failed or canceled."""
+        self.centring_status["valid"] = False
+        self.emit(
+            "centringFailed", (self.current_centring_method, self.get_centring_status())
+        )
+        self.current_centring_procedure = None
+        self.current_centring_method = None
+
+    def start_auto_centring(self):
+        """Start automatic centring procedure"""
+        if self.current_centring_procedure is not None:
+            logging.getLogger("HWR").exception("Already centring")
+
+        beam_pos_x, beam_pos_y = HWR.beamline.beam.get_beam_position_on_screen()
+        diffr = HWR.beamline.diffractometer
+        diffr.set_phase(diffr.get_phase_enum.CENTRE)
+
+        pixels_per_mm_x, pixels_per_mm_y = diffr.get_pixels_per_mm()
+        diffr.wait_status_ready(5)
+
+        self.current_centring_procedure = sample_centring.start_auto(
+            self,
+            self.centring_motors,
+            pixels_per_mm_x,
+            pixels_per_mm_y,
+            beam_pos_x,
+            beam_pos_y,
+            chi_angle=0.0,
+        )
+
+        self.current_centring_method = "Automatic"
+        self.emit("centringStarted", ("Automatic"))
+        self.current_centring_procedure.link(self.auto_centring_done)
+
+    def move_to_beam(self, x: float, y: float):
+        """Move the sample to the x,y coordinates.
+        Args:
+            x: Pixels on x axis
+            y: Pixels on y axis
+        """
+        beam_pos_x, beam_pos_y = HWR.beamline.beam.get_beam_position_on_screen()
+        diffr = HWR.beamline.diffractometer
+        pixels_per_mm_x, pixels_per_mm_y = diffr.get_pixels_per_mm()
+        if not all([pixels_per_mm_x, pixels_per_mm_y]):
+            logging.getLogger("HWR").exception("Cannot move to beam")
+
+        # here added the calculation for moving to the beam position
+        dx = (x - beam_pos_x) / pixels_per_mm_x
+        dy = (y - beam_pos_y) / pixels_per_mm_y
+
+        diffr.wait_status_ready(5)
+        motors_dict = self.get_positions()
+        for key, val in motors_dict.items():
+            motors_dict.update({key: self.centring_motors[key].direction * val})
+        omega_angle = math.radians(motors_dict.get("omega", 0))
+
+        rot_matrix = np.matrix(
+            [
+                [math.cos(omega_angle), -math.sin(omega_angle)],
+                [math.sin(omega_angle), math.cos(omega_angle)],
+            ]
+        )
+        inv_rot_matrix = np.array(rot_matrix.I)
+        dsampx, dsampy = np.dot(np.array([0, dy]), inv_rot_matrix)
+
+        chi_angle = math.radians(motors_dict.get("chi", 0))
+        chi_rot = np.matrix(
+            [
+                [math.cos(chi_angle), -math.sin(chi_angle)],
+                [math.sin(chi_angle), math.cos(chi_angle)],
+            ]
+        )
+
+        sx, sy = np.dot(np.array([dsampx, dsampy]), np.array(chi_rot))
+
+        sampx = -motors_dict.get("sampx") + sx
+        sampy = motors_dict.get("sampy") + sy
+        phiy = motors_dict.get("phiy") + dx
+
+        self.centring_motors.get("sampx").set_value(-sampx)
+        self.centring_motors.get("sampy").set_value(sampy)
+        self.centring_motors.get("phiy").set_value(-phiy)
+        HWR.beamline.diffractometer.save_centring_positions()
+
+    def get_snapshot(
+        self,
+        overlay: str | None = None,
+        bw: bool = False,
+        return_as_array: bool = False,
+    ) -> BytesIO:
+        """Get snapshot(s)
+
+        Args:
+            overlay: Image data with shapes and other items to display
+                          on the snapshot
+            bw: return grayscale image
+            return_as_array: return as np array if True, Default False
 
         Returns:
             (BytesIO) snapshot as bytes image
@@ -124,27 +392,58 @@ class SampleView(AbstractSampleView):
 
         return buffered
 
-    def save_snapshot(self, path, overlay=None, bw=False):
+    def take_acq_snapshot(self, image_path_list: list):
+        """Take snapshot in the acquisition sequence.
+        Args:
+           image_path_list: List of file name(s) to save the snapshot(s}
+                            (full path).
         """
-        Save a snapshot to file.
+        if len(image_path_list) > 0:
+            diffr = HWR.beamline.diffractometer
+            phase = diffr.get_phase_enum.CENTRE
+            if diffr.get_phase() != phase:
+                use_custom_snapshot_routine = (
+                    self.get_property("custom_snapshot_script_dir") or False
+                )
+
+                if not use_custom_snapshot_routine:
+                    diffr.set_phase(phase)
+
+        for image_path in image_path_list:
+            snapshot_index = image_path_list.index(image_path)
+            msg = f"Taking {snapshot_index + 1} sample snapshot(s)"
+            self.log.info(msg)
+
+            self.save_snapshot(filename=image_path)
+            # do not move 90 degrees if not needed
+            if not diffr.in_plate_mode and snapshot_index < len(image_path_list) - 1:
+                diffr.omega.set_value_relative(90, timeout=200)
+
+    def save_snapshot(
+        self,
+        filename: str,
+        overlay: str | None = None,
+        bw: bool = False,
+    ):
+        """Save a snapshot to file.
 
         Args:
-            path (str): The filename.
-            overlay(str): Image data with shapes and other items to display on the snapshot
-            bw(bool): return grayscale image
+            filename: The filename.
+            overlay: Image data with shapes and other items to display
+                      on the snapshot
+            bw): return grayscale image if true. Default False
         """
         img = self.take_snapshot(overlay_data=overlay, bw=bw)
-        img.save(path)
+        img.save(filename)
 
-        self._last_oav_image = path
+        self._last_oav_image = filename
 
-    def take_snapshot(self, overlay_data=None, bw=False):
-        """
-        Get snapshot with overlaid data.
+    def take_snapshot(self, overlay_data: str | None = None, bw: bool = False):
+        """Get snapshot with overlaid data.
 
         Args:
-            overlay_data (str): base64 encoded image to lay over camera image
-            bw (bool): return grayscale image
+            overlay_data: base64 encoded image to lay over camera image
+            bw: return grayscale image if True, Default False
 
         Returns:
             (Image) rgb or grayscale image
@@ -170,21 +469,19 @@ class SampleView(AbstractSampleView):
         return self._last_oav_image
 
     def add_shape(self, shape):
-        """
-        Add the shape <shape> to the dictionary of handled shapes.
+        """Add the shape <shape> to the dictionary of handled shapes.
 
         Args:
-            param (shape): Shape to add.
-            type (shape): Shape object.
+            shape: Shape to add.
         """
         self.shapes[shape.id] = shape
         shape.shapes_hw_object = self
 
     def add_shape_from_mpos(
         self,
-        mpos_list,
-        screen_coord,
-        t,
+        mpos_list: list[float],
+        screen_coord: tuple[int, int],
+        t: str,
         state: ShapeState = "SAVED",
         user_state: ShapeState = "SAVED",
     ):
@@ -193,9 +490,9 @@ class SampleView(AbstractSampleView):
         screen position screen_coord.
 
         Args:
-            mpos_list (list[mpos_list]): List of motor positions
-            screen_coord (tuple(x, y): Screen coordinate for shape
-            t (str): Type str for shape, P (Point), L (Line), G (Grid)
+            mpos_list: List of motor positions
+            screen_coord: Screen coordinate for shape (x, y)
+            t: Type str for shape, P (Point), L (Line), G (Grid)
 
         Returns:
             (Shape) Shape of type <t>
@@ -304,7 +601,7 @@ class SampleView(AbstractSampleView):
 
     def select_shape_with_cpos(self, cpos):
         """
-        Selects shape with the assocaitaed centered position <cpos>
+        Selects shape with the assocaitaed centred position <cpos>
 
         Args:
             cpos (CenteredPosition)
@@ -320,21 +617,19 @@ class SampleView(AbstractSampleView):
         Line.SHAPE_COUNT = 0
         Point.SHAPE_COUNT = 0
 
-    def get_shapes(self):
-        """
-        Get all Shapes.
+    def get_shapes(self) -> list:
+        """Get all Shapes.
 
         Returns:
             (list[Shape]) All the shapes
         """
         return self.shapes.values()
 
-    def get_points(self):
-        """
-        Get all Points currently handled.
+    def get_points(self) -> list:
+        """Get all Points currently handled.
 
         Returns:
-            (list[Point]) All points currently handled
+            List[Point] - All currently handled points.
         """
         current_points = []
 
@@ -344,12 +639,11 @@ class SampleView(AbstractSampleView):
 
         return current_points
 
-    def get_lines(self):
-        """
-        Get all Lines currently handled.
+    def get_lines(self) -> list:
+        """Get all Lines currently handled.
 
         Returns:
-            (list[Line]) All lines currently handled
+            List[Line] - All currently handled lines.
         """
         lines = []
 
@@ -359,12 +653,11 @@ class SampleView(AbstractSampleView):
 
         return lines
 
-    def get_grids(self):
-        """
-        Get all Grids currently handled.
+    def get_grids(self) -> list:
+        """Get all Grids currently handled.
 
         Returns:
-            (list[Grid]) All lines currently handled
+            List[Grid] - All currently handled grids,
         """
         grid = []
 
@@ -374,12 +667,11 @@ class SampleView(AbstractSampleView):
 
         return grid
 
-    def get_shape(self, sid):
-        """
-        Get Shape with id <sid>.
+    def get_shape(self, sid: str):
+        """Get Shape with id <sid>.
 
         Args:
-            sid (str): id of Shape to retrieve
+            sid: id of Shape to retrieve
 
         Returns:
             (Shape) All the shapes
@@ -405,18 +697,18 @@ class SampleView(AbstractSampleView):
 
         return grid
 
-    def set_grid_data(self, sid, result_data, data_file_path):
+    def set_grid_data(self, sid: str, result_data, data_file_path: str):
         """
         Sets grid rsult data for a shape with the specified id.
 
         Args:
-            sid (str): The id of the shape to set grid data for.
-            result_data: The result data to set for the shape. Either a base64 encoded string for PNG/image
-            or a dictionary for RGB (keys are cell number and value RGBa list). Data is only updated if result is RGB based
-            data_file_path (str): The path to the data file associated with the result data.
-
-        Returns:
-            None
+            sid: The id of the shape to set grid data for.
+            result_data: The result data to set for the shape.
+                         Either a base64 encoded string for PNG/image or a
+                         dictionary for RGB (keys are cell number and value
+                         RGBa list). Data is only updated if result is RGB based
+            data_file_path: The path to the data file associated with the
+                            result data.
 
         Raises:
             AttributeError: If no shape with the specified id exists.
@@ -425,7 +717,7 @@ class SampleView(AbstractSampleView):
         shape = self.get_shape(sid)
 
         if shape:
-            if shape.result and type(shape.result) == dict:
+            if shape.result and isinstance(shape.result, dict):
                 # append data
                 shape.result.update(result_data)
             else:
@@ -434,7 +726,7 @@ class SampleView(AbstractSampleView):
 
             self.emit("newGridResult", shape)
         else:
-            msg = "Cant set result for %s, no shape with id %s" % (sid, sid)
+            msg = f"Cant set result, no shape with id {sid}"
             raise AttributeError(msg)
 
     def get_grid_data(self, key):
@@ -454,31 +746,68 @@ class SampleView(AbstractSampleView):
         Args:
             cpos (CenteredPosition): CenteredPosition of shape
         """
-        pass
+
+    def set_rotation_axis_position(self, value: float):
+        """Set the reference position for the rotation axis.
+
+        value: the position
+        """
+        motor = self.rotation_reference.get("motor")
+        if motor:
+            self.log.info(f"Setting rotation axis ({motor.name}) position to {value}")
+            self.centring_motors[motor.name].reference_position = value
+            script_name = self.rotation_reference["script"]
+            try:
+                self.log.info("Setting MD Alignment reference position")
+                HWR.beamline.diffractometer.run_script(f"{script_name}, {value}")
+            except:
+                self.log.exception("Setting Alignment reference position failed")
+                raise
+
+    def _set_rotation_axis_position(self, value: float, motor_name="phiz"):
+        if motor_name == "phiz":
+            self.centringPhiz = sample_centring.CentringMotor(
+                self.phizMotor, reference_position=value
+            )
+        elif motor_name == "phiy":
+            self.centringPhiy = sample_centring.CentringMotor(
+                self.phiyMotor, reference_position=value
+            )
+
+        script_name = (
+            "Change_AlignmentZ" if motor_name == "phiz" else "Change_AlignmentY"
+        )
+
+        try:
+            self.log.info("Setting MD Alignment reference position")
+            self.run_script(f"{script_name}, {value}")
+        except:
+            self.log.exception("Setting MD Alignment reference position failed")
+            raise
 
 
-class Shape(object):
+class Shape:
     """
     Base class for shapes.
     """
 
     SHAPE_COUNT = 0
 
-    def __init__(self, mpos_list=[], screen_coord=(-1, -1)):
-        object.__init__(self)
+    def __init__(self, mpos_list=None, screen_coord=(-1, -1)):
         Shape.SHAPE_COUNT += 1
         self.t = "S"
         self.id = ""
         self.cp_list = []
         self.name = ""
         self.state: ShapeState = "SAVED"
-        self.user_state: ShapeState = "SAVED"  # used to persist user preferences in regards whether to show or hide particular shape.
+        # used to persist user preferences to show or hide particular shape.
+        self.user_state: ShapeState = "SAVED"
         self.label = ""
         self.screen_coord = screen_coord
         self.selected = False
         self.refs = []
         self.shapes_hw_object = None
-
+        mpos_list = mpos_list or []
         self.add_cp_from_mp(mpos_list)
 
     def get_centred_positions(self):
@@ -502,18 +831,18 @@ class Shape(object):
 
     def update_position(self, transform):
         spos_list = [transform(cp.as_dict()) for cp in self.cp_list]
-        spos_list = tuple([pos for l in spos_list for pos in l])
+        spos_list = tuple([pos for x in spos_list for pos in x])
         self.screen_coord = spos_list
 
     def add_cp_from_mp(self, mpos_list):
         for mp in mpos_list:
-            self.cp_list.append(queue_model_objects.CentredPosition(mp))
+            self.cp_list.append(qmo.CentredPosition(mp))
 
     def set_id(self, id_num):
-        self.id = self.t + "%s" % id_num
-        self.name = self.label + "-%s" % id_num
+        self.id = f"{self.t}{id_num}"
+        self.name = f"{self.label}-{id_num}"
 
-    def move_to_mpos(self, mpos_list, screen_coord=[]):
+    def move_to_mpos(self, mpos_list, screen_coord=None):
         self.cp_list = []
         self.add_cp_from_mp(mpos_list)
 
@@ -521,7 +850,7 @@ class Shape(object):
             self.screen_coord = screen_coord
 
     def update_from_dict(self, shape_dict):
-        # We don't allow id or result updates
+        # We do not allow id or result updates
         shape_dict.pop("id", None)
         shape_dict.pop("result", None)
 
@@ -530,10 +859,7 @@ class Shape(object):
                 setattr(self, key, value)
 
     def as_dict(self):
-        cpos_list = []
-
-        for cpos in self.cp_list:
-            cpos_list.append(cpos.as_dict())
+        cpos_list = [x.as_dict() for x in self.cp_list]
 
         d = copy.deepcopy(vars(self))
 
@@ -585,7 +911,7 @@ class Line(Shape):
     SHAPE_COUNT = 0
 
     def __init__(self, mpos_list, screen_coord):
-        Shape.__init__(self, mpos_list, screen_coord)
+        super().__init__(mpos_list, screen_coord)
         Line.SHAPE_COUNT += 1
         self.t = "L"
         self.label = "Line"
@@ -595,19 +921,17 @@ class Line(Shape):
         Shape.set_id(self, id_num)
         self.cp_list[0].index = self.name
 
-    def get_centred_positions(self):
-        return [self.start_cpos, self.end_cpos]
-
     def get_points_index(self):
         if all(self.cp_list):
             return (self.cp_list[0].get_index(), self.cp_list[1].get_index())
+        return (None, None)
 
 
 class Grid(Shape):
     SHAPE_COUNT = 0
 
     def __init__(self, mpos_list, screen_coord):
-        Shape.__init__(self, mpos_list, screen_coord)
+        super().__init__(mpos_list, screen_coord)
         Grid.SHAPE_COUNT += 1
         self.t = "G"
         self.set_id(Grid.SHAPE_COUNT)
@@ -645,7 +969,7 @@ class Grid(Shape):
         if min(_d, 360 - _d) > self.shapes_hw_object.hide_grid_threshold:
             self.state = "HIDDEN"
         else:
-            super(Grid, self).update_position(transform)
+            super().update_position(transform)
             self.state = "SAVED"
 
     def get_centred_position(self):
@@ -660,10 +984,9 @@ class Grid(Shape):
     def get_num_lines(self):
         if self.cell_count_fun == "zig-zag":
             return self.num_rows
-        elif self.cell_count_fun == "inverse-zig-zag":
+        if self.cell_count_fun == "inverse-zig-zag":
             return self.num_cols
-        else:
-            return self.num_rows
+        return self.num_rows
 
     def set_id(self, id_num):
         Shape.set_id(self, id_num)
@@ -675,7 +998,8 @@ class Grid(Shape):
     def get_result(self):
         return self.result
 
-    def as_dict(self):
+    def as_dict(self) -> dict:
+        """Convert a shape to a dictionary."""
         d = Shape.as_dict(self)
         # replace cpos_list with the motor positions
         d["motor_positions"] = self.cp_list[0].as_dict()

--- a/mxcubecore/HardwareObjects/SampleView.py
+++ b/mxcubecore/HardwareObjects/SampleView.py
@@ -209,7 +209,7 @@ class SampleView(AbstractSampleView):
                 ]
             )
             inv_rot_matrix = np.array(rot_matrix.I)
-            dx, dy = np.dot(np.array([sampx, sampy]), inv_rot_matrix) * p_x
+            _, dy = np.dot(np.array([sampx, sampy]), inv_rot_matrix) * p_x
 
             chi_angle = math.radians(positions_dict.get("chi", 0))
             chi_rot = np.matrix(
@@ -873,7 +873,7 @@ class Shape:
 
     def update_position(self, transform):
         spos_list = [transform(cp.as_dict()) for cp in self.cp_list]
-        spos_list = tuple([pos for x in spos_list for pos in x])
+        spos_list = tuple(pos for x in spos_list for pos in x)
         self.screen_coord = spos_list
 
     def add_cp_from_mp(self, mpos_list):

--- a/mxcubecore/HardwareObjects/SampleView.py
+++ b/mxcubecore/HardwareObjects/SampleView.py
@@ -134,7 +134,52 @@ class SampleView(AbstractSampleView):
         return motors_dict
 
     def get_centred_point_from_coord(self, x, y, return_by_names=None):
-        return self.get_positions()
+        """Get the motor positions form x,y pixel coordinates"""
+
+        beam_pos_x, beam_pos_y = HWR.beamline.beam.get_beam_position_on_screen()
+        diffr = HWR.beamline.diffractometer
+        pixels_per_mm_x, pixels_per_mm_y = diffr.get_pixels_per_mm()
+        if not all([pixels_per_mm_x, pixels_per_mm_y]):
+            return 0, 0
+
+        # distance from the point to the beam
+        dx = (x - beam_pos_x) / pixels_per_mm_x
+        dy = (y - beam_pos_y) / pixels_per_mm_y
+
+        motors_dict = self.get_positions()
+        for key, val in motors_dict.items():
+            motors_dict.update({key: self.centring_motors[key].direction * val})
+
+        omega_angle = math.radians(motors_dict.get("omega", 0))
+        rot_matrix = np.matrix(
+            [
+                [math.cos(omega_angle), -math.sin(omega_angle)],
+                [math.sin(omega_angle), math.cos(omega_angle)],
+            ]
+        )
+        inv_rot_matrix = np.array(rot_matrix.I)
+        dsampx, dsampy = np.dot(np.array([0, dy]), inv_rot_matrix)
+
+        chi_angle = math.radians(motors_dict.get("chi", 0))
+        chi_rot = np.matrix(
+            [
+                [math.cos(chi_angle), -math.sin(chi_angle)],
+                [math.sin(chi_angle), math.cos(chi_angle)],
+            ]
+        )
+        sx, sy = np.dot(np.array([dsampx, dsampy]), np.array(chi_rot))
+
+        sampx = -motors_dict.get("sampx") + sx
+        sampy = motors_dict.get("sampy") + sy
+        phiy = motors_dict.get("phiy") + dx
+
+        return {
+            "omega": motors_dict.get("omega"),
+            "phiy": float(-phiy),
+            "phiz": motors_dict.get("phiz"),
+            "sampx": float(-sampx),
+            "sampy": float(sampy),
+        }
 
     def motor_positions_to_screen(
         self, positions_dict: dict[str, float]
@@ -237,6 +282,23 @@ class SampleView(AbstractSampleView):
                 self.centring_failed()
 
             self.centring_done()
+
+    def auto_centring_done(self, auto_centring_procedure):
+        try:
+            res = auto_centring_procedure.get()
+        except Exception:
+            logging.exception("Could not complete automatic centring")
+            logging.getLogger("user_level_log").info("Automatic loop centring failed")
+            self.centring_failed()
+        else:
+            if res is None:
+                logging.error("Could not complete automatic centring")
+                logging.getLogger("user_level_log").info(
+                    "Automatic loop centring failed"
+                )
+                self.centring_failed()
+            else:
+                self.centring_done()
 
     def centring_done(self):
         """Execute if centring accepted."""
@@ -363,7 +425,7 @@ class SampleView(AbstractSampleView):
         self.centring_motors.get("sampx").set_value(-sampx)
         self.centring_motors.get("sampy").set_value(sampy)
         self.centring_motors.get("phiy").set_value(-phiy)
-        HWR.beamline.diffractometer.save_centring_positions()
+        diffr.save_centring_positions()
 
     def get_snapshot(
         self,

--- a/mxcubecore/HardwareObjects/SampleView.py
+++ b/mxcubecore/HardwareObjects/SampleView.py
@@ -118,7 +118,7 @@ class SampleView(AbstractSampleView):
 
     def _update_shape_positions(self, *args, **kwargs):
         for shape in self.get_shapes():
-            shape.update_position(self.motor_positions_to_screen)
+            shape.update_position(self.motor_positions_to_screen())
 
         self.emit("shapesChanged")
 
@@ -274,7 +274,6 @@ class SampleView(AbstractSampleView):
             logging.exception("Could not complete manual centring")
             self.centring_failed()
         else:
-            self.emit("centringMoving", ())
             try:
                 sample_centring.end()
             except Exception:
@@ -299,6 +298,7 @@ class SampleView(AbstractSampleView):
                 self.centring_failed()
             else:
                 self.centring_done()
+                self.accept_centring()
 
     def centring_done(self):
         """Execute if centring accepted."""
@@ -318,6 +318,7 @@ class SampleView(AbstractSampleView):
     def accept_centring(self):
         """Accept the current centred position."""
         self.centring_status["valid"] = True
+        self.centring_status["accepted"] = True
         self.emit("centringAccepted", (True, self.get_centring_status()))
         logging.getLogger("user_level_log").info("Centring successful")
 
@@ -1000,8 +1001,8 @@ class Grid(Shape):
         self.set_id(Grid.SHAPE_COUNT)
 
     def update_position(self, transform):
-        phi_pos = HWR.beamline.diffractometer.omega.get_value() % 360
-        _d = abs((self.get_centred_position().omega % 360) - phi_pos)
+        omega_pos = HWR.beamline.diffractometer.omega.get_value() % 360
+        _d = abs((self.get_centred_position().omega % 360) - omega_pos)
 
         if self.user_state == "HIDDEN":
             self.state = "HIDDEN"

--- a/mxcubecore/HardwareObjects/SampleView.py
+++ b/mxcubecore/HardwareObjects/SampleView.py
@@ -118,7 +118,7 @@ class SampleView(AbstractSampleView):
 
     def _update_shape_positions(self, *args, **kwargs):
         for shape in self.get_shapes():
-            shape.update_position(self.motor_positions_to_screen())
+            shape.update_position(self.motor_positions_to_screen)
 
         self.emit("shapesChanged")
 

--- a/mxcubecore/HardwareObjects/XMLRPCServer.py
+++ b/mxcubecore/HardwareObjects/XMLRPCServer.py
@@ -364,7 +364,7 @@ class XMLRPCServer(HardwareObject):
 
         """
         grid_dict = HWR.beamline.sample_view.get_shape(sid).as_dict()
-
+        grid_dict.update({"result": None})
         return grid_dict
 
     def shape_history_set_grid_data(self, key, result_data, data_file_path=None):

--- a/mxcubecore/HardwareObjects/XMLRPCServer.py
+++ b/mxcubecore/HardwareObjects/XMLRPCServer.py
@@ -699,3 +699,6 @@ class XMLRPCServer(HardwareObject):
         """
         actions = HWR.beamline.beamline_actions.get_object_by_role("controller")
         actions.centrebeam()
+
+    def get_current_cd_crystal_id(self):
+        return HWR.beamline.harvester.get_current_crystal_id()

--- a/mxcubecore/HardwareObjects/XMLRPCServer.py
+++ b/mxcubecore/HardwareObjects/XMLRPCServer.py
@@ -157,11 +157,6 @@ class XMLRPCServer(HardwareObject):
         self._server.register_function(self.get_image_num, "get_image_num")
         self._server.register_function(self.set_zoom_level)
         self._server.register_function(self.get_zoom_level)
-        self._server.register_function(self.get_available_zoom_levels)
-        self._server.register_function(self.set_front_light_level)
-        self._server.register_function(self.get_front_light_level)
-        self._server.register_function(self.set_back_light_level)
-        self._server.register_function(self.get_back_light_level)
         self._server.register_function(self.centre_beam)
 
         self._server.register_function(self.get_gphl_workflow_status)
@@ -171,6 +166,8 @@ class XMLRPCServer(HardwareObject):
         self._server.register_function(self.set_characterisation_result)
 
         self._server.register_function(self.set_rotation_axis_position)
+
+        self._server.register_function(self.get_current_cd_crystal_id)
 
         # Register functions from modules specified in <apis> element
         apis = self.get_property("apis", {})
@@ -435,10 +432,10 @@ class XMLRPCServer(HardwareObject):
         return HWR.beamline.resolution.get_limits()
 
     def get_diffractometer_positions(self):
-        return HWR.beamline.diffractometer.get_positions()
+        return HWR.beamline.sample_view.get_positions()
 
     def move_diffractometer(self, roles_positions_dict):
-        HWR.beamline.diffractometer.move_motors(roles_positions_dict)
+        HWR.beamline.diffractometer.set_value_motors(roles_positions_dict)
         return True
 
     def save_twelve_snapshots_script(self, path):
@@ -451,21 +448,21 @@ class XMLRPCServer(HardwareObject):
 
         try:
             for angle, path in path_list:
-                HWR.beamline.diffractometer.phiMotor.set_value(angle)
+                HWR.beamline.diffractometer.omega.set_value(angle)
                 # give some time to get the snapshot
                 time.sleep(1)
-                HWR.beamline.diffractometer.wait_ready()
+                HWR.beamline.diffractometer.wait_status_ready()
                 self.save_snapshot(path, show_scale, handle_light=False)
         except Exception as ex:
             self.log.exception("Could not take snapshot %s " % str(ex))
 
-    def save_snapshot(self, imgpath, showScale=False, handle_light=True):
+    def save_snapshot(self, imgpath, show_scale=False, handle_light=True):
         res = True
         self.log.info("Taking snapshot %s " % str(imgpath))
 
         try:
-            if showScale:
-                HWR.beamline.diffractometer.save_snapshot(imgpath)
+            if show_scale:
+                HWR.beamline.sample_view.save_snapshot(imgpath)
             else:
                 HWR.beamline.sample_view.save_snapshot(imgpath, overlay=False, bw=False)
         except Exception as ex:
@@ -481,11 +478,11 @@ class XMLRPCServer(HardwareObject):
         Saves the current position as a centered position.
         """
         self.log.debug("Saving position via XMLRPC")
-        HWR.beamline.diffractometer.save_current_position()
+        HWR.beamline.sample_view.accept_centring()
         return True
 
     def cryo_temperature(self):
-        return HWR.beamline.diffractometer.cryostream.get_value()
+        return HWR.beamline.cryo.get_value()
 
     def flux(self):
         flux = HWR.beamline.flux.get_value()
@@ -591,50 +588,14 @@ class XMLRPCServer(HardwareObject):
         """
         Sets the zoom to a pre-defined level.
         """
-        zoom = HWR.beamline.diffractometer.zoomMotor
+        zoom = HWR.beamline.diffractometer.zoom
         zoom.set_value(zoom.value_to_enum(pos))
 
     def get_zoom_level(self):
         """
         Returns the zoom level.
         """
-        zoom = HWR.beamline.diffractometer.zoomMotor
-        pos = zoom.get_value().value
-        return pos
-
-    def get_available_zoom_levels(self):
-        """
-        Returns the available pre-defined zoom levels.
-        """
-        _value_enum = HWR.beamline.diffractometer.zoomMotor.VALUES.items()
-        _names = [name for name, value in _value_enum.items()]
-
-        return _names
-
-    def set_front_light_level(self, level):
-        """
-        Sets the level of the front light
-        """
-        HWR.beamline.diffractometer.setFrontLightLevel(level)
-
-    def get_front_light_level(self):
-        """
-        Gets the level of the front light
-        """
-        return HWR.beamline.diffractometer.getFrontLightLevel()
-
-    def set_back_light_level(self, level):
-        """
-        Sets the level of the back light
-        """
-        self.log.info("Setting backlight level to %s" % level)
-        HWR.beamline.diffractometer.setBackLightLevel(level)
-
-    def get_back_light_level(self):
-        """
-        Gets the level of the back light
-        """
-        return HWR.beamline.diffractometer.getBackLightLevel()
+        return HWR.beamline.diffractometer.zoom.get_value().value
 
     def _register_module_functions(self, module_name, recurse=True, prefix=""):
         log = logging.getLogger("HWR")
@@ -730,7 +691,7 @@ class XMLRPCServer(HardwareObject):
         return self.gphl_workflow_status
 
     def set_rotation_axis_position(self, value: float):
-        HWR.beamline.diffractometer.set_rotation_axis_position(value)
+        HWR.beamline.sample_view.set_rotation_axis_position(value)
 
     def centre_beam(self):
         """

--- a/mxcubecore/HardwareObjects/abstract/AbstractDiffractometer.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractDiffractometer.py
@@ -1,0 +1,617 @@
+# encoding: utf-8
+#
+#  Project name: MXCuBE
+#  https://github.com/mxcube
+#
+#  This file is part of MXCuBE software.
+#
+#  MXCuBE is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  MXCuBE is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU General Lesser Public License
+#  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
+
+"""Abstract Diffractometer class.
+Initialises the username property and all the motors and nstate (discrete
+positions) equipment, which are part of the diffractometer.
+Certain number of roles are fixed and define a corresponding motor or nstate
+actuator object. This allows to use them in a standard way by the MXCuBE
+application (web or Qt).
+There is also a convention of the direction of the motors:
+  - x axis is parallel to the beam. Positive direction is from right to left.
+  - y axis is perpendicular to the beam, parallel to the ground. Positive
+      direction is from left to right when facing the beam.
+  - z axis is perpendicular to the floor. Positive direction is top down.
+
+Here follows the list of the fixed roles and the description of the
+corresponding objects, accessible via beamline.diffractometer hardware object.
+
+1. Motor objects (roles)  and their functionality:
+  omega - the rotation axis, independent of the orientation (up, down or side).
+          Pisitive direction is clockwise.
+  sampx - centring table x axis
+  sampy - centring table y axis
+  focus - alignment table x axis
+  phiy - alignment table y axis
+  phiz - alignment table z axis
+  sample_horizontal - x axis, combination of sampx and sampy. Equivalent to
+                      sampx at omega=0 and sampy for omega=90.
+  samle_vertical - y axis, combination of sampx and sampy. Equivalent to
+                   sampy at omega=0 and sampx for omega=90.
+  backlight - adjust the intensity of the back light
+  frontlight - adjust the intensity of the front light
+  kappa - the minikappa kappa axis
+  kappa_phi - the minikappa phi axis
+
+2. Discrete (N) state equipment and its functionality:
+zoom - zoom levels
+fshutter - fast (ms) shutter - allow beam on the sample
+beamstop - put in front of a detector to avoid the direct beam.
+capillary - if present, a tube to reduce the scattering background.
+backlightswitch - move the backlight on the level of the on-axis viewer
+frontlightswitch - switch on/off the front light
+fluo_detector - if present, actuator to move a fluorescence detector close to the sample
+"""
+
+import abc
+import json
+from enum import Enum, unique
+from typing import Dict, List, Optional, Tuple, Union
+from pathlib import Path
+from pydantic.v1 import BaseModel, Field, ValidationError
+
+from mxcubecore.BaseHardwareObjects import HardwareObject, HardwareObjectState
+from mxcubecore import HardwareRepository as HWR
+
+
+__copyright__ = """ Copyright © by the MXCuBE collaboration """
+__license__ = "LGPLv3+"
+
+
+@unique
+class DiffractometerHead(Enum):
+    """Enumeration diffractometer head types."""
+
+    UNKNOWN = "Unknown"
+    MINI_KAPPA = "MiniKappa"
+    SMART_MAGNET = "SmartMagnet"
+    PLATE = "Plate"
+    SSX = "SSX"
+    HARVESTER = "Harvester"
+
+
+@unique
+class DiffractometerPhase(Enum):
+    """Enumeration diffractometer phases."""
+
+    UNKNOWN = "Unknown"
+    CENTRE = "Centring"
+    COLLECT = "DataCollection"
+    SEE_BEAM = "BeamLocation"
+    TRANSFER = "Transfer"
+
+
+@unique
+class DiffractometerConstraint(Enum):
+    """Enumeration diffractometer constraint types."""
+
+    UNKNOWN = "Unknown"
+    RELEASE = "Normal"
+    INJECTOR = "Injector"
+    STILL = "LockRotation"
+
+
+class HolderTypeEnum(Enum):
+    """Enumeration of chip holder geometry."""
+
+    KNOWN_GEOMETRY = "known_geometry"
+    FREE_GEOMETRY = "free_geometry"
+
+
+class ChipShapeEnum(Enum):
+    """Enumeration of chip holder shape."""
+
+    RECTANGULAR = "RECTANGULAR"
+    ELLIPTICAL = "ELLIPTICAL"
+
+
+# Diffractometer pydantic models
+
+
+class CalibrationData(BaseModel):
+    """Chip calibration model."""
+
+    top_left: Tuple[float, float, float] = Field(
+        [0, 0, 0], description="Top left corner motor position"
+    )
+    top_right: Tuple[float, float, float] = Field(
+        [0, 0, 0], description="Top right corner motor position"
+    )
+    bottom_left: Tuple[float, float, float] = Field(
+        [0, 0, 0], description="Bottom left corner motor position"
+    )
+
+
+class SampleHolderSectionModel(BaseModel):
+    """Generic sample holder."""
+
+    calibration_data: Optional[CalibrationData]
+    section_offset: Tuple[int, int] = Field(
+        [0, 0], description="Block offset in grid layout system coordinates x, y"
+    )
+    block_size: Tuple[float, float] = Field(
+        [15, 15], description="Block size horizontal, vertical in mm"
+    )
+    block_spacing: Tuple[float, float] = Field(
+        [15, 15], description="Spacing between blocks horizontal, vertical in mm"
+    )
+    block_shape: ChipShapeEnum = ChipShapeEnum.RECTANGULAR
+    number_of_rows: int = Field(6, description="Numer of rows")
+    number_of_collumns: int = Field(6, description="Numer of collumns")
+    row_labels: List[str] = Field([], description="Row lables")
+    column_lables: List[str] = Field([], description="Collumn lables")
+    targets_per_block: Tuple[int, int] = Field(
+        [20, 20], description="Targets per block dim1 and dim2"
+    )
+
+
+class ChipLayout(BaseModel):
+    """Chip layout model."""
+
+    head_type: DiffractometerHead = DiffractometerHead.SSX
+    holder_type: HolderTypeEnum = HolderTypeEnum.KNOWN_GEOMETRY
+    holder_brand: str = Field("", description="Brand/make of sample holder")
+    holder_size: Tuple[float, float] = Field(
+        [0, 0], description="Size of sample holder in mm horizontal and vertical"
+    )
+    sections: List[SampleHolderSectionModel]
+    calibration_data: CalibrationData
+
+
+class GonioHeadConfiguration(BaseModel):
+    current: str = Field("", description="Selected chip layout")
+    available: Dict[str, ChipLayout]
+
+
+class AbstractDiffractometer(HardwareObject):
+    """Abstract Diffractometer.
+
+    Attributes:
+        motors_hwobj_dict (dict): Motor hardware objects.
+        nstate_equipment_hwobj_dict (dict): N state hardware objects.
+        username (str): User name
+        head_type (DiffractometerHead Enum): Current head type
+        current_phase (DiffractometerPhase Enum): Current phase
+        current_constraint (DiffractometerConstraint Enum): Current constraint.
+        timeout (float): Default action timeout [s]
+
+    Emits:
+        valueChanged: ("valueChanged", (value,))
+        phaseChanged: ("phaseChanged", (state))
+
+    States:
+        HardwareObjectStates: READY, BUSY, FAULT
+    """
+
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, name):
+        super().__init__(name)
+        self.motors_hwobj_dict = {}
+        self.nstate_equipment_hwobj_dict = {}
+        self.username = name
+        self.current_phase = None
+        self.head_type = None
+        self.current_constraint = None
+        self.timeout = 3  # default timeout 3 s
+        self.chip_definition_file = ""
+
+    def init(self):
+        """Initialise username property.
+        Initialise the equipment, defined in the configuration file
+        """
+        self.username = self.get_property("username") or self.username
+
+        # motors
+        for role in self.config.motors:
+            try:
+                _hobj = self.get_object_by_role(role)
+                self.motors_hwobj_dict[role] = _hobj
+                setattr(self, role, _hobj)
+                self.connect(_hobj, "valueChanged", _hobj.update_value)
+            except KeyError:
+                self.log.warning("Diffractometer: No motors configured")
+
+        # nstate (discrete positions) equipment
+        for role in self.config.nstate_equipment:
+            try:
+                _hobj = self.get_object_by_role(role)
+                self.nstate_equipment_hwobj_dict[role] = _hobj
+                setattr(self, role, _hobj)
+                self.connect(_hobj, "valueChanged", _hobj.update_value)
+            except KeyError:
+                self.log.warning("No nstate (discrete positions) equipment configured")
+
+        # chip definition
+        _fp = self.get_property("chip_definition_file", "")
+        self.chip_definition_file = HWR.get_hardware_repository().find_in_repository(
+            _fp
+        )
+
+    def get_motors(self) -> dict:
+        """Get the dictionary of all configured motors or the ones to use.
+
+        Returns:
+            Dictionary {role: hardware_object}
+        """
+        return self.motors_hwobj_dict.copy()
+
+    def get_nstate_equipment(self) -> dict:
+        """Get the dictionary of all the nstate (discrete positions) equipment.
+
+        Returns:
+            Dictionary {role: hardware_object}
+        """
+        return self.nstate_equipment_hwobj_dict.copy()
+
+    # -------- Motor Groups --------
+
+    def set_value_motors(
+        self,
+        motors_positions_dict: dict,
+        simultaneous: bool = True,
+        timeout: float | None = None,
+    ):
+        """Move specified motors to the requested positions
+
+        Args:
+            motors_positions_dict: Dictionary {motor_role: target_value}.
+            simultaneous: Move the motors simultaneousl (True - default) or not.
+            timeout: timeout [s],
+                     if timeout = 0: return at once and do not wait,
+                     if timeout is None: wait forever (default).
+
+        Raises:
+            TimeoutError: Timeout
+            KeyError: The name does not correspond to an existing motor
+        """
+
+        # use only the available motors
+        mot_hwobj_dict = self.get_motors()
+
+        tout = timeout
+        if simultaneous:
+            tout = 0
+
+        self.update_state(HardwareObjectState.BUSY)
+        for key, val in motors_positions_dict.items():
+            try:
+                mot_hwobj_dict[key].set_value(val, timeout=tout)
+            except KeyError as err:
+                msg = f"Invalid motor name {key}"
+                raise RuntimeError(msg) from err
+
+        # wait for the end of move of all the motors, if needed
+        if simultaneous:
+            for key in motors_positions_dict:
+                mot_hwobj_dict[key].wait_ready(timeout)
+        self.update_state()
+
+    def get_value_motors(self, motors_list: list | None = None) -> dict:
+        """Get the positions of diffractometer motors. If the motors_list is
+            empty, return the positions of all the available motors.
+
+        Args:
+            List of motor roles.
+
+        Returns:
+            Dictionary {motor_role: position}
+        """
+        mot_pos_dict = {}
+
+        # use only the available motors
+        mot_hwobj_dict = self.get_motors()
+
+        if not motors_list:
+            for role, motor in mot_hwobj_dict.items():
+                try:
+                    mot_pos_dict[role] = float(motor.get_value())
+                except TypeError:
+                    msg = f"No value for {role}"
+                    self.log.warning(msg)
+            return mot_pos_dict
+
+        for motor in motors_list:
+            try:
+                mot_pos_dict[str(motor)] = float(mot_hwobj_dict[motor].get_value())
+            except KeyError:
+                msg = f"Invalid motor name {motor}"
+                self.log.exceptionb(msg)
+            except TypeError:
+                msg = f"No value for {motor}"
+                self.log.warning(msg)
+        return mot_pos_dict
+
+    def get_state_motors(self, motors_list: list | None = None) -> dict:
+        """Get the state of diffractometer motors. If the motors_list is
+            empty, return the state of all the available motors.
+
+        Args:
+             List of motor roles.
+
+        Returns:
+            Dictionary {motor_role: state}
+        """
+        mot_state_dict = {}
+
+        # use only the available motors
+        mot_hwobj_dict = self.get_motors()
+
+        motors_list = motors_list or mot_hwobj_dict.keys()
+
+        if not motors_list:
+            for role, motor in mot_hwobj_dict.items():
+                try:
+                    mot_state_dict[role] = float(motor.get_state())
+                except TypeError:
+                    msg = f"No value for {role}"
+                    self.log.warning(msg)
+            return mot_state_dict
+
+        for motor in motors_list:
+            try:
+                mot_state_dict[str(motor)] = float(mot_hwobj_dict[motor].get_state())
+            except KeyError:
+                msg = f"Invalid motor name {motor}"
+                self.log.exception(msg)
+            except TypeError:
+                msg = f"No value for {motor}"
+                self.log.warning(msg)
+        return mot_state_dict
+
+    # -------- Head Type and Modes --------
+
+    @property
+    def get_head_type(self) -> DiffractometerHead:
+        """Get the head type
+        Returns:
+            DiffractometerHead member.
+        """
+        return self.head_type
+
+    @property
+    def in_plate_mode(self) -> bool:
+        """Check if the head is a plate."""
+
+        return self.get_head_type == DiffractometerHead.PLATE
+
+    @property
+    def in_kappa_mode(self) -> bool:
+        """Check if the head is MiniKappa."""
+
+        return self.get_head_type == DiffractometerHead.MINI_KAPPA
+
+    @property
+    def in_chip_mode(self) -> bool:
+        """Check if there is chip configuration of the head."""
+        return (
+            self.get_head_type == DiffractometerHead.SSX
+            and self.current_constraint == DiffractometerConstraint.STILL
+        )
+
+    @property
+    def in_injector_mode(self) -> bool:
+        """Check if there is injector on the head."""
+        return (
+            self.get_head_type == DiffractometerHead.SSX
+            and self.current_constraint == DiffractometerConstraint.INJECTOR
+        )
+
+    @property
+    def get_head_enum(self) -> DiffractometerHead:
+        """Get the diffractometer head Enum. Used when no import possible."""
+        return DiffractometerHead
+
+    def get_chip_configuration(self) -> Union[GonioHeadConfiguration, None]:
+        """Get the chip configuration."""
+
+        data = None
+
+        if Path(self.chip_definition_file).is_file():
+            with Path(self.chip_definition_file).open("r") as _f:
+                chip_def = json.load(_f)
+                try:
+                    data = GonioHeadConfiguration(**chip_def)
+                except ValidationError:
+                    msg = f"Validation error in {self.chip_definition_file}"
+                    self.log.exception(msg)
+        return data
+
+    def set_head_configuration(self, str_data: str) -> None:
+        """Write the chip configuration in the chip configuration json file.
+        Args:
+            String containing the configuration.
+        """
+        data = json.loads(str_data)
+
+        if Path(self.chip_definition_file).is_file():
+            with Path(self.chip_definition_file).open("w+") as _f:
+                try:
+                    GonioHeadConfiguration(**data)
+                except ValidationError:
+                    msg = f"Validation error in {self.chip_definition_file}"
+                    self.log.exception(msg)
+                else:
+                    _f.write(json.dumps(data, indent=4))
+
+    def set_chip_layout(self, layout_name: str) -> bool:
+        """Choose the chip configuration layout.
+        Args:
+            The layout name.
+        """
+        data = self.get_head_configuration().dict()
+        data["current"] = layout_name
+        self.set_head_configuration(json.dumps(data))
+        return True
+
+    # -------- Phases --------
+
+    def set_phase(self, value: DiffractometerPhase | str, timeout: float | None = None):
+        """Sets diffractometer to selected phase.
+
+        Args:
+            value: DiffractometerPhase or string value
+            timeout: timeout [s],
+                     If timeout = 0: return at once and do not wait;
+                     if timeout is None: wait forever (default).
+        """
+        if not isinstance(value, DiffractometerPhase):
+            value = self.value_to_enum(value, DiffractometerPhase)
+        if value != DiffractometerPhase.UNKNOWN:
+            self.update_state(HardwareObjectState.BUSY)
+            self._set_phase(value)
+            if timeout == 0:
+                return
+            self.wait_ready(timeout)
+
+    def _set_phase(self, value: DiffractometerPhase):
+        """Specific implementation to set the diffractometer to selected phase
+
+        Args:
+            value: requested phase.
+        """
+
+    def get_phase(self) -> DiffractometerPhase:
+        """Get the current phase."""
+        return self.current_phase
+
+    def get_phase_list(self) -> list:
+        """Return a list of all the defined phases."""
+        phase_list = []
+        for member in DiffractometerPhase:
+            _nam = member.name
+            if _nam not in ["IN", "OUT", "UNKNOWN"]:
+                phase_list.append(_nam)
+        return phase_list
+
+    @property
+    def get_phase_enum(self) -> DiffractometerPhase:
+        """Get the phase Enum. Used when no import possible."""
+        return DiffractometerPhase
+
+    def update_phase(self, value: DiffractometerPhase | None = None):
+        """Update the phase value, Emit phaseChanged signal.
+
+        Args:
+            value: DiffractometerPhase member. Optional.
+        """
+        if value is None:
+            value = self.get_phase()
+        if not isinstance(value, DiffractometerPhase):
+            value = DiffractometerPhase(value)
+        if self.current_phase != value:
+            self.current_phase = value
+            self.emit("phaseChanged", (value.name,))
+
+    # -------- Constraints --------
+
+    def set_constraint(
+        self, value: DiffractometerConstraint, timeout: float | None = None
+    ):
+        """Sets diffractometer to selected constraint.
+
+        Args:
+            value: DiffractometerConstraint member.
+            timeout: optional - timeout [s],
+                     if timeout = 0: return at once and do not wait,
+                     if timeout is None: wait forever (default).
+        """
+        if isinstance(value, DiffractometerConstraint):
+            constraint = value
+        else:
+            constraint = self.value_to_enum(value, DiffractometerConstraint)
+
+        self._set_constraint(constraint)
+        self._update_value(constraint, value_cmp=self.get_constraint())
+        if timeout == 0:
+            return
+        self.wait_ready(timeout)
+
+    def _set_constraint(self, value: DiffractometerConstraint):
+        """Specific implementation to set the diffractometer to selected
+        constraint.
+        """
+
+    def get_constraint(self):
+        """Get the current constraint
+        Returns:
+            (Enum): DiffractometerConstraint member.
+        """
+        return self.current_constraint
+
+    @property
+    def get_constraint_enum(self) -> DiffractometerConstraint:
+        """Get the constraints Enum. Used when no import possible."""
+        return DiffractometerConstraint
+
+    # -------- data acquisition scans --------
+    def do_oscillation_scan(self, *args, **kwargs):
+        """Do an oscillation scan."""
+        raise NotImplementedError
+
+    def do_line_scan(self, *args, **kwargs):
+        """Do a line (helical) scan."""
+        raise NotImplementedError
+
+    def do_mesh_scan(self, *args, **kwargs):
+        """Do a mesh scan."""
+        raise NotImplementedError
+
+    def do_still_scan(self, *args, **kwargs):
+        """Do a zero oscillation acquisition."""
+        raise NotImplementedError
+
+    def do_characterisation_scan(self, *args, **kwargs):
+        """Do characterisation."""
+        raise NotImplementedError
+
+    def _update_value(self, value=None, value_cmp=None):
+        """Check if the value has changed. Emits signal valueChanged.
+
+        Args:
+            value: value of any type
+            value_cmp: Value to compare with.
+        """
+        curr_value = None
+        if value_cmp and value is None:
+            curr_value = value_cmp
+
+        if value != curr_value:
+            self.emit("valueChanged", (value,))
+
+    # -------- auxilarly methods --------
+
+    def value_to_enum(self, value, which_enum):
+        """Tranform a value to Enum
+
+        Args:
+           value(str, int, float, tuple, list): value
+           which_enum (Enum): The enum to be checked.
+
+        Returns:
+            (Enum): Enum member, corresponding to the value or UNKNOWN.
+        """
+        try:
+            return which_enum[value]
+        except ValueError:
+            for evar in which_enum:
+                if isinstance(evar.value, (tuple, list)) and (value in evar.value):
+                    return evar
+        return which_enum.UNKNOWN

--- a/mxcubecore/HardwareObjects/abstract/AbstractDiffractometer.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractDiffractometer.py
@@ -415,8 +415,8 @@ class AbstractDiffractometer(HardwareObject):
         )
 
     @property
-    def get_head_enum(self) -> DiffractometerHead:
-        """Get the diffractometer head Enum. Used when no import possible."""
+    def get_head_enum(self):
+        """Get the diffractometer head Enum. Used when no import wished."""
         return DiffractometerHead
 
     def get_chip_configuration(self) -> Union[GonioHeadConfiguration, None]:
@@ -502,8 +502,8 @@ class AbstractDiffractometer(HardwareObject):
         return phase_list
 
     @property
-    def get_phase_enum(self) -> DiffractometerPhase:
-        """Get the phase Enum. Used when no import possible."""
+    def get_phase_enum(self):
+        """Get the phase Enum. Used when no import wished."""
         return DiffractometerPhase
 
     def update_phase(self, value: DiffractometerPhase | None = None):
@@ -557,8 +557,8 @@ class AbstractDiffractometer(HardwareObject):
         return self.current_constraint
 
     @property
-    def get_constraint_enum(self) -> DiffractometerConstraint:
-        """Get the constraints Enum. Used when no import possible."""
+    def get_constraint_enum(self):
+        """Get the constraints Enum. Used when no import wished."""
         return DiffractometerConstraint
 
     # -------- data acquisition scans --------

--- a/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
@@ -321,7 +321,7 @@ class AbstractMultiCollect(object):
 
         snapshot_directory = dc_params["fileinfo"]["archive_directory"]
 
-        if HWR.beamline.diffractometer.in_plate_mode():
+        if HWR.beamline.diffractometer.in_plate_mode:
             if self.number_of_snapshots > 0:
                 self.number_of_snapshots = 1
 
@@ -346,7 +346,7 @@ class AbstractMultiCollect(object):
                 snapshot_filename
             )
 
-        HWR.beamline.diffractometer.take_snapshot(image_path_list)
+        HWR.beamline.sample_view.take_acq_snapshot(image_path_list)
 
     @abc.abstractmethod
     def set_helical(self, helical_on):
@@ -485,6 +485,9 @@ class AbstractMultiCollect(object):
         logging.getLogger("user_level_log").info(
             "Creating directory for images and processing"
         )
+
+        self._bliss_data_collection_hook(data_collect_parameters)
+
         self.create_directories(
             file_parameters["directory"], file_parameters["process_directory"]
         )
@@ -535,7 +538,7 @@ class AbstractMultiCollect(object):
         centring_info = {}
         try:
             logging.getLogger("user_level_log").info("Getting centring status")
-            centring_status = self.diffractometer().get_centring_status()
+            centring_status = HWR.beamline.sample_view.get_centring_status()
         except Exception:
             logging.getLogger("HWR").exception("")
         else:
@@ -553,7 +556,7 @@ class AbstractMultiCollect(object):
                 continue
             motors_to_move_before_collect[motor] = pos
 
-        current_diffractometer_position = self.diffractometer().get_positions()
+        current_diffractometer_position = HWR.beamline.sample_view.get_positions()
 
         for motor in motors_to_move_before_collect:
             if motors_to_move_before_collect[motor] is not None:
@@ -582,7 +585,7 @@ class AbstractMultiCollect(object):
                 f"Taking sample ({self.number_of_snapshots}) snapshosts"
             )
             self.take_snapshots(data_collect_parameters)
-        centring_info = HWR.beamline.diffractometer.get_centring_status()
+        centring_info = HWR.beamline.sample_view.get_centring_status()
         # move *again* motors, since taking snapshots may change positions
         logging.getLogger("user_level_log").info(
             "Moving motors to centered position: %r", motors_to_move_before_collect
@@ -1056,7 +1059,7 @@ class AbstractMultiCollect(object):
             # possibly download diagnostics) so we cannot trigger the cleanup
             # (that will send an abort on the diffractometer) as soon as
             # the last frame is counted
-            self.diffractometer().wait_ready(1000)
+            self.diffractometer().wait_status_ready(1000)
 
         # data collection done
         self.data_collection_end_hook(data_collect_parameters)

--- a/mxcubecore/HardwareObjects/abstract/AbstractNState.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractNState.py
@@ -23,7 +23,7 @@ Implements validate_value, set/update limits.
 """
 
 import abc
-import ast
+from ast import literal_eval
 from enum import (
     Enum,
     unique,
@@ -86,17 +86,12 @@ class AbstractNState(AbstractActuator):
 
     def initialise_values(self):
         """Initialise the ValueEnum with the values from the config."""
-        try:
-            values = self.get_property("values", [])
-            if isinstance(values, str):
-                values = ast.literal_eval(values)
+        values = self.get_property("values", [])
+        if isinstance(values, str):
+            values = literal_eval(values)
             values_dict = dict(**{item.name: item.value for item in self.VALUES})
             values_dict.update(values)
             self.VALUES = Enum("ValueEnum", values_dict)
-        except (ValueError, TypeError):
-            self.log.exception(
-                "Error initialising values for %s", self.__class__.__name__
-            )
 
     def value_to_enum(self, value, idx=0):
         """Transform a value to Enum

--- a/mxcubecore/HardwareObjects/abstract/AbstractNState.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractNState.py
@@ -31,7 +31,7 @@ from enum import (
 
 from mxcubecore.HardwareObjects.abstract.AbstractActuator import AbstractActuator
 
-__copyright__ = """ Copyright © 2010-2022 by the MXCuBE collaboration """
+__copyright__ = """ Copyright © by the MXCuBE collaboration """
 __license__ = "LGPLv3+"
 
 

--- a/mxcubecore/HardwareObjects/abstract/AbstractSampleChanger.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractSampleChanger.py
@@ -901,14 +901,17 @@ class SampleChanger(Container, HardwareObject):
         self._trigger_loaded_sample_changed_event(None)
 
     def _set_loaded_sample(self, sample):
+        loaded_sample = self.get_loaded_sample()
+
         for s in self.get_sample_list():
             if s != sample:
                 s._set_loaded(False)
             else:
-                if self.get_loaded_sample() != s:
+                if loaded_sample != s:
                     s._set_loaded(True)
 
-        self._trigger_loaded_sample_changed_event(sample)
+        if sample != loaded_sample:
+            self._trigger_loaded_sample_changed_event(sample)
 
     def _set_selected_sample(self, sample):
         cur = self.get_selected_sample()

--- a/mxcubecore/HardwareObjects/abstract/AbstractSampleView.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractSampleView.py
@@ -25,6 +25,7 @@ __copyright__ = """2019 by the MXCuBE collaboration """
 __license__ = "LGPLv3+"
 
 import abc
+import logging
 from typing import (
     Literal,
     Union,
@@ -46,7 +47,8 @@ class AbstractSampleView(HardwareObject):
         self._zoom = None
         self._frontlight = None
         self._backlight = None
-        self._shapes = None
+        self._shapes = {}
+        self.current_centring_procedure = None
 
     @property
     def camera(self):
@@ -54,7 +56,10 @@ class AbstractSampleView(HardwareObject):
 
     @abc.abstractmethod
     def get_snapshot(
-        self, overlay: Union[bool, str] = True, bw=False, return_as_array=False
+        self,
+        overlay: bool | str = True,
+        bw: bool = False,
+        return_as_array: bool = False,
     ):
         """Get snappshot(s)
         Args:
@@ -64,7 +69,9 @@ class AbstractSampleView(HardwareObject):
         """
 
     @abc.abstractmethod
-    def save_snapshot(self, filename, overlay: Union[bool, str] = True, bw=False):
+    def save_snapshot(
+        self, filename, overlay: Union[bool, str] = True, bw: bool = False
+    ):
         """Save a snapshot to file.
         Args:
             filename (str): The filename.
@@ -112,38 +119,28 @@ class AbstractSampleView(HardwareObject):
         return self._backlight
 
     @abc.abstractmethod
-    def start_centring(self, tree_click=True):
-        """
-        Starts centring procedure
-        """
-        return
-
-    @abc.abstractmethod
-    def cancel_centring(self):
-        """
-        Cancels current centring procedure
-        """
-        return
+    def start_manual_centring(self, nb_click=3):
+        """Starts manual centring procedure"""
 
     @abc.abstractmethod
     def start_auto_centring(self):
-        """
-        Start automatic centring procedure
-        """
-        return
+        """Start automatic centring procedure"""
 
-    # Not sure these should be abstarct ?
-    # @abc.abstractmethod
-    # def create_line(self):
-    #     return
+    def move_to_beam(self, x: float, y: float):
+        """Move the sample to the x,y coordinates"""
 
-    # @abc.abstractmethod
-    # def create_auto_line(self):
-    #     return
-
-    # @abc.abstractmethod
-    # def create_grid(self, spacing):
-    #     return
+    def cancel_centring(self):
+        """Cancels current centring procedure"""
+        if self.current_centring_procedure:
+            try:
+                self.current_centring_procedure.kill(block=True)
+            except Exception:
+                logging.getLogger("HWR").exception(
+                    "Problem aborting the centring method"
+                )
+            self.current_centring_procedure = None
+            self.emit("centringFailed")
+            logging.getLogger("HWR").exception("Centring canceled")
 
     @abc.abstractmethod
     def add_shape(self, shape):
@@ -238,7 +235,7 @@ class AbstractSampleView(HardwareObject):
         return
 
     @abc.abstractmethod
-    def get_shape(self, sid):
+    def get_shape(self, sid: str):
         """
         Get Shape with id <sid>.
 
@@ -291,4 +288,8 @@ class AbstractSampleView(HardwareObject):
         Args:
             cpos (CentredPosition): CentredPosition of shape
         """
-        return
+
+    def motor_positions_to_screen(self, positions_dict: dict) -> tuple:
+        """Get the motor positions according to the calibration"""
+
+        return ()

--- a/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
@@ -71,6 +71,12 @@ class DiffractometerMockup(AbstractDiffractometer):
     def abort(self):
         self.update_state(HardwareObjectState.READY)
 
+    def wait_status_ready(self, timeout=None):
+        return True
+
+    def save_centring_positions(self):
+        """This is a place holder, as needed for some of the diffractometers"""
+
     def do_oscillation_scan(self, *args, **kwargs):
         if self.in_kappa_mode:
             self.update_state(HardwareObjectState.BUSY)
@@ -110,8 +116,8 @@ class DiffractometerMockup(AbstractDiffractometer):
 
     def _set_phase(self, value: DiffractometerPhase):
         """Set a phase."""
-        print(f"Change phase to ---> {value}")
         self.current_phase = value
+        self.update_state(self.STATES.READY)
 
     def _set_constraint(self, value):
         self.current_constraint = value

--- a/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
@@ -1,5 +1,5 @@
 #
-#  Project name: MXCuBE
+#  Project: MXCuBE
 #  https://github.com/mxcube
 #
 #  This file is part of MXCuBE software.
@@ -16,409 +16,102 @@
 #
 #   You should have received a copy of the GNU Lesser General Public License
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
+"""
+Example xml file:
 
-import logging
+.. code-block:: xml
+
+ <object class = "DiffractometerMockup">
+  <username>MD2S</username>
+  <motors>
+    <device role="omega" hwrid="/diff-omega-mockup"/>
+    <device role="phiy" hwrid="/diff-phiy-mockup"/>
+    <device role="phiz" hwrid="/diff-phiz-mockup"/>
+    <device role="phiz" hwrid="/diff-phiz-mockup"/>
+    <device role="sampx" hwrid="/diff-sampx-mockup"/>
+    <device role="sampy" hwrid="/diff-sampy-mockup"/>
+    <device role="kappa" hwrid="/diff-kappa-mockup"/>
+    <device role="kappa_phi" hwrid="/diff-kappaphi-mockup"/>
+  </motors>
+  <nstate_equipment>
+    <object role="fshutter" href="/fast-shutter-mockup"/>
+    <object role="beamstop" href="/beamstop-mockup"/>
+  </nstate_equipment>
+ </object>
+"""
+
 import random
 import time
-import warnings
+from warnings import warn
 
-from gevent.event import AsyncResult
-
-from mxcubecore import HardwareRepository as HWR
-from mxcubecore.HardwareObjects.GenericDiffractometer import (
-    GenericDiffractometer,
-    PhaseEnum,
+from mxcubecore.BaseHardwareObjects import HardwareObjectState
+from mxcubecore.HardwareObjects.abstract.AbstractDiffractometer import (
+    AbstractDiffractometer,
+    DiffractometerConstraint,
+    DiffractometerHead,
+    DiffractometerPhase,
 )
 
 
-class DiffractometerMockup(GenericDiffractometer):
+class DiffractometerMockup(AbstractDiffractometer):
     """
     Descript. :
     """
 
-    def __init__(self, name):
-        """
-        Descript. :
-        """
-        GenericDiffractometer.__init__(self, name)
-
-        # child object slots
-        self.backlight = None
-        self.backlightswitch = None
-        self.beamstop_distance = None
-        self.focus = None
-        self.frontlight = None
-        self.frontlightswitch = None
-        self.phi = None
-        self.phiy = None
-        self.phiz = None
-        self.sampx = None
-        self.sampy = None
-
     def init(self):
+        super().init()
+        self.head_type = DiffractometerHead.MINI_KAPPA
+        self.current_phase = DiffractometerPhase.CENTRE
+        self.current_constraint = DiffractometerConstraint.RELEASE
+        self.update_state(HardwareObjectState.READY)
+        for mot in self.motors_hwobj_dict.values():
+            mot.set_value(random.uniform(0.0, 8.8))
+        self.omega.set_value(random.uniform(0, 359.9))
+
+    def abort(self):
+        self.update_state(HardwareObjectState.READY)
+
+    def do_oscillation_scan(self, *args, **kwargs):
+        if self.in_kappa_mode:
+            self.update_state(HardwareObjectState.BUSY)
+            time.sleep(random.uniform(0, 2.2))
+        self.update_state(HardwareObjectState.READY)
+
+    def get_pixels_per_mm(self):
+        """Get the pixel/mm values.
+        Returns:
+            (tuple): x,y [pixel/mm]
         """
-        Descript. :
-        """
-        # self.image_width = 100
-        # self.image_height = 100
+        # calibration values
+        x_calib = 0.000444
+        y_calib = 0.000446
+        return 1.0 / x_calib, 1.0 / y_calib
 
-        GenericDiffractometer.init(self)
-        self.x_calib = 0.000444
-        self.y_calib = 0.000446
-        self.last_centred_position = [318, 238]
-
-        self.pixels_per_mm_x = 1.0 / self.x_calib
-        self.pixels_per_mm_y = 1.0 / self.y_calib
-        self.beam_position = [318, 238]
-
-        self.current_phase = GenericDiffractometer.PHASE_CENTRING
-
-        self.cancel_centring_methods = {}
-        self.current_motor_positions = {
-            "phiy": 1.0,
-            "sampx": 0.0,
-            "sampy": -1.0,
-            "zoom": 8.53,
-            "focus": -0.42,
-            "phiz": 1.1,
-            "phi": 311.1,
-            "kappa": 11,
-            "kappa_phi": 22.0,
-        }
-        self.move_motors(self._get_random_centring_position())
-
-        self.current_state_dict = {}
-        self.centring_status = {"valid": False}
-        self.centring_time = 0
-
-        # self.image_width = 400
-        # self.image_height = 400
-
-        self.mount_mode = self.get_property("sample_mount_mode")
-        if self.mount_mode is None:
-            self.mount_mode = "manual"
-
-        self.equipment_ready()
-
-        self.connect(self.motor_hwobj_dict["phi"], "valueChanged", self.phi_motor_moved)
-        self.connect(
-            self.motor_hwobj_dict["phiy"], "valueChanged", self.phiy_motor_moved
+    def move_motors(self, motors_positions_dict):
+        warn(
+            "move_motors is deprecated, please use set_value_motors instead",
+            DeprecationWarning,
         )
-        self.connect(
-            self.motor_hwobj_dict["phiz"], "valueChanged", self.phiz_motor_moved
+        self.set_value_motors(motors_positions_dict)
+
+    def get_positions(self):
+        warn(
+            "get_positions is deprecated, please use get_value_motors instead",
+            DeprecationWarning,
         )
-        self.connect(
-            self.motor_hwobj_dict["kappa"], "valueChanged", self.kappa_motor_moved
+        return self.get_value_motors()
+
+    def get_current_phase(self):
+        warn(
+            "get_current_phase is deprecated, please use get get_phase instead",
+            DeprecationWarning,
         )
-        self.connect(
-            self.motor_hwobj_dict["kappa_phi"],
-            "valueChanged",
-            self.kappa_phi_motor_moved,
-        )
-        self.connect(
-            self.motor_hwobj_dict["sampx"], "valueChanged", self.sampx_motor_moved
-        )
-        self.connect(
-            self.motor_hwobj_dict["sampy"], "valueChanged", self.sampy_motor_moved
-        )
+        return self.get_phase().name
 
-    def execute_server_task(self, method, timeout=30, *args):
-        return
+    def _set_phase(self, value: DiffractometerPhase):
+        """Set a phase."""
+        print(f"Change phase to ---> {value}")
+        self.current_phase = value
 
-    def in_plate_mode(self):
-        return self.mount_mode == "plate"
-
-    def use_sample_changer(self):
-        return self.mount_mode == "sample_changer"
-
-    def is_reversing_rotation(self):
-        return True
-
-    def get_grid_direction(self):
-        """
-        Descript. :
-        """
-        return self.grid_direction
-
-    def manual_centring(self):
-        """
-        Descript. :
-        """
-        for click in range(3):
-            self.user_clicked_event = AsyncResult()
-            self.waiting_for_click = True
-            x, y = self.user_clicked_event.get()
-            if click < 2:
-                self.motor_hwobj_dict["phi"].set_value_relative(90)
-        self.last_centred_position[0] = x
-        self.last_centred_position[1] = y
-        centred_pos_dir = self._get_random_centring_position()
-        return centred_pos_dir
-
-    def automatic_centring(self):
-        """Automatic centring procedure"""
-        centred_pos_dir = self._get_random_centring_position()
-        self.emit("newAutomaticCentringPoint", centred_pos_dir)
-        return centred_pos_dir
-
-    def _get_random_centring_position(self):
-        """Get random centring result for current positions"""
-
-        # Names of motors to vary during centring
-        vary_actuator_names = ("sampx", "sampy", "phiy")
-
-        # Range of random variation
-        var_range = 0.08
-
-        # absolute value limit for varied motors
-        var_limit = 2.0
-
-        result = self.current_motor_positions.copy()
-        for tag in vary_actuator_names:
-            val = result.get(tag)
-            if val is not None:
-                random_num = random.random()
-                var = (random_num - 0.5) * var_range
-                val += var
-                if abs(val) > var_limit:
-                    val *= 1 - var_range / var_limit
-                result[tag] = val
-        return result
-
-    def is_ready(self) -> bool:
-        """
-        Descript. :
-        """
-        return True
-
-    def is_valid(self):
-        """
-        Descript. :
-        """
-        return True
-
-    def invalidate_centring(self):
-        """
-        Descript. :
-        """
-        if self.current_centring_procedure is None and self.centring_status["valid"]:
-            self.centring_status = {"valid": False}
-            # self.emitProgressMessage("")
-            self.emit("centringInvalid", ())
-
-    def get_centred_point_from_coord(self, x, y, return_by_names=None):
-        """
-        Descript. :
-        """
-        centred_pos_dir = self._get_random_centring_position()
-        return centred_pos_dir
-
-    def get_calibration_data(self, offset):
-        """
-        Descript. :
-        """
-        # return (1.0 / self.x_calib, 1.0 / self.y_calib)
-        return (1.0 / self.x_calib, 1.0 / self.y_calib)
-
-    def refresh_omega_reference_position(self):
-        """
-        Descript. :
-        """
-        return
-
-    # def get_omega_axis_position(self):
-    #     """
-    #     Descript. :
-    #     """
-    #     return self.current_positions_dict.get("phi")
-
-    def beam_position_changed(self, value):
-        """
-        Descript. :
-        """
-        self.beam_position = value
-
-    def get_current_centring_method(self):
-        """
-        Descript. :
-        """
-        return self.current_centring_method
-
-    def motor_positions_to_screen(self, centred_positions_dict):
-        """
-        Descript. :
-        """
-        return self.last_centred_position[0], self.last_centred_position[1]
-
-    def moveToCentredPosition(self, centred_position, wait=False):
-        """
-        Descript. :
-        """
-        try:
-            return self.move_to_centred_position(centred_position)
-        except Exception:
-            logging.exception("Could not move to centred position")
-
-    def phi_motor_moved(self, pos):
-        """
-        Descript. :
-        """
-        self.current_motor_positions["phi"] = pos
-        self.emit("phiMotorMoved", pos)
-
-    def phiy_motor_moved(self, pos):
-        self.current_motor_positions["phiy"] = pos
-
-    def phiz_motor_moved(self, pos):
-        self.current_motor_positions["phiz"] = pos
-
-    def sampx_motor_moved(self, pos):
-        self.current_motor_positions["sampx"] = pos
-
-    def sampy_motor_moved(self, pos):
-        self.current_motor_positions["sampy"] = pos
-
-    def kappa_motor_moved(self, pos):
-        """
-        Descript. :
-        """
-        self.current_motor_positions["kappa"] = pos
-        if time.time() - self.centring_time > 1.0:
-            self.invalidate_centring()
-        self.emit_diffractometer_moved()
-        self.emit("kappaMotorMoved", pos)
-
-    def kappa_phi_motor_moved(self, pos):
-        """
-        Descript. :
-        """
-        self.current_motor_positions["kappa_phi"] = pos
-        if time.time() - self.centring_time > 1.0:
-            self.invalidate_centring()
-        self.emit_diffractometer_moved()
-        self.emit("kappaPhiMotorMoved", pos)
-
-    def refresh_video(self):
-        """
-        Descript. :
-        """
-        self.emit("minidiffStateChanged", "testState")
-        if HWR.beamline.beam:
-            HWR.beamline.beam.beam_pos_hor_changed(300)
-            HWR.beamline.beam.beam_pos_ver_changed(200)
-
-    def start_auto_focus(self):
-        """
-        Descript. :
-        """
-        return
-
-    def move_to_beam(self, x, y, omega=None):
-        """
-        Descript. : function to create a centring point based on all motors
-                    positions.
-        """
-
-        print(
-            (
-                "moving to beam position: %d %d"
-                % (self.beam_position[0], self.beam_position[1])
-            )
-        )
-
-    def move_to_coord(self, x, y, omega=None):
-        """
-        Descript. : function to create a centring point based on all motors
-                    positions.
-        """
-        warnings.warn(
-            "Deprecated method, call move_to_beam instead", DeprecationWarning
-        )
-        return self.move_to_beam(x, y, omega)
-
-    def start_move_to_beam(self, coord_x=None, coord_y=None, omega=None):
-        """
-        Descript. :
-        """
-        self.last_centred_position[0] = coord_x
-        self.last_centred_position[1] = coord_y
-        self.centring_time = time.time()
-        curr_time = time.strftime("%Y-%m-%d %H:%M:%S")
-        self.centring_status = {
-            "valid": True,
-            "startTime": curr_time,
-            "endTime": curr_time,
-        }
-        motors = self.get_positions()
-        # motors["beam_x"] = 0.1
-        # motors["beam_y"] = 0.1
-        self.last_centred_position[0] = coord_x
-        self.last_centred_position[1] = coord_y
-        self.centring_status["motors"] = motors
-        self.centring_status["valid"] = True
-        self.centring_status["angleLimit"] = False
-        self.emit_progress_message("")
-        self.accept_centring()
-        self.current_centring_method = None
-        self.current_centring_procedure = None
-
-    def re_emit_values(self):
-        self.emit("zoomMotorPredefinedPositionChanged", None, None)
-        omega_ref = [0, 238]
-        self.emit("omegaReferenceChanged", omega_ref)
-
-    def move_kappa_and_phi(self, kappa, kappa_phi):
-        return
-
-    def get_osc_max_speed(self):
-        return 66
-
-    def get_osc_limits(self):
-        if self.in_plate_mode:
-            return (170, 190)
-        else:
-            return (-360, 360)
-
-    def get_scan_limits(self, speed=None, num_images=None, exp_time=None):
-        if self.in_plate_mode:
-            return (170, 190)
-        else:
-            return (-360, 360)
-
-    def get_osc_dynamic_limits(self):
-        """Returns dynamic limits of oscillation axis"""
-        return (0, 20)
-
-    def get_scan_dynamic_limits(self, speed=None):
-        return (-360, 360)
-
-    def move_omega_relative(self, relative_angle):
-        self.motor_hwobj_dict["phi"].set_value_relative(relative_angle, 5)
-
-    def set_phase(self, phase, timeout=None):
-        self.current_phase = str(phase)
-        self.emit("minidiffPhaseChanged", (self.current_phase,))
-
-    def get_point_from_line(self, point_one, point_two, index, images_num):
-        return point_one.as_dict()
-
-    def abort(self) -> None:
-        return None
-
-    def status(self) -> str:
-        return "READY"
-
-    def my_fancy_function(
-        self, speed: float, num_images: int, exp_time: float, phase: PhaseEnum
-    ) -> bool:
-        return True
-
-    def my_other_funny_function(self) -> None:
-        pass
-
-    def ssx_chip_scan(self, parameters):
-        return
-
-    def move_chip_to(self, x: int, y: int) -> None:
-        print("moving chip to")
-        return
+    def _set_constraint(self, value):
+        self.current_constraint = value

--- a/mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/ISPyBClientMockup.py
@@ -32,10 +32,9 @@ class ISPyBClientMockup(ProposalTypeISPyBLims):
         self.loginType = LOGIN_TYPE_FALLBACK
 
     def init(self):
-        try:
-            self.base_result_url = self.get_property("base_result_url").strip()
-        except AttributeError:
-            self.log.exception("")
+        base_result_url = self.get_property("base_result_url")
+        if isinstance(base_result_url, str):
+            self.base_result_url = base_result_url.strip()
 
         self.__test_proposal = {
             "status": {"code": "ok"},

--- a/mxcubecore/HardwareObjects/sample_centring.py
+++ b/mxcubecore/HardwareObjects/sample_centring.py
@@ -406,7 +406,6 @@ def _retry_on_ex(fun, N, *args, **kwargs):
                 raise RuntimeError(msg) from e
 
         time.sleep(1)
-    return
 
 
 def move_motors(motor_positions_dict):

--- a/mxcubecore/HardwareObjects/sample_centring.py
+++ b/mxcubecore/HardwareObjects/sample_centring.py
@@ -94,13 +94,13 @@ def prepare(centring_motors_dict):
         m.motor: m.motor.get_value() for m in centring_motors_dict.values()
     }
 
-    phi = centring_motors_dict["phi"]
+    omega = centring_motors_dict["omega"]
     phiy = centring_motors_dict["phiy"]
     sampx = centring_motors_dict["sampx"]
     sampy = centring_motors_dict["sampy"]
     phiz = centring_motors_dict["phiz"]
 
-    return phi, phiy, phiz, sampx, sampy
+    return omega, phiy, phiz, sampx, sampy
 
 
 def start(
@@ -114,11 +114,11 @@ def start(
 ):
     global CURRENT_CENTRING
 
-    phi, phiy, phiz, sampx, sampy = prepare(centring_motors_dict)
+    omega, phiy, phiz, sampx, sampy = prepare(centring_motors_dict)
 
     CURRENT_CENTRING = gevent.spawn(
         center,
-        phi,
+        omega,
         phiy,
         phiz,
         sampx,
@@ -142,20 +142,20 @@ def start_plate(
     plate_vertical,
     chi_angle=0,
     n_points=3,
-    phi_range=10,
+    omega_range=10,
     lim_pos=314.0,
 ):
     global CURRENT_CENTRING
 
     plateTranslation = centring_motors_dict["plateTranslation"]
     centring_motors_dict.pop("plateTranslation")
-    phi, phiy, phiz, sampx, sampy = prepare(centring_motors_dict)
+    omega, phiy, phiz, sampx, sampy = prepare(centring_motors_dict)
 
-    phi.set_value(lim_pos)
+    omega.set_value(lim_pos)
 
     CURRENT_CENTRING = gevent.spawn(
         centre_plate,
-        phi,
+        omega,
         phiy,
         phiz,
         sampx,
@@ -168,7 +168,7 @@ def start_plate(
         plate_vertical,
         chi_angle,
         n_points,
-        phi_range,
+        omega_range,
     )
     return CURRENT_CENTRING
 
@@ -180,8 +180,8 @@ def start_plate_1_click(
     beam_xc,
     beam_yc,
     plate_vertical,
-    phi_min,
-    phi_max,
+    omega_min,
+    omega_max,
     n_points=10,
 ):
     global CURRENT_CENTRING
@@ -189,20 +189,17 @@ def start_plate_1_click(
     # plateTranslation = centring_motors_dict["plateTranslation"]
     # centring_motors_dict.pop("plateTranslation")
 
-    # phi, phiy,phiz, sampx, sampy = prepare(centring_motors_dict)
-
-    phi = centring_motors_dict["phi"]
+    omega = centring_motors_dict["omega"]
     phiy = centring_motors_dict["phiy"]
     sampx = centring_motors_dict["sampx"]
     sampy = centring_motors_dict["sampy"]
     phiz = centring_motors_dict["phiz"]
 
-    # phi.set_value(phi_min)
     plate_vertical()
 
     CURRENT_CENTRING = gevent.spawn(
         centre_plate1Click,
-        phi,
+        omega,
         phiy,
         phiz,
         sampx,
@@ -212,8 +209,8 @@ def start_plate_1_click(
         beam_xc,
         beam_yc,
         plate_vertical,
-        phi_min,
-        phi_max,
+        omega_min,
+        omega_max,
         n_points,
     )
 
@@ -221,7 +218,7 @@ def start_plate_1_click(
 
 
 def centre_plate1Click(
-    phi,
+    omega,
     phiy,
     phiz,
     sampx,
@@ -231,8 +228,8 @@ def centre_plate1Click(
     beam_xc,
     beam_yc,
     plate_vertical,
-    phi_min,
-    phi_max,
+    omega_min,
+    omega_max,
     n_points,
 ):
     global USER_CLICKED_EVENT
@@ -263,14 +260,14 @@ def centre_plate1Click(
             previous_click_x = x
             previous_click_y = y
 
-            # Alterning between phi min and phi max to gradually converge to the
+            # Alterning between phi min and omega max to gradually converge to the
             # centring point
             if i % 2 == 0:
-                phi_min = phi.get_value()  # in case the phi range sent us to a position where sample is invisible, if user moves phi, this modifications is saved for future moves
-                phi.set_value(phi_max)
+                omega_min = omega.get_value()  # in case the omega range sent us to a position where sample is invisible, if user moves omega, this modifications is saved for future moves
+                omega.set_value(omega_max)
             else:
-                phi_max = phi.get_value()  # in case the phi range sent us to a position where sample is invisible, if user moves phi, this modifications is saved for future moves
-                phi.set_value(phi_min)
+                omega_max = omega.get_value()  # in case the omega range sent us to a position where sample is invisible, if user moves omega, this modifications is saved for future moves
+                omega.set_value(omega_min)
 
             READY_FOR_NEXT_POINT.set()
             i += 1
@@ -291,7 +288,7 @@ def centre_plate1Click(
 
 
 def centre_plate(
-    phi,
+    omega,
     phiy,
     phiz,
     sampx,
@@ -304,12 +301,12 @@ def centre_plate(
     plate_vertical,
     chi_angle,
     n_points,
-    phi_range=40,
+    omega_range=40,
 ):
     global USER_CLICKED_EVENT
-    X, Y, phi_positions = [], [], []
+    X, Y, omega_positions = [], [], []
 
-    phi_angle = phi_range / (n_points - 1)
+    omega_angle = omega_range / (n_points - 1)
 
     try:
         i = 0
@@ -321,9 +318,9 @@ def centre_plate(
             USER_CLICKED_EVENT = gevent.event.AsyncResult()
             X.append(x / float(pixelsPerMm_Hor))
             Y.append(y / float(pixelsPerMm_Ver))
-            phi_positions.append(phi.direction * math.radians(phi.get_value()))
+            omega_positions.append(omega.direction * math.radians(omega.get_value()))
             if i != n_points - 1:
-                phi.set_value_relative(phi.direction * phi_angle, timeout=None)
+                omega.set_value_relative(omega.direction * omega_angle, timeout=None)
             READY_FOR_NEXT_POINT.set()
             i += 1
     except Exception:
@@ -343,7 +340,7 @@ def centre_plate(
     z = Z[1]
     avg_pos = Z[0].mean()
 
-    r, a, offset = multiPointCentre(numpy.array(z).flatten(), phi_positions)
+    r, a, offset = multiPointCentre(numpy.array(z).flatten(), omega_positions)
     dy = r * numpy.sin(a)
     dx = r * numpy.cos(a)
 
@@ -387,7 +384,7 @@ def centre_plate(
 
 def ready(motor_list):
     logging.getLogger("HWR").info([m.actuator_name for m in motor_list])
-    rstate = [m._ready() for m in motor_list]
+    rstate = [m.is_ready() for m in motor_list]
     logging.getLogger("HWR").info(rstate)
     return all(rstate)
 
@@ -398,7 +395,25 @@ def wait_ready(motor_positions_dict, timeout=None):
             time.sleep(0.1)
 
 
+def _retry_on_ex(fun, N, *args, **kwargs):
+    """ """
+    for attempt in range(1, N + 1):
+        try:
+            return fun(*args, **kwargs)
+        except Exception as e:
+            if attempt == N:
+                msg = f"Tried cenring {N} times and failed"
+                raise RuntimeError(msg) from e
+
+        time.sleep(1)
+    return
+
+
 def move_motors(motor_positions_dict):
+    _retry_on_ex(_move_motors, 5, motor_positions_dict)
+
+
+def _move_motors(motor_positions_dict):
     if not motor_positions_dict:
         return
 
@@ -420,7 +435,7 @@ def user_click(x, y, wait=False):
 
 
 def center(
-    phi,
+    omega,
     phiy,
     phiz,
     sampx,
@@ -431,13 +446,12 @@ def center(
     beam_yc,
     chi_angle,
     n_points,
-    phi_range=180,
+    omega_range=180,
 ):
     global USER_CLICKED_EVENT
-    X, Y, phi_positions = [], [], []
+    X, Y, omega_positions = [], [], []
 
-    phi_angle = phi_range / (n_points - 1)
-
+    omega_angle = omega_range / (n_points - 1)
     try:
         i = 0
         while i < n_points:
@@ -452,9 +466,9 @@ def center(
             USER_CLICKED_EVENT = gevent.event.AsyncResult()
             X.append(x / float(pixelsPerMm_Hor))
             Y.append(y / float(pixelsPerMm_Ver))
-            phi_positions.append(phi.direction * math.radians(phi.get_value()))
+            omega_positions.append(omega.direction * math.radians(omega.get_value()))
             if i != n_points - 1:
-                phi.set_value_relative(phi.direction * phi_angle, timeout=10)
+                omega.set_value_relative(omega.direction * omega_angle, timeout=10)
             READY_FOR_NEXT_POINT.set()
             i += 1
         logging.getLogger("HWR").debug(f"Click at {x}, {y}")
@@ -476,7 +490,7 @@ def center(
     z = Z[1]
     avg_pos = Z[0].mean()
 
-    r, a, offset = multiPointCentre(numpy.array(z).flatten(), phi_positions)
+    r, a, offset = multiPointCentre(numpy.array(z).flatten(), omega_positions)
     dy = r * numpy.sin(a)
     dx = r * numpy.cos(a)
 
@@ -485,7 +499,7 @@ def center(
     d_horizontal = d[0] - (beam_xc / float(pixelsPerMm_Hor))
     d_vertical = d[1] - (beam_yc / float(pixelsPerMm_Ver))
 
-    phi_pos = math.radians(phi.direction * phi.get_value())
+    omega_pos = math.radians(omega.direction * omega.get_value())
 
     centred_pos = SAVED_INITIAL_POSITIONS.copy()
     centred_pos.update(
@@ -534,12 +548,12 @@ def start_auto(
 ):
     global CURRENT_CENTRING
 
-    phi, phiy, phiz, sampx, sampy = prepare(centring_motors_dict)
+    omega, phiy, phiz, sampx, sampy = prepare(centring_motors_dict)
 
     CURRENT_CENTRING = gevent.spawn(
         auto_center,
         sample_view,
-        phi,
+        omega,
         phiy,
         phiz,
         sampx,
@@ -590,7 +604,7 @@ def find_loop(sample_view, pixelsPerMm_Hor, chi_angle, msg_cb, new_point_cb):
 
 def auto_center(
     sample_view,
-    phi,
+    omega,
     phiy,
     phiz,
     sampx,
@@ -612,7 +626,7 @@ def auto_center(
     while -1 in find_loop(
         sample_view, pixelsPerMm_Hor, chi_angle, msg_cb, new_point_cb
     ):
-        phi.set_value_relative(90)
+        omega.set_value_relative(90)
         i += 1
         if i > 4:
             if callable(msg_cb):
@@ -625,7 +639,7 @@ def auto_center(
 
         centring_greenlet = gevent.spawn(
             center,
-            phi,
+            omega,
             phiy,
             phiz,
             sampx,
@@ -646,7 +660,7 @@ def auto_center(
             if x < 0 or y < 0:
                 for i in range(1, 18):
                     logging.getLogger("HWR").info("loop not found - moving back %d" % i)
-                    phi.set_value_relative(5)
+                    omega.set_value_relative(5)
                     x, y = find_loop(
                         sample_view,
                         pixelsPerMm_Hor,
@@ -675,7 +689,7 @@ def auto_center(
                         f"DEBUG: Incorrect position from auto loop centring {(x, y)}"
                     )
                     raise RuntimeError("Could not centre sample automatically.")
-                phi.set_value_relative(-i * 5)
+                omega.set_value_relative(-i * 5)
             else:
                 user_click(x, y, wait=True)
 

--- a/mxcubecore/HardwareObjects/sample_centring.py
+++ b/mxcubecore/HardwareObjects/sample_centring.py
@@ -397,7 +397,7 @@ def wait_ready(motor_positions_dict, timeout=None):
 
 def _retry_on_ex(fun, N, *args, **kwargs):
     """ """
-    for attempt in range(1, N + 1):
+    for attempt in range(1, N + 1):  # noqa: RET503
         try:
             return fun(*args, **kwargs)
         except Exception as e:

--- a/mxcubecore/configuration/mockup/backlightswitch.xml
+++ b/mxcubecore/configuration/mockup/backlightswitch.xml
@@ -1,0 +1,5 @@
+<object class="ExporterNStateMockup">
+  <username>backlightlight_switch</username>
+  <default_value>False</default_value>
+  <values>{"IN": True, "OUT": False}</values>
+</object>

--- a/mxcubecore/configuration/mockup/beamstop.xml
+++ b/mxcubecore/configuration/mockup/beamstop.xml
@@ -1,0 +1,5 @@
+<object class="ExporterNStateMockup">
+  <username>beamstop</username>
+  <values>{"IN": "BEAM", "OUT": "OFF"}</values>
+  <use_hwstate>True</use_hwstate>
+</object>

--- a/mxcubecore/configuration/mockup/diff-phix-mockup.xml
+++ b/mxcubecore/configuration/mockup/diff-phix-mockup.xml
@@ -1,0 +1,3 @@
+<object class="MotorMockup">
+  <actuator_name>PhiX</actuator_name>
+</object>

--- a/mxcubecore/configuration/mockup/diffractometer-mockup.xml
+++ b/mxcubecore/configuration/mockup/diffractometer-mockup.xml
@@ -1,23 +1,23 @@
 <object class="DiffractometerMockup">
-  <object href="/diff-omega-mockup" role="phi"/>
-  <object href="/diff-kappa-mockup" role="kappa"/>
-  <object href="/diff-kappaphi-mockup" role="kappa_phi"/>
-
-  <!-- Next block added by rhfogh for better representation of move_motor behaviour -->
-  <object href="/diff-phiz-mockup" role="phiz"/>
-  <object href="/diff-phiy-mockup" role="phiy"/>
-  <object href="/diff-sampx-mockup" role="sampx"/>
-  <object href="/diff-sampy-mockup" role="sampy"/>
-  <object href="/diff-aperture-mockup" role="aperture"/>
-  <centring_motors>("phi", "kappa", "kappa_phi", "phiz", "phiy", "sampx", "sampy")</centring_motors>
-
-  <zoom_centre>{"x":340,"y":250}</zoom_centre>
-  <omega_reference>{"actuator_name": "phiz", "position":-0.2224, "camera_axis":"x"}</omega_reference>
-
-  <!-- MD2 -->
-  <!-- <gridDirection>{"fast": (1, 0), "slow": (0, -1)}</gridDirection>  -->
-  <sample_mount_mode>sample_changer</sample_mount_mode>
-  <!-- MD3 -->
-  <grid_direction>{"fast": (0, 1), "slow": (1, 0), "omega_ref": 0}</grid_direction>
-  <exports>["abort", "status", "my_fancy_function", "my_other_funny_function"]</exports>
+  <username>Mock Diffractometer</username>
+  <motors>
+    <object href="/diff-omega-mockup" role="omega"/>
+    <object href="/diff-kappa-mockup" role="kappa"/>
+    <object href="/diff-kappaphi-mockup" role="kappa_phi"/>
+    <object href="/diff-phix-mockup" role="focus"/>
+    <object href="/diff-phiy-mockup" role="phiy"/>
+    <object href="/diff-phiz-mockup" role="phiz"/>
+    <object href="/diff-sampx-mockup" role="sampx"/>
+    <object href="/diff-sampy-mockup" role="sampy"/>
+    <object href="/udiff_backlight" role="backlight"/>
+    <object href="/udiff_frontlight" role="frontlight"/>
+  </motors>
+  <nstate_equipment>
+    <object href="/fast-shutter-mockup" role="fshutter"/>
+    <object href="/diff-aperture-mockup" role="aperture"/>
+    <object href="/beamstop" role="beamstop"/>
+    <object href="/backlightswitch" role="backlightswitch"/>
+    <object href="/frontlightswitch" role="frontlightswitch"/>
+    <object href="/diff-zoom" role="zoom"/>
+  </nstate_equipment>
 </object>

--- a/mxcubecore/configuration/mockup/frontlightswitch.xml
+++ b/mxcubecore/configuration/mockup/frontlightswitch.xml
@@ -1,0 +1,5 @@
+<object class="ExporterNStateMockup">
+  <username>frontlight_switch</username>
+  <default_value>False</default_value>
+  <values>{"IN": True, "OUT": False}</values>
+</object>

--- a/mxcubecore/configuration/mockup/sample-view-mockup.xml
+++ b/mxcubecore/configuration/mockup/sample-view-mockup.xml
@@ -1,0 +1,10 @@
+<object class="SampleView">
+  <!-- <object hwrid="/camera-mockup" role="camera"/>-->
+  <centring_motors>["omega", "phiy", "phiz", "sampx", "sampy"]</centring_motors>
+  <centring_reference_position>{"phiz": 0.099}</centring_reference_position>
+  <motor_directions>{"omega": -1, "phiy": -1}</motor_directions>
+  <rotation_reference>{"name": "phiz", "script": "Change_AlignmentZ"}</rotation_reference>
+
+  <!--- Automatically hide grid when 5 deg from defined angle -->
+  <hide_grid_threshold>5</hide_grid_threshold>
+</object>

--- a/mxcubecore/configuration/mockup/test/beamline.yaml
+++ b/mxcubecore/configuration/mockup/test/beamline.yaml
@@ -32,7 +32,6 @@ objects:
   - flux: flux-mockup.xml
   - detector: detector-mockup.xml
   - resolution: resolution-mockup.xml
-  # - hutch_interlock: door-interlock-mockup.xml
   - safety_shutter: safety-shutter-mockup.xml
   # - fast_shutter: shutter-mockup.xml
   - sample_changer: sample-changer-mockup.xml
@@ -41,21 +40,9 @@ objects:
   - diffractometer: diffractometer-mockup.xml
   - sample_view: sample-view-mockup.xml
   - lims: lims-client-mockup.xml
-  # - queue_manager: queue.xml
-  # - queue_model: queue-model.xml
   # Procedures:
-  # - collect: mxcollect.xml
   - xrf_spectrum: xrf-spectrum-mockup.xml
-  # - energy_scan: energyscan-mockup.xml
-  # - imaging: xray-imaging.xml # Only in EMBL as of 201907
-  # - gphl_workflow: gphl-workflow.xml
-  # - gphl_connection: gphl-setup.xml
-  # - centring: centring.xml
   # Analysis:
-  # - offline_processing: auto-processing-mockup.xml
-  # - online_processing: parallel-processing.xml
-  # - characterisation: data-analysis.xml
-  # - beam_realign: # Skipped - optional
   - procedure: procedure-mockup.yml
 
 # Non-object attributes:

--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -1775,9 +1775,12 @@ class AcquisitionParameters(object):
         return copy.deepcopy(self)
 
     def get_detector_mode_list(self):
-        return ast.literal_eval(
-            HWR.beamline.detector.get_property("roi_mode_list", "[]")
-        )
+        try:
+            return ast.literal_eval(
+                HWR.beamline.detector.get_property("roi_mode_list", "[]")
+            )
+        except AttributeError:
+            return []
 
 
 class XrayImagingParameters(object):

--- a/mxcubecore/queue_entry/base_queue_entry.py
+++ b/mxcubecore/queue_entry/base_queue_entry.py
@@ -707,7 +707,7 @@ class SampleQueueEntry(BaseQueueEntry):
 
         # Only execute samples with collections and when sample changer is used
         if len(self.get_data_model().get_children()) != 0 and sc_used:
-            if HWR.beamline.diffractometer.in_plate_mode():
+            if HWR.beamline.diffractometer.in_plate_mode:
                 return
             else:
                 mount_device = HWR.beamline.sample_changer
@@ -800,7 +800,7 @@ class SampleQueueEntry(BaseQueueEntry):
                         }
                     )
 
-        programs = HWR.beamline.collect.get_property("auto_processing")
+        programs = HWR.beamline.collect.get("auto_processing")
         if programs:
             try:
                 autoprocessing.start(programs, "end_multicollect", params)
@@ -857,29 +857,29 @@ def mount_sample(data_model, centring_done_cb, async_result):
         raise QueueSkipEntryException("Sample not loaded", "")
     else:
         HWR.beamline.sample_changer.trigger_progress_message("Sample loaded")
-        dm = HWR.beamline.diffractometer
+        sview = HWR.beamline.sample_view
         centring_method = HWR.beamline.queue_manager.centring_method
 
         if centring_method != CENTRING_METHOD.NONE:
             try:
-                dm.connect("centringAccepted", centring_done_cb)
+                sview.connect("centringAccepted", centring_done_cb)
 
                 if centring_method == CENTRING_METHOD.MANUAL:
                     log.warning(
                         "Manual centring used, waiting for" + " user to center sample"
                     )
-                    dm.start_centring_method(dm.MANUAL3CLICK_MODE)
+                    sview.start_manual_centring()
                 elif centring_method == CENTRING_METHOD.LOOP:
-                    dm.start_centring_method(dm.C3D_MODE)
+                    sview.start_auto_centring()
                     log.warning(
                         "Centring in progress. Please save"
                         + " the suggested centring or re-center"
                     )
                 elif centring_method == CENTRING_METHOD.FULLY_AUTOMATIC:
                     log.info("Centring sample, please wait.")
-                    dm.start_centring_method(dm.C3D_MODE)
+                    sview.start_auto_centring()
                 else:
-                    dm.start_centring_method(dm.MANUAL3CLICK_MODE)
+                    sview.start_manual_centring()
 
                 HWR.beamline.sample_changer.trigger_progress_message("Centring !")
                 centring_result = async_result.get()
@@ -902,7 +902,7 @@ def mount_sample(data_model, centring_done_cb, async_result):
             except Exception:
                 logging.getLogger("HWR").exception("")
             finally:
-                dm.disconnect("centringAccepted", centring_done_cb)
+                sview.disconnect("centringAccepted", centring_done_cb)
 
 
 class DelayQueueEntry(BaseQueueEntry):
@@ -924,7 +924,7 @@ def center_before_collect(view, dm, queue, sample_view):
 
     queue.pause(True)
     pos, shape = None, None
-
+    dm = dm or None
     if len(sample_view.get_selected_shapes()):
         shape = sample_view.get_selected_shapes()[0]
         pos = shape.mpos()
@@ -933,7 +933,7 @@ def center_before_collect(view, dm, queue, sample_view):
         log.info(msg)
 
         # Create a centred positions of the current position
-        pos = dm.get_positions()
+        pos = sample_view.get_positions()
         shape = sample_view.add_shape_from_mpos([pos], (0, 0), "P")
 
     view(1, "Centring completed")

--- a/mxcubecore/queue_entry/data_collection.py
+++ b/mxcubecore/queue_entry/data_collection.py
@@ -232,7 +232,7 @@ class DataCollectionQueueEntry(BaseQueueEntry):
                 if cpos != empty_cpos:
                     HWR.beamline.sample_view.select_shape_with_cpos(cpos)
                 else:
-                    pos_dict = HWR.beamline.diffractometer.get_positions()
+                    pos_dict = HWR.beamline.sample_view.get_positions()
                     cpos = queue_model_objects.CentredPosition(pos_dict)
                     snapshot = HWR.beamline.sample_view.get_snapshot()
                     acq_1.acquisition_parameters.centred_position = cpos

--- a/mxcubecore/queue_entry/sample_centring.py
+++ b/mxcubecore/queue_entry/sample_centring.py
@@ -71,9 +71,9 @@ class SampleCentringQueueEntry(BaseQueueEntry):
         if dd0:
             if (
                 not hasattr(HWR.beamline.diffractometer, "in_kappa_mode")
-                or HWR.beamline.diffractometer.in_kappa_mode()
+                or HWR.beamline.diffractometer.in_kappa_mode
             ):
-                HWR.beamline.diffractometer.move_motors(dd0)
+                HWR.beamline.diffractometer.set_value_motors(dd0)
 
         motor_positions = dict(
             tt0
@@ -81,7 +81,7 @@ class SampleCentringQueueEntry(BaseQueueEntry):
             if tt0[1] is not None
         )
         if motor_positions:
-            HWR.beamline.diffractometer.move_motors(motor_positions)
+            HWR.beamline.diffractometer.set_value_motors(motor_positions)
 
         log.warning("Please center a new or select an existing point and press resume.")
         self.get_queue_controller().pause(True)
@@ -99,7 +99,7 @@ class SampleCentringQueueEntry(BaseQueueEntry):
             log.info(msg)
 
             # Create a centred positions of the current position
-            pos_dict = HWR.beamline.diffractometer.get_positions()
+            pos_dict = HWR.beamline.sample_view.get_positions()
             cpos = queue_model_objects.CentredPosition(pos_dict)
 
         self._data_model.set_centring_result(cpos)
@@ -110,7 +110,7 @@ class SampleCentringQueueEntry(BaseQueueEntry):
         BaseQueueEntry.pre_execute(self)
 
     def post_execute(self):
-        # If centring is executed once then we don't have to execute it again
+        # If centring is executed once, don't do it again
         self.get_view().set_checkable(False)
         BaseQueueEntry.post_execute(self)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mxcubecore"
-version = "1.451.0"
+version = "2.0.0"
 license = "LGPL-3.0-or-later"
 description = "Core libraries for the MXCuBE application"
 authors = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -2409,6 +2409,13 @@ convention = "google"
     "TD005",
     "TRY002",
 ]
+"mxcubecore/HardwareObjects/MicroDiffractometer.py" = [
+    "FBT001",
+    "FBT002",
+    "N999",
+    "PERF203",
+    "PLR0913"
+]
 "mxcubecore/HardwareObjects/Microdiff.py" = [
     "ARG002",
     "BLE001",
@@ -3300,18 +3307,11 @@ convention = "google"
 ]
 "mxcubecore/HardwareObjects/SampleView.py" = [
     "ARG002",
-    "B006",
-    "B007",
-    "E501",
-    "E721",
-    "E741",
     "EM101",
+    "FBT001",
     "FBT002",
-    "PERF102",
     "PERF401",
-    "PIE790",
-    "RET503",
-    "RET505",
+    "TRY301",
 ]
 "mxcubecore/HardwareObjects/SardanaMotor.py" = [
     "BLE001",
@@ -3755,6 +3755,14 @@ convention = "google"
     "RET501",
     "RET504",
 ]
+"mxcubecore/HardwareObjects/abstract/AbstractDiffractometer.py" = [
+    "EM102",
+    "FBT001",
+    "FBT002",
+    "N999",
+    "PERF203",
+    "I001",
+]
 "mxcubecore/HardwareObjects/abstract/AbstractEnergy.py" = [
     "FIX002",
     "TD002",
@@ -3882,7 +3890,8 @@ convention = "google"
     "TRY400",
 ]
 "mxcubecore/HardwareObjects/abstract/AbstractSampleView.py" = [
-    "ERA001",
+    "ARG002",
+    "FBT001",
     "FBT002",
 ]
 "mxcubecore/HardwareObjects/abstract/AbstractSlits.py" = [

--- a/test/test_diffractometer.py
+++ b/test/test_diffractometer.py
@@ -1,0 +1,80 @@
+#  Project name: MXCuBE
+#  https://github.com/mxcube
+#
+#  This file is part of MXCuBE software.
+#
+#  MXCuBE is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  MXCuBE is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU General Lesser Public License
+#  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test suite for AbstractDiffractometer"""
+
+import pytest
+
+from test.TestHardwareObjectBase import TestHardwareObjectBase
+
+_copyright__ = """ Copyright © by the MXCuBE collaboration """
+__license__ = "LGPLv3+"
+
+
+@pytest.fixture
+def test_object(beamline):
+    """Use the diffractometer object from beamline"""
+    return beamline.diffractometer
+
+
+class TestDiffarctometer(TestHardwareObjectBase):
+    def test_diffractometer_atributes(self, test_object):
+        assert test_object is not None, (
+            "Diffractometer hardware objects is None (not initialized)"
+        )
+
+        # test if all the predefined motor roles are set
+        for role in ("omega", "focus", "phiy", "phiz", "sampx", "sampy"):
+            assert hasattr(test_object, role)
+
+        # test if all the predefined nstate roles are set
+        for role in (
+            "fshutter",
+            "beamstop",
+            "backlightswitch",
+            "frontlightswitch",
+            "aperture",
+            "zoom",
+        ):
+            assert hasattr(test_object, role)
+
+    def test_get_set_phase(self, test_object):
+        phase_enum = test_object.get_phase_enum
+        # in the mockup we set the initial phase to CENTRE
+        assert test_object.get_phase() == phase_enum.CENTRE
+        test_object.set_phase(phase_enum.COLLECT, timeout=0)
+        assert test_object.get_phase() == phase_enum.COLLECT
+
+    def test_get_phase_list(self, test_object):
+        phase_enum = test_object.get_phase_enum
+        # subtract one for the UNKNOWN
+        assert len(phase_enum) - 1 == len(test_object.get_phase_list())
+
+    def test_get_head_type(self, test_object):
+        head_enum = test_object.get_head_enum
+        # in the mockup we set the head to be minikappa
+        assert test_object.get_head_type == head_enum.MINI_KAPPA
+        assert test_object.in_kappa_mode
+        assert not test_object.in_plate_mode
+
+    def test_get_set_constraint(self, test_object):
+        constraint_enum = test_object.get_constraint_enum
+        # in the mockup we set the initial constraint RELEASE
+        assert test_object.get_constraint() == constraint_enum.RELEASE
+        test_object.set_constraint(constraint_enum.STILL)
+        assert test_object.get_constraint() == constraint_enum.STILL


### PR DESCRIPTION
This PR replaces #1386.
- Create AbstractDiffractometer class:
  -   inherits from HardwareObject and uses wait_ready, abort methods and the state handling.
  -  defines some methods, properties and the DiffractometerHead, DiffractometerPhase enums.
  -  defines some scan types
  -  in the init method defines standard access to different equipment (motors and nstate equipment).
- Change DiffarctometerMockup accordingly
- Implement MicroDiffractometer for the Arinax MD2S
- Refactor AbstractSampleView and SampleView to include the methods, previously attached to the diffractometer.

Dependant on [mxcubeweb/pull/2000](https://github.com/mxcube/mxcubeweb/pull/2000)
 