### PR TITLE
Remove TaskPrerequisite.MESH from test collection.

### DIFF
--- a/mxcubecore/queue_entry/test_collection.py
+++ b/mxcubecore/queue_entry/test_collection.py
@@ -78,7 +78,6 @@ class TestCollectionQueueEntry(BaseQueueEntry):
         TaskPrerequisite.POINT,
         TaskPrerequisite.LINE,
         TaskPrerequisite.CHIP,
-        TaskPrerequisite.MESH,
         TaskPrerequisite.NO_SHAPE_2D,
     ]
 


### PR DESCRIPTION
As of https://github.com/mxcube/mxcubecore/pull/1536 the MESH Enum item has been removed, as it is not used by the frontend application.

An alternative - reverting it's removal is not considered, since the MESH requirement would not differ substantially from already present GRID.


---

note: I've tested it by selecting `Test Collection` task from the context menu. Previously that option was not showing up in the UI.