### PR TITLE
Make HO compliant with bioth xml and yaml configuration

### DIFF
--- a/mxcubecore/HardwareObjects/DetectorCover.py
+++ b/mxcubecore/HardwareObjects/DetectorCover.py
@@ -40,13 +40,13 @@ Example xml file:
 
 """
 
-from mxcubecore.HardwareObjects.abstract.AbstractActuator import AbstractActuator
+from mxcubecore.BaseHardwareObjects import HardwareObject
 
 __copyright__ = """ Copyright © by the MXCuBE collaboration """
 __license__ = "LGPLv3+"
 
 
-class DetectorCover(AbstractActuator):
+class DetectorCover(HardwareObject):
     """Detector Cover class"""
 
     def __init__(self, name):

--- a/mxcubecore/HardwareObjects/ESRF/ESRFBeamDefiner.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFBeamDefiner.py
@@ -69,7 +69,7 @@ class ESRFBeamDefiner(AbstractNState):
     def init_config(self):
         """Get the configutarion from the file"""
 
-        cfg = self["beam_config"]
+        cfg = self.get_property("beam_config")
         if not isinstance(cfg, list):
             cfg = [cfg]
 
@@ -78,7 +78,7 @@ class ESRFBeamDefiner(AbstractNState):
             beam_size = beam_cfg.get_property("beam_size", (0.015, 0.015))
             if isinstance(beam_size, str):
                 beam_size = literal_eval(beam_size)
-                self.beam_config.update({name: beam_size})
+            self.beam_config.update({name: beam_size})
         return cfg
 
     def get_limits(self):

--- a/mxcubecore/HardwareObjects/ESRF/ESRFBeamlineActions.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFBeamlineActions.py
@@ -35,7 +35,7 @@ Example xml file:
 </object>
 """
 
-import ast
+from ast import literal_eval
 
 from mxcubecore.HardwareObjects.BeamlineActions import (
     BeamlineActions,
@@ -59,34 +59,31 @@ class ESRFBeamlineActions(BeamlineActions):
         """Initialise the controller commands and the actuator object
         to be used.
         """
-        try:
-            ctrl_cmds = self["controller_commands"].get_properties().items()
+        ctrl_cmds = self.get_property("controller_commands")
 
-            if ctrl_cmds:
-                controller = self.get_object_by_role("controller")
-                for key, name in ctrl_cmds:
-                    # name = self.get_property(cmd)
+        if ctrl_cmds:
+            controller = self.get_object_by_role("controller")
+            for key, name in ctrl_cmds.items():
+                try:
                     action = getattr(controller, key)
                     self.ctrl_list.append(ControllerCommand(name, action))
-        except KeyError:
-            self.log.exception("")
+                except AttributeError:
+                    # self.log.exception("")
+                    pass
 
-        try:
-            hwobj_cmd_roles = ast.literal_eval(
-                self.get_property("hwobj_command_roles").strip()
-            )
-
-            if hwobj_cmd_roles:
-                for role in hwobj_cmd_roles:
-                    try:
-                        hwobj_cmd = self.get_object_by_role(role)
-                        self.hwobj_list.append(
-                            HWObjActuatorCommand(hwobj_cmd.username, hwobj_cmd)
-                        )
-                    except:
-                        pass
-        except AttributeError:
-            self.log.exception("")
+        hwobj_cmd_roles = self.get_property("hwobj_command_roles")
+        if hwobj_cmd_roles:
+            if isinstance(hwobj_cmd_roles, str):
+                hwobj_cmd_roles = literal_eval(hwobj_cmd_roles.strip())
+            for role in hwobj_cmd_roles:
+                try:
+                    hwobj_cmd = self.get_object_by_role(role)
+                    self.hwobj_list.append(
+                        HWObjActuatorCommand(hwobj_cmd.username, hwobj_cmd)
+                    )
+                except AttributeError:
+                    # self.log.exception("")
+                    pass
 
     def get_commands(self):
         """Get which objects to be used in the GUI

--- a/mxcubecore/HardwareObjects/MicroDiffractometer.py
+++ b/mxcubecore/HardwareObjects/MicroDiffractometer.py
@@ -227,7 +227,20 @@ class MicroDiffractometer(AbstractDiffractometer):
         Args:
             value: requested phase.
         """
-        self._exporter.execute("startSetPhase", (value.value,))
+        _use_custom = self.get_property("use_custom_phase_script") or False
+        current_phase = self.get_phase()
+
+        if value != current_phase:
+            msg = f"Current phase is {current_phase} and moving to {value}"
+            self.log.info(msg)
+
+        if _use_custom and not self.in_plate_mode:
+            script = "ChangePhase_" + value.value.lower()
+            msg = f"Changing phase to {value.value}, using pmac script"
+            self.log.info(msg)
+            self.run_custom_script(script)
+        else:
+            self._exporter.execute("startSetPhase", (value.value,))
         self.wait_status_ready(timeout=200)
 
     def get_phase(self) -> DiffractometerPhase:
@@ -491,3 +504,8 @@ class MicroDiffractometer(AbstractDiffractometer):
             self.beam_position_horizontal.get_value(),
             self.beam_position_vertical.get_value(),
         )
