### PR TITLE
Use ``msg`` to improve logging of unsuccesfull login to ISPYB

### DIFF
--- a/mxcubecore/HardwareObjects/ProposalTypeISPyBLims.py
+++ b/mxcubecore/HardwareObjects/ProposalTypeISPyBLims.py
@@ -42,19 +42,23 @@ class ProposalTypeISPyBLims(ISPyBAbstractLIMS):
         """
         Authentication step based on the authServerType
         """
-
+        msg = ""
         if self.authServerType == "ldap":
             self.log.debug("Starting LDAP authentication %s" % user_name)
             ok = self.ldap_login(user_name, psd)
         elif self.authServerType == "ispyb":
             self.log.debug("ISPyB login")
-            ok, _ = self.ispyb_login(user_name, psd)
+            ok, msg = self.ispyb_login(user_name, psd)
         else:
             raise Exception("Authentication server type is not defined")
 
         if not ok:
             # refuse Login
-            self.log.error("Authentication with %s failed" % self.authServerType)
+            self.log.error(
+                "Authentication with %s failed. %s",
+                self.authServerType,
+                msg.capitalize(),
+            )
             raise Exception("Authentication failed")
 
         self.log.debug("User %s logged in %s" % (user_name, self.authServerType))

--- a/mxcubecore/HardwareObjects/UserTypeISPyBLims.py
+++ b/mxcubecore/HardwareObjects/UserTypeISPyBLims.py
@@ -87,10 +87,10 @@ class UserTypeISPyBLims(ISPyBAbstractLIMS):
             login_name = self._translate(proposal_code, "ldap") + str(proposal_number)
 
         # Authentication
+        msg = ""
         if self.authServerType == "ldap":
             self.log.debug("Starting LDAP authentication %s" % login_name)
             self.login_ok = self.ldap_login(login_name, psd, ldap_connection)
-            msg = loginID
             self.log.debug("User %s logged in LDAP" % login_name)
         elif self.authServerType == "ispyb":
             self.log.debug("ISPyB login")
@@ -100,7 +100,11 @@ class UserTypeISPyBLims(ISPyBAbstractLIMS):
 
         if not self.login_ok:
             # refuse login
-            self.log.error("ISPyB login not ok. %s", msg.capitalize())
+            self.log.error(
+                "Authentication with %s failed. %s",
+                self.authServerType,
+                msg.capitalize(),
+            )
             raise Exception("Error lims authentication")
 
         # login succeed, get proposal and sessions

--- a/mxcubecore/HardwareObjects/UserTypeISPyBLims.py
+++ b/mxcubecore/HardwareObjects/UserTypeISPyBLims.py
@@ -99,9 +99,8 @@ class UserTypeISPyBLims(ISPyBAbstractLIMS):
             raise Exception("Authentication server type is not defined")
 
         if not self.login_ok:
-            msg = "%s." % msg.capitalize()
-            # refuse Login
-            self.log.error("ISPyB login not ok")
+            # refuse login
+            self.log.error("ISPyB login not ok. %s", msg.capitalize())
             raise Exception("Error lims authentication")
 
         # login succeed, get proposal and sessions


### PR DESCRIPTION
`msg` was defined and never used.   
In case of `self.login_ok = False` for "ldap" type, the debug message is a bit wired, though: `ISPYB login not ok: <login_id>`