### PR TITLE
Tightened up motor definitions and adapted virtual-motor names

### DIFF
--- a/diffractometer.md
+++ b/diffractometer.md
@@ -5,7 +5,7 @@ This allows them to be used in a standard way by the MXCuBE application (web or 
 We also introduce a convention about the direction of the alignment and centring motors:
 
 - z axis is in the direction of gravity. Positive direction is downwards.
-- y axis is perpendicular to the z axis and to the nominal beam direction.  Positive direction is so that x,y,z would form a right-handed coordinate system.
+- y axis is perpendicular to the z axis and to the nominal beam direction. Positive direction is so that x,y,z would form a right-handed coordinate system.
 - x axis is orthogonal to the y and z axes (and approximately parallel to the beam). Positive direction is from the sample towards the detector.
 
 Here follows the list of the fixed roles and the description of the corresponding objects, accessible via beamline.diffractometer hardware object.

--- a/diffractometer.md
+++ b/diffractometer.md
@@ -4,22 +4,23 @@ This allows them to be used in a standard way by the MXCuBE application (web or 
 
 We also introduce a convention about the direction of the alignment and centring motors:
 
-- x axis is parallel to the beam. Positive direction is from right to left.
-- y axis is perpendicular to the beam, parallel to the ground. Positive direction is from left to right, facing the beam.
-- z axis is perpendicular to the floor. Positive direction is top down.
+- z axis is in the direction of gravity. Positive direction is downwards.
+- y axis is perpendicular to the z axis and to the nominal beam direction.  Positive direction is so that x,y,z would form a right-handed coordinate system.
+- x axis is orthogonal to the y and z axes (and approximately parallel to the beam). Positive direction is from the sample towards the detector.
 
 Here follows the list of the fixed roles and the description of the corresponding objects, accessible via beamline.diffractometer hardware object.
 
 1\. Motor objects (roles) and their functionality:
 
-- **omega** - the rotation axis, independent of the orientation (up, down or side). Positive direction is clockwise
-- **sampx** - centring table x axis
+- **omega** - the rotation axis, independent of the orientation (up, down or side). Positive direction is a right-handed rotation
+- **kappa** - the rotation axis between the omega and kappa_phi axes. Positive direction is a right-handed rotation. Not present on all goniostats.
+- **kappa_phi** - the rotation axis directly attached to the sample. Positive direction is a right-handed rotation. Not present on all goniostats.
 - **sampy** - centring table y axis
 - **focus** - alignment table x axis
 - **phiy** - alignment table y axis
 - **phiz** - alignment table z axis
-- **sample_horizontal** - x axis, combination of sampx and sampy. Equivalent to sampx at omega=0 and sampy for omega=90.
-- **sample_vertical** - y axis, combination of sampx and sampy. Equivalent to sampy at omega=0 and sampx for omega=90.
+- **sample_focus** - virtual motor along the y axis, omega-dependent combination of sampx and sampy.
+- **sample_lateral** - virtual motor along the z axis, omega-dependent combination of sampx and sampy.
 - **backlight** - adjust the intensity of the back light
 - **frontlight** - adjust the intensity of the front light
 

--- a/mxcubecore/HardwareObjects/abstract/AbstractDiffractometer.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractDiffractometer.py
@@ -25,26 +25,30 @@ Certain number of roles are fixed and define a corresponding motor or nstate
 actuator object. This allows to use them in a standard way by the MXCuBE
 application (web or Qt).
 There is also a convention of the direction of the motors:
-  - x axis is parallel to the beam. Positive direction is from right to left.
-  - y axis is perpendicular to the beam, parallel to the ground. Positive
-      direction is from left to right when facing the beam.
-  - z axis is perpendicular to the floor. Positive direction is top down.
+- z axis is in the direction of gravity. Positive direction is downwards.
+- y axis is perpendicular to the z axis and to the nominal beam direction.  Positive direction is so that x,y,z would form a right-handed coordinate system.
+- x axis is orthogonal to the y and z axes (and approximately parallel to the beam). Positive direction is from the sample towards the detector.
+
 
 Here follows the list of the fixed roles and the description of the
 corresponding objects, accessible via beamline.diffractometer hardware object.
 
 1. Motor objects (roles)  and their functionality:
   omega - the rotation axis, independent of the orientation (up, down or side).
-          Pisitive direction is clockwise.
+          Positive direction is a right-handed rotation.
+  kappa - the rotation axis between the omega and kappa_phi axes.
+          Positive direction is a right-handed rotation. Not present on all goniostats.
+  kappa_phi - the rotation axis directly attached to the sample.
+          Positive direction is a right-handed rotation. Not present on all goniostats.
   sampx - centring table x axis
   sampy - centring table y axis
   focus - alignment table x axis
   phiy - alignment table y axis
   phiz - alignment table z axis
-  sample_horizontal - x axis, combination of sampx and sampy. Equivalent to
-                      sampx at omega=0 and sampy for omega=90.
-  samle_vertical - y axis, combination of sampx and sampy. Equivalent to
-                   sampy at omega=0 and sampx for omega=90.
+  sample_focus - virtual motor along the x axis,
+                      omega-dependent combination of sampx and sampy.
+  sample_lateral - virtual motor along the y or z axis, orthogonal to the omega axis,
+                      omega-dependent combination of sampx and sampy.
   backlight - adjust the intensity of the back light
   frontlight - adjust the intensity of the front light
   kappa - the minikappa kappa axis

--- a/mxcubecore/HardwareObjects/abstract/AbstractDiffractometer.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractDiffractometer.py
@@ -26,8 +26,10 @@ actuator object. This allows to use them in a standard way by the MXCuBE
 application (web or Qt).
 There is also a convention of the direction of the motors:
 - z axis is in the direction of gravity. Positive direction is downwards.
-- y axis is perpendicular to the z axis and to the nominal beam direction.  Positive direction is so that x,y,z would form a right-handed coordinate system.
-- x axis is orthogonal to the y and z axes (and approximately parallel to the beam). Positive direction is from the sample towards the detector.
+- y axis is perpendicular to the z axis and to the nominal beam direction.
+  Positive direction is so that x,y,z would form a right-handed coordinate system.
+- x axis is orthogonal to the y and z axes (and approximately parallel to the beam).
+  Positive direction is from the sample towards the detector.
 
 
 Here follows the list of the fixed roles and the description of the


### PR DESCRIPTION
Modified motor definitions following discussion in #1470

- Definitions follow the original system of @beteva, but are tightened to avoid any possible ambiguity. x, y and z form a right-handed orthogonal axis system with z in the direction of gravity, y orthogonal to gravity and beam, and x approximately along the beam. Note that the definitions use the _nominal_ beam direction, as the motor vectors are not supposed to be update when the actual beam drifts. 

- sample_horizontal and sample_vertical have been renamed sample_focus and sample_lateral, as proposed by Gleb, and the comment about being equal to sampx and sampy at certain omega values have been removed as inapplicable in many circumstances. The new names are valid for both horizontal and vertical goniostats.

The new names have been applied across the mxcubecore and mxcubeweb code (see separate mxcubeweb PR).


**NBNB** The @beteva definitions said that the Z axis direction was _Positive direction is top down_ and this PR follows tha, having the positive direction downwards. The comment in #1470 by @marcus-oscarsson sais _ẑ: Is in the, negative, direction of gravity, pointing "upwards"_! This seems contradictory. We should make sure which convention we want and if necessary adapt this PR. 