### PR TITLE
Sync TaskPrerequisites with ContextMenu

### DIFF
--- a/docs/source/dev/queue.md
+++ b/docs/source/dev/queue.md
@@ -180,8 +180,7 @@ class TestCollectionQueueEntry(BaseQueueEntry):
     REQUIRES = [
         TaskPrerequisite.POINT,
         TaskPrerequisite.LINE,
-        TaskPrerequisite.CHIP,
-        TaskPrerequisite.MESH,
+        TaskPrerequisite.GRID,
         TaskPrerequisite.NO_SHAPE_2D,
     ]
 

--- a/mxcubecore/queue_entry/base_queue_entry.py
+++ b/mxcubecore/queue_entry/base_queue_entry.py
@@ -79,8 +79,7 @@ class TaskPrerequisite(str, Enum):
                 REQUIRES = [
                     TaskPrerequisite.POINT,
                     TaskPrerequisite.LINE,
-                    TaskPrerequisite.CHIP,
-                    TaskPrerequisite.MESH,
+                    TaskPrerequisite.GRID,
                     TaskPrerequisite.NO_SHAPE_2D,
                 ]
     """
@@ -88,8 +87,8 @@ class TaskPrerequisite(str, Enum):
     POINT = "point"
     LINE = "line"
     NO_SHAPE = "no_shape"
-    CHIP = "chip"
-    MESH = "mesh"
+    GRID = "grid"
+    CHIP = "chip"  # currently unused by the web frontend.
     # This is used for the case when no shape is selected and we want to
     # create a 2D point in the place where context menu was opened.
     NO_SHAPE_2D = "no_shape_2d"


### PR DESCRIPTION
Currently ContextMenu component on MXCuBE-Web side respects following prerequisites:
- point
- no_shape
- no_shape_2d
- line
- grid

The "grid" constant was missing from TaskPrerequisites. Also, the already existing "mesh" and "chip" prerequisites are nowhere to be found in MXCuBE-Web.

---

I will also note that the original list of values was derived from hardware objects in this repo, `mesh` and `chip` were present [there](https://github.com/mxcube/mxcubecore/blob/4bf73a083ed38793e7a04fb417bc2674dec2c148/mxcubecore/HardwareObjects/ESRF/queue_entry/fast_char_collection.py#L45), maybe they were used in the past?