### PR TITLE
Fix bug at LNLSDiffractometer

### DIFF
--- a/mxcubecore/HardwareObjects/LNLS/LNLSDiffractometer.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSDiffractometer.py
@@ -123,3 +123,6 @@ class LNLSDiffractometer(GenericDiffractometer):
 
     def motor_positions_to_screen(self, motor_positions):
         return self.beam_position
+
+    def get_value_motors(self):
+        return self.current_motor_positions


### PR DESCRIPTION
Not having this function at LNLSDiffractometer is causing the app to crash. This is a remaining from our recent bluesky PR:
https://github.com/mxcube/mxcubecore/pull/1490/changes