+
+    def run_custom_script(self, script_cmd: str, timeout: float | None = None):
+        """Run custom script."""
+        self.run_script(script_cmd)
+        self.wait_status_ready(timeout)

--- a/mxcubecore/HardwareObjects/SampleView.py
+++ b/mxcubecore/HardwareObjects/SampleView.py
@@ -80,12 +80,16 @@ class SampleView(AbstractSampleView):
     def init(self):
         super().init()
 
-        centring_motor_roles = literal_eval(self.get_property("centring_motors", []))
+        centring_motor_roles = self.get_property("centring_motors", [])
+        if isinstance(centring_motor_roles, str):
+            centring_motor_roles = literal_eval(centring_motor_roles)
         # need to set the motor names for the centring points
         qmo.CentredPosition.DIFFRACTOMETER_MOTOR_NAMES = centring_motor_roles
-        centring_ref_position = literal_eval(
-            self.get_property("centring_reference_position", {})
-        )
+
+        centring_ref_position = self.get_property("centring_reference_position", {})
+        if isinstance(centring_ref_position, str):
+            centring_ref_position = literal_eval(centring_ref_position)
+
         motor_directions = self.get_property("motor_directions", {})
         if isinstance(motor_directions, str):
             motor_directions = literal_eval(motor_directions)

--- a/mxcubecore/HardwareObjects/SampleView.py
+++ b/mxcubecore/HardwareObjects/SampleView.py
@@ -356,31 +356,46 @@ class SampleView(AbstractSampleView):
         self.current_centring_procedure = None
         self.current_centring_method = None
 
+    def run_custom_auto_centring(self):
+        """Run custom script for the automatic centring"""
+        self.log.info("Using custom sample centring")
+        self.current_centring_method = "Automatic"
+        self.emit("centringStarted", ("Automatic"))
+        diffr = HWR.beamline.diffractometer
+        diffr.run_custom_script("sample_centering")
+        diffr.wait_status_ready()
+        self.centring_done()
+        self.accept_centring()
+
     def start_auto_centring(self):
         """Start automatic centring procedure"""
         if self.current_centring_procedure is not None:
             logging.getLogger("HWR").exception("Already centring")
 
-        beam_pos_x, beam_pos_y = HWR.beamline.beam.get_beam_position_on_screen()
         diffr = HWR.beamline.diffractometer
+        diffr.wait_status_ready(60)
         diffr.set_phase(diffr.get_phase_enum.CENTRE)
 
-        pixels_per_mm_x, pixels_per_mm_y = diffr.get_pixels_per_mm()
-        diffr.wait_status_ready(5)
+        if self.get_property("use_custom_auto_centring"):
+            self.run_custom_auto_centring()
+        else:
+            beam_pos_x, beam_pos_y = HWR.beamline.beam.get_beam_position_on_screen()
 
-        self.current_centring_procedure = sample_centring.start_auto(
-            self,
-            self.centring_motors,
-            pixels_per_mm_x,
-            pixels_per_mm_y,
-            beam_pos_x,
-            beam_pos_y,
-            chi_angle=0.0,
-        )
+            pixels_per_mm_x, pixels_per_mm_y = diffr.get_pixels_per_mm()
 
