### PR TITLE
Making centring more robust

### DIFF
--- a/mxcubecore/HardwareObjects/sample_centring.py
+++ b/mxcubecore/HardwareObjects/sample_centring.py
@@ -629,6 +629,7 @@ def auto_center(
         i += 1
         if i > 4:
             if callable(msg_cb):
+                logging.getLogger("HWR").info("No loop detected")
                 msg_cb("No loop detected, aborting")
             return
 

--- a/mxcubecore/HardwareObjects/sample_centring.py
+++ b/mxcubecore/HardwareObjects/sample_centring.py
@@ -73,7 +73,7 @@ def prepare(centring_motors_dict):
 
     if CURRENT_CENTRING and not CURRENT_CENTRING.ready():
         logging.getLogger("HWR").debug("DEBUG: ENDING CURRENT CENTRING")
-        end()
+        CURRENT_CENTRING.kill()
 
     if USER_CLICKED_EVENT and not USER_CLICKED_EVENT.ready():
         logging.getLogger("HWR").debug("DEBUG: USER_CLICKED_EVENT: false")

--- a/mxcubecore/queue_entry/base_queue_entry.py
+++ b/mxcubecore/queue_entry/base_queue_entry.py
@@ -870,10 +870,7 @@ def mount_sample(data_model, centring_done_cb, async_result):
                     sview.start_manual_centring()
                 elif centring_method == CENTRING_METHOD.LOOP:
                     sview.start_auto_centring()
-                    log.warning(
-                        "Centring in progress. Please save"
-                        + " the suggested centring or re-center"
-                    )
+                    log.warning("Centring sample, please wait")
                 elif centring_method == CENTRING_METHOD.FULLY_AUTOMATIC:
                     log.info("Centring sample, please wait.")
                     sview.start_auto_centring()


### PR DESCRIPTION
Making sure that no centering routine is running by calling `kill()` on the greenlet before starting a new centering.