### PR TITLE
Implement EPICSActuatorBluesky

### DIFF
--- a/mxcubecore/HardwareObjects/LNLS/BlueskyHttpServer.py
+++ b/mxcubecore/HardwareObjects/LNLS/BlueskyHttpServer.py
@@ -15,7 +15,7 @@ class BlueskyHttpServer(HardwareObject):
         response_content = response.json()
         if response_content["success"]:
             try:
-                self.api.monitor_manager_state("running")
+                self.api.monitor_manager_state("executing_queue")
                 self.api.monitor_manager_state("idle")
             except TimeoutError:
                 self.log.exception("The Bluesky plan has timed out!")

--- a/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSActuator.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSActuator.py
@@ -5,6 +5,7 @@ import gevent
 import numpy as np
 
 from mxcubecore.HardwareObjects.abstract.AbstractActuator import AbstractActuator
+from mxcubecore import HardwareRepository as HWR
 
 
 class EPICSActuator(AbstractActuator):
@@ -74,3 +75,52 @@ class EPICSActuator(AbstractActuator):
         if self._wait_task is not None:
             self._wait_task.set()
         self.update_state(self.STATES.READY)
+
+
+class EPICSActuatorBluesky(EPICSActuator):
+    """
+    This class alters the _set_value function of EPICSActuator for
+    cases when the set is done via bluesky rather than directly by
+    MXCuBE. The plan's name and parameter must be specified at the
+    configuration file. Because wait_ready function works the same
+    way as EPICSActuator, frontend functionality remains the same.
+
+    YAML Example
+    ------------
+
+    %YAML 1.2
+    ---
+    class: LNLS.EPICS.EPICSActuator.EPICSActuatorBluesky
+    epics:
+    "MNC:A:DCM01:":
+        channels:
+        rbv:
+            suffix: "GonRx_Energy_RBV"
+            polling_period: 200
+        val:
+            suffix: "Energy_SP"
+    configuration:
+    tolerance: 0.01
+    plan_name: "move_energy_and_phase"
+    plan_parameter: "energy"
+    default_limits: (5, 20)
+    """
+
+    def __init__(self, name):
+        super().__init__(name)
+        self._bluesky_api = HWR.beamline.get_object_by_role("bluesky")
+
+    def init(self):
+        super().init()
+        self.plan_name = self.get_property("plan_name")
+        self.plan_parameter = self.get_property("plan_parameter")
+
+    def _set_value(self, value):
+        self.setpoint = value
+        self.update_state(self.STATES.BUSY)
+        self._bluesky_api.execute_plan(
+            plan_name=self.plan_name,
+            kwargs={
+                self.plan_parameter: value,
+            },
+        )

--- a/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSActuator.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSActuator.py
@@ -4,8 +4,8 @@ from typing import Optional
 import gevent
 import numpy as np
 
-from mxcubecore.HardwareObjects.abstract.AbstractActuator import AbstractActuator
 from mxcubecore import HardwareRepository as HWR
+from mxcubecore.HardwareObjects.abstract.AbstractActuator import AbstractActuator
 
 
 class EPICSActuator(AbstractActuator):


### PR DESCRIPTION
This PR implements the `EPICSActuatorBluesky` class, which will be used for devices that are moved with a bluesky plan, but have an RBV that can be read by MXCuBE as if it was a regular `EPICSActuator`. Because of that, only the `_set_value` function needs to be overwritten. Our energy will be moved via bluesky plans.