### PR TITLE
EpicsMotorDetachable

### DIFF
--- a/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSMotor.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSMotor.py
@@ -100,6 +100,30 @@ class EPICSMotor(EPICSActuator, AbstractMotor):
 
 
 class EPICSMotorDetachable(EPICSMotor):
+    """
+    Class that implements an interface of motor record IOC and accepts
+    a presence PV, that indicated if the motor is or is not present on the 
+    facility. If it is present, it actuates as an EpicsMotor, if it is not,
+    then the widget receives the state OFF and remains disabled. 
+
+    YAML Example
+    ------------
+
+    %YAML 1.2
+    ---
+    class: LNLS.EPICS.EPICSMotor.EPICSMotorDetachable
+    epics: 
+    "MOTOR_PV":
+        channels:
+        '':
+    'PRESENCE_PREFIX':
+        channels:
+        'presence':
+            suffix: "PRESENCE_SUFFIX"
+    configuration:
+    is_present_value: 0
+
+    """
     MOTOR_PRESENCE_RBV = "presence"
 
     def init(self):

--- a/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSMotor.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSMotor.py
@@ -135,6 +135,4 @@ class EPICSMotorDetachable(EPICSMotor):
         current_value = int(self.get_channel_value(self.MOTOR_PRESENCE_RBV))
         if current_value == value:
             self.update_state(self.STATES.OFF)
-        else:
-            self.update_state(self.STATES.READY)
         return super().get_value()

--- a/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSMotor.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSMotor.py
@@ -121,7 +121,7 @@ class EPICSMotorDetachable(EPICSMotor):
         'presence':
             suffix: "PRESENCE_SUFFIX"
     configuration:
-    is_present_value: 0
+    is_absent_value: 0
 
     """
 
@@ -132,7 +132,7 @@ class EPICSMotorDetachable(EPICSMotor):
         self.get_value()
 
     def get_value(self):
-        value = self.get_property("is_present_value")
+        value = self.get_property("is_absent_value")
         current_value = int(self.get_channel_value(self.MOTOR_PRESENCE_RBV))
         if current_value == value:
             self.update_state(self.STATES.OFF)

--- a/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSMotor.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSMotor.py
@@ -102,9 +102,9 @@ class EPICSMotor(EPICSActuator, AbstractMotor):
 class EPICSMotorDetachable(EPICSMotor):
     """
     Class that implements an interface of motor record IOC and accepts
-    a presence PV, that indicated if the motor is or is not present on the 
+    a presence PV, that indicated if the motor is or is not present on the
     facility. If it is present, it actuates as an EpicsMotor, if it is not,
-    then the widget receives the state OFF and remains disabled. 
+    then the widget receives the state OFF and remains disabled.
 
     YAML Example
     ------------
@@ -112,7 +112,7 @@ class EPICSMotorDetachable(EPICSMotor):
     %YAML 1.2
     ---
     class: LNLS.EPICS.EPICSMotor.EPICSMotorDetachable
-    epics: 
+    epics:
     "MOTOR_PV":
         channels:
         '':
@@ -124,6 +124,7 @@ class EPICSMotorDetachable(EPICSMotor):
     is_present_value: 0
 
     """
+
     MOTOR_PRESENCE_RBV = "presence"
 
     def init(self):

--- a/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSMotor.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSMotor.py
@@ -97,3 +97,20 @@ class EPICSMotor(EPICSActuator, AbstractMotor):
     def done_movement(self):
         dmov = self.get_channel_value(self.MOTOR_DMOV)
         return bool(dmov)
+
+
+class EPICSMotorDetachable(EPICSMotor):
+    MOTOR_PRESENCE_RBV = "presence"
+
+    def init(self):
+        super().init()
+        self.get_value()
+
+    def get_value(self):
+        value = self.get_property("is_present_value")
+        current_value = int(self.get_channel_value(self.MOTOR_PRESENCE_RBV))
+        if current_value == value:
+            self.update_state(self.STATES.OFF)
+        else:
+            self.update_state(self.STATES.READY)
+        return super().get_value()


### PR DESCRIPTION
Class that implements an interface of motor record IOC and accepts a presence PV, that indicated if the motor is or is not present on the facility. If it is present, it actuates as an EpicsMotor, if it is not, then the widget receives the state OFF and remains disabled.