-        self.current_centring_method = "Automatic"
-        self.emit("centringStarted", ("Automatic"))
-        self.current_centring_procedure.link(self.auto_centring_done)
+            self.current_centring_procedure = sample_centring.start_auto(
+                self,
+                self.centring_motors,
+                pixels_per_mm_x,
+                pixels_per_mm_y,
+                beam_pos_x,
+                beam_pos_y,
+                chi_angle=0.0,
+            )
+
+            self.current_centring_method = "Automatic"
+            self.emit("centringStarted", ("Automatic"))
+            self.current_centring_procedure.link(self.auto_centring_done)
 
     def move_to_beam(self, x: float, y: float):
         """Move the sample to the x,y coordinates.

--- a/mxcubecore/HardwareObjects/XMLRPCServer.py
+++ b/mxcubecore/HardwareObjects/XMLRPCServer.py
@@ -478,6 +478,7 @@ class XMLRPCServer(HardwareObject):
         Saves the current position as a centered position.
         """
         self.log.debug("Saving position via XMLRPC")
+        HWR.beamline.sample_view.centring_done()
         HWR.beamline.sample_view.accept_centring()
         return True
 

--- a/mxcubecore/HardwareObjects/abstract/AbstractActuator.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractActuator.py
@@ -88,12 +88,10 @@ class AbstractActuator(HardwareObject):
         self.default_value = self.get_property("default_value")
         if self.default_value is not None:
             self.update_value(self.default_value)
-        limits = self.get_property("default_limits")
-        if limits:
-            try:
-                self._nominal_limits = tuple(literal_eval(limits))
-            except TypeError:
-                print("Invalid limits")
+        self._nominal_limits = self.get_property("default_limits", (None, None))
+        if isinstance(self._nominal_limits, str):
+            self._nominal_limits = tuple(literal_eval(self._nominal_limits))
+
         self.username = self.get_property("username")
 
     @abc.abstractmethod

--- a/mxcubecore/HardwareObjects/abstract/AbstractNState.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractNState.py
@@ -89,9 +89,9 @@ class AbstractNState(AbstractActuator):
         values = self.get_property("values", [])
         if isinstance(values, str):
             values = literal_eval(values)
-            values_dict = dict(**{item.name: item.value for item in self.VALUES})
-            values_dict.update(values)
-            self.VALUES = Enum("ValueEnum", values_dict)
+        values_dict = dict(**{item.name: item.value for item in self.VALUES})
+        values_dict.update(values)
+        self.VALUES = Enum("ValueEnum", values_dict)
 
     def value_to_enum(self, value, idx=0):
         """Transform a value to Enum

--- a/mxcubecore/HardwareObjects/mockup/BeamMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/BeamMockup.py
@@ -83,11 +83,11 @@ class BeamMockup(AbstractBeam):
 
         self._definer_type = self.get_property("definer_type", _definer_type)
 
-        self._beam_position_on_screen = self.get_property("beam_position", "[318, 238]")
+        self._beam_position_on_screen = self.get_property("beam_position") or [318, 238]
         if isinstance(self._beam_position_on_screen, str):
             self._beam_position_on_screen = literal_eval(self._beam_position_on_screen)
 
-        self._check_beam = self.get_property("check_beam")
+        self._check_beam = self.get_property("check_beam") or False
         if isinstance(self._check_beam, str):
             self._check_beam = literal_eval(self._check_beam)
 

--- a/mxcubecore/HardwareObjects/mockup/BeamMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/BeamMockup.py
@@ -83,13 +83,13 @@ class BeamMockup(AbstractBeam):
 
         self._definer_type = self.get_property("definer_type", _definer_type)
 
-        self._beam_position_on_screen = literal_eval(
-            self.get_property("beam_position", "[318, 238]"),
-        )
+        self._beam_position_on_screen = self.get_property("beam_position", "[318, 238]")
+        if isinstance(self._beam_position_on_screen, str):
+            self._beam_position_on_screen = literal_eval(self._beam_position_on_screen)
 
-        _check_beam = self.get_property("check_beam")
-        if _check_beam:
-            self._check_beam = literal_eval(_check_beam)
+        self._check_beam = self.get_property("check_beam")
+        if isinstance(self._check_beam, str):
+            self._check_beam = literal_eval(self._check_beam)
 
         # Needed to trigger first value setting
         self.get_value()

--- a/mxcubecore/HardwareObjects/mockup/MotorMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/MotorMockup.py
@@ -32,13 +32,10 @@ Example of xml config file
 </object>
 """
 
-import ast
 import time
+from ast import literal_eval
 
-from mxcubecore.HardwareObjects.abstract.AbstractMotor import (
-    AbstractMotor,
-    MotorStates,
-)
+from mxcubecore.HardwareObjects.abstract.AbstractMotor import AbstractMotor, MotorStates
 from mxcubecore.HardwareObjects.mockup.ActuatorMockup import ActuatorMockup
 
 __copyright__ = """ Copyright © 2010-2020 by the MXCuBE collaboration """
@@ -69,11 +66,12 @@ class MotorMockup(ActuatorMockup, AbstractMotor):
             self.set_velocity(DEFAULT_VELOCITY)
         if None in self.get_limits():
             self.update_limits(DEFAULT_LIMITS)
-        try:
-            _wr = self.get_property("wrap_range")
-            self._wrap_range = DEFAULT_WRAP_RANGE if not _wr else ast.literal_eval(_wr)
-        except (ValueError, SyntaxError):
-            self._wrap_range = DEFAULT_WRAP_RANGE
+
+        self._wrap_range = DEFAULT_WRAP_RANGE
+        _wr = self.get_property("wrap_range")
+        if isinstance(_wr, str):
+            self._wrap_range = literal_eval(_wr)
+
         if self.default_value is None:
             self.default_value = DEFAULT_VALUE
             self.update_value(self.default_value)

--- a/mxcubecore/HardwareObjects/mockup/MotorMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/MotorMockup.py
@@ -33,7 +33,6 @@ Example of xml config file
 """
 
 import time
-from ast import literal_eval
 
 from mxcubecore.HardwareObjects.abstract.AbstractMotor import AbstractMotor, MotorStates
 from mxcubecore.HardwareObjects.mockup.ActuatorMockup import ActuatorMockup
@@ -67,10 +66,10 @@ class MotorMockup(ActuatorMockup, AbstractMotor):
         if None in self.get_limits():
             self.update_limits(DEFAULT_LIMITS)
 
-        self._wrap_range = DEFAULT_WRAP_RANGE
-        _wr = self.get_property("wrap_range")
-        if isinstance(_wr, str):
-            self._wrap_range = literal_eval(_wr)
+        try:
+            self._wrap_range = float(self.get_property("wrap_range"))
+        except ValueError:
+            self._wrap_range = DEFAULT_WRAP_RANGE
 
         if self.default_value is None:
             self.default_value = DEFAULT_VALUE

--- a/mxcubecore/HardwareObjects/mockup/MotorMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/MotorMockup.py
@@ -68,7 +68,7 @@ class MotorMockup(ActuatorMockup, AbstractMotor):
 
         try:
             self._wrap_range = float(self.get_property("wrap_range"))
-        except ValueError:
+        except (TypeError, ValueError):
             self._wrap_range = DEFAULT_WRAP_RANGE
 
         if self.default_value is None:

--- a/mxcubecore/queue_entry/base_queue_entry.py
+++ b/mxcubecore/queue_entry/base_queue_entry.py
@@ -799,8 +799,7 @@ class SampleQueueEntry(BaseQueueEntry):
                             "inverse_beam": inverse_beam,
                         }
                     )
-
-        programs = HWR.beamline.collect.get("auto_processing")
+        programs = HWR.beamline.collect.get_property("auto_processing")
         if programs:
             try:
                 autoprocessing.start(programs, "end_multicollect", params)


### PR DESCRIPTION
The incompatibility is with properties of type tuple, list, dictionary.
**get_property** returns a string which we have to convert with xml, an tuple, list or dictionary with the yaml.
The fix is that we only convert with literal_eval if the return value is a string.