### PR TITLE
Minor fixes after move to AbstractDiffractometer

### DIFF
--- a/mxcubecore/HardwareObjects/EMBLFlexHCD.py
+++ b/mxcubecore/HardwareObjects/EMBLFlexHCD.py
@@ -577,7 +577,9 @@ class EMBLFlexHCD(SampleChanger):
                             "Sample is Loaded from EMBLFlexHCD.py "
                         )
                         HWR.beamline.diffractometer.wait_status_ready(100)
-                        HWR.beamline.diffractometer.run_custom_script("ChangePhase_centring")
+                        HWR.beamline.diffractometer.run_custom_script(
+                            "ChangePhase_centring"
+                        )
                         HWR.beamline.diffractometer.run_custom_script(
                             "sample_centering", wait=False
                         )

--- a/mxcubecore/HardwareObjects/EMBLFlexHCD.py
+++ b/mxcubecore/HardwareObjects/EMBLFlexHCD.py
@@ -576,9 +576,9 @@ class EMBLFlexHCD(SampleChanger):
                         logging.getLogger("user_level_log").info(
                             "Sample is Loaded from EMBLFlexHCD.py "
                         )
-                        HWR.beamline.diffractometer.wait_ready(100)
-                        HWR.beamline.diffractometer.run_script("ChangePhase_centring")
-                        HWR.beamline.diffractometer.run_script(
+                        HWR.beamline.diffractometer.wait_status_ready(100)
+                        HWR.beamline.diffractometer.run_custom_script("ChangePhase_centring")
+                        HWR.beamline.diffractometer.run_custom_script(
                             "sample_centering", wait=False
                         )
                     break

--- a/mxcubecore/HardwareObjects/Gphl/GphlMessages.py
+++ b/mxcubecore/HardwareObjects/Gphl/GphlMessages.py
@@ -233,6 +233,8 @@ class IdentifiedElement(MessageData):
             self._id = value
         else:
             self._id = uuid.uuid1()
+
+
 #            raise TypeError("UUID input must be of type uuid.UUID")
 
 

--- a/mxcubecore/HardwareObjects/Gphl/GphlMessages.py
+++ b/mxcubecore/HardwareObjects/Gphl/GphlMessages.py
@@ -232,7 +232,8 @@ class IdentifiedElement(MessageData):
         elif isinstance(value, uuid.UUID):
             self._id = value
         else:
-            raise TypeError("UUID input must be of type uuid.UUID")
+            self._id = uuid.uuid1()
+#            raise TypeError("UUID input must be of type uuid.UUID")
 
 
 # Sync with Java 4/5/2017

--- a/mxcubecore/HardwareObjects/Gphl/GphlMessages.py
+++ b/mxcubecore/HardwareObjects/Gphl/GphlMessages.py
@@ -232,10 +232,7 @@ class IdentifiedElement(MessageData):
         elif isinstance(value, uuid.UUID):
             self._id = value
         else:
-            self._id = uuid.uuid1()
-
-
-#            raise TypeError("UUID input must be of type uuid.UUID")
+            raise TypeError("UUID input must be of type uuid.UUID")
 
 
 # Sync with Java 4/5/2017

--- a/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
+++ b/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
@@ -1135,7 +1135,7 @@ class GphlWorkflow(HardwareObject):
             dose_label = "Characterisation dose (MGy)"
             if not self.config.settings.get("recentre_before_start"):
                 # replace planned orientation with current orientation
-                current_pos_dict = HWR.beamline.diffractometer.get_positions()
+                current_pos_dict = HWR.beamline.sample_view.get_positions()
                 dd0 = grouped_sweeps[0]["axis_settings"]
                 for tag in dd0:
                     pos = current_pos_dict.get(tag)
@@ -1723,7 +1723,7 @@ class GphlWorkflow(HardwareObject):
         sweepSetting = sweepSettings[0]
 
         # Get current position
-        current_pos_dict = HWR.beamline.diffractometer.get_positions()
+        current_pos_dict = HWR.beamline.sample_view.get_positions()
         current_okp = tuple(current_pos_dict[role] for role in self.rotation_axes)
         current_xyz = tuple(current_pos_dict[role] for role in self.translation_axes)
 

--- a/mxcubecore/HardwareObjects/MicroDiffractometer.py
+++ b/mxcubecore/HardwareObjects/MicroDiffractometer.py
@@ -19,6 +19,8 @@
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 
 """Micro Diffractometer implementation of the AbstractDiffractometer class."""
+import time
+
 
 from gevent import Timeout, sleep
 
@@ -250,7 +252,7 @@ class MicroDiffractometer(AbstractDiffractometer):
             self.run_custom_script(script)
         else:
             self._exporter.execute("startSetPhase", (value.value,))
-        self.wait_status_ready(timeout=200)
+        self.wait_status_ready(timeout=600)
 
     def get_phase(self) -> DiffractometerPhase:
         """Get the current phase."""
@@ -517,4 +519,7 @@ class MicroDiffractometer(AbstractDiffractometer):
     def run_custom_script(self, script_cmd: str, timeout: float | None = None):
         """Run custom script."""
         self.run_script(script_cmd)
+        # Wait for script to start before checking status,
+        # can perhaps be improved to wait for ready-busy-ready ?
+        time.sleep(0.4) 
         self.wait_status_ready(timeout)

--- a/mxcubecore/HardwareObjects/MicroDiffractometer.py
+++ b/mxcubecore/HardwareObjects/MicroDiffractometer.py
@@ -34,6 +34,8 @@ from mxcubecore.HardwareObjects.abstract.AbstractDiffractometer import (
     DiffractometerPhase,
 )
 
+import sample_centring
+
 __copyright__ = """ Copyright © by the MXCuBE collaboration """
 __license__ = "LGPLv3+"
 
@@ -80,6 +82,10 @@ class MicroDiffractometer(AbstractDiffractometer):
         except AttributeError:
             self.log.exception("global_state and phase_channel not configured!")
 
+        sample_centring.NUM_CENTRING_ROUNDS = self.get_property(
+            "num_centering_rounds", 1
+        )
+            
     def abort(self):
         """Immediately terminate action."""
         self._exporter.execute("abort")

--- a/mxcubecore/HardwareObjects/MicroDiffractometer.py
+++ b/mxcubecore/HardwareObjects/MicroDiffractometer.py
@@ -19,9 +19,10 @@
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 
 """Micro Diffractometer implementation of the AbstractDiffractometer class."""
+
 import time
 
-
+import sample_centring
 from gevent import Timeout, sleep
 
 from mxcubecore import HardwareRepository as HWR
@@ -33,8 +34,6 @@ from mxcubecore.HardwareObjects.abstract.AbstractDiffractometer import (
     DiffractometerHead,
     DiffractometerPhase,
 )
-
-import sample_centring
 
 __copyright__ = """ Copyright © by the MXCuBE collaboration """
 __license__ = "LGPLv3+"
@@ -85,7 +84,7 @@ class MicroDiffractometer(AbstractDiffractometer):
         sample_centring.NUM_CENTRING_ROUNDS = self.get_property(
             "num_centering_rounds", 1
         )
-            
+
     def abort(self):
         """Immediately terminate action."""
         self._exporter.execute("abort")
@@ -527,5 +526,5 @@ class MicroDiffractometer(AbstractDiffractometer):
         self.run_script(script_cmd)
         # Wait for script to start before checking status,
         # can perhaps be improved to wait for ready-busy-ready ?
-        time.sleep(0.4) 
+        time.sleep(0.4)
         self.wait_status_ready(timeout)

--- a/mxcubecore/HardwareObjects/MicrodiffLightInOut.py
+++ b/mxcubecore/HardwareObjects/MicrodiffLightInOut.py
@@ -1,22 +1,3 @@
-# encoding: utf-8
-#
-#  Project: MXCuBE
-#  https://github.com/mxcube
-#
-#  This file is part of MXCuBE software.
-#
-#  MXCuBE is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU Lesser General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  MXCuBE is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU Lesser General Public License for more details.
-#
-#  You should have received a copy of the GNU General Lesser Public License
-#  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 """
 Combine setting the back light IN with moving the beamstop out.
 This is used to set the back light in/out faster, than using
@@ -32,10 +13,9 @@ Example xml configuration:
    <state_channel_name>HardwareState</state_channel_name>
  </object>
 """
-import logging
+
 from mxcubecore import HardwareRepository as HWR
 from mxcubecore.HardwareObjects.ExporterNState import ExporterNState
-
 
 __copyright__ = """ Copyright © by the MXCuBE collaboration """
 __license__ = "LGPLv3+"
@@ -51,8 +31,6 @@ class MicrodiffLightInOut(ExporterNState):
         """
         # first move the beamstop in our out
         beamstop = HWR.beamline.diffractometer.beamstop
-        if value == self.VALUES.IN:
-            # set the beamstop off, if needed
-            if beamstop.get_value() == beamstop.VALUES.IN:
-                beamstop.set_value(beamstop.VALUES.OUT)
+        if value == self.VALUES.IN and beamstop.get_value() == beamstop.VALUES.IN:
+            beamstop.set_value(beamstop.VALUES.OUT)
         super()._set_value(value)

--- a/mxcubecore/HardwareObjects/MicrodiffLightInOut.py
+++ b/mxcubecore/HardwareObjects/MicrodiffLightInOut.py
@@ -1,0 +1,58 @@
+# encoding: utf-8
+#
+#  Project: MXCuBE
+#  https://github.com/mxcube
+#
+#  This file is part of MXCuBE software.
+#
+#  MXCuBE is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  MXCuBE is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU General Lesser Public License
+#  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
+"""
+Combine setting the back light IN with moving the beamstop out.
+This is used to set the back light in/out faster, than using
+the phase CENTRING - the beamstop motor moves only if needed.
+Example xml configuration:
+
+.. code-block:: xml
+ <object class="MicrodiffLightInOut">
+   <username>Back Light</username>
+   <exporter_address>wid30bmd:9001</exporter_address>
+   <value_channel_name>BackLightIsOn</value_channel_name>
+   <values>{"IN": True, "OUT": False}</values>
+   <state_channel_name>HardwareState</state_channel_name>
+ </object>
+"""
+import logging
+from mxcubecore import HardwareRepository as HWR
+from mxcubecore.HardwareObjects.ExporterNState import ExporterNState
+
+
+__copyright__ = """ Copyright © by the MXCuBE collaboration """
+__license__ = "LGPLv3+"
+
+
+class MicrodiffLightInOut(ExporterNState):
+    """MicrodiffAperture class"""
+
+    def _set_value(self, value):
+        """Set device to value
+        Args:
+            value (str, int, float or enum): Value to be set.
+        """
+        # first move the beamstop in our out
+        beamstop = HWR.beamline.diffractometer.beamstop
+        if value == self.VALUES.IN:
+            # set the beamstop off, if needed
+            if beamstop.get_value() == beamstop.VALUES.IN:
+                beamstop.set_value(beamstop.VALUES.OUT)
+        super()._set_value(value)

--- a/mxcubecore/HardwareObjects/XMLRPCServer.py
+++ b/mxcubecore/HardwareObjects/XMLRPCServer.py
@@ -441,7 +441,7 @@ class XMLRPCServer(HardwareObject):
     def save_twelve_snapshots_script(self, path):
         path = path[14:]  # NBNB: Temporary fix, to be addressed in calling code
         self.log.info("Taking 6 snapshots to be saved in  %s " % str(path))
-        HWR.beamline.diffractometer.run_script("Take6Snapshots, " + path)
+        HWR.beamline.diffractometer.run_custom_script("Take6Snapshots, " + path)
 
     def save_multiple_snapshots(self, path_list, show_scale=False):
         self.log.info("Taking snapshot %s " % str(path_list))

--- a/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
@@ -580,6 +580,11 @@ class AbstractMultiCollect(object):
         self.move_motors(motors_to_move_before_collect)
         HWR.beamline.diffractometer.save_centring_positions()
 
+        aperture_ho = HWR.beamline.beam.aperture
+
+        if aperture_ho:
+            aperture = HWR.beamline.beam.aperture.get_value()
+
         if data_collect_parameters.get("take_snapshots", False):
             logging.getLogger("user_level_log").info(
                 f"Taking sample ({self.number_of_snapshots}) snapshosts"
@@ -590,6 +595,10 @@ class AbstractMultiCollect(object):
         logging.getLogger("user_level_log").info(
             "Moving motors to centered position: %r", motors_to_move_before_collect
         )
+
+        if aperture_ho:
+            HWR.beamline.beam.aperture.set_value(aperture)
+
         self.move_motors(motors_to_move_before_collect)
 
         if HWR.beamline.lims:

--- a/mxcubecore/queue_entry/xray_centering2.py
+++ b/mxcubecore/queue_entry/xray_centering2.py
@@ -57,10 +57,10 @@ class XrayCentering2QueueEntry(BaseQueueEntry):
         if pos_dict:
             # Some beamlines move centering motors while moving kappa, kappa_phi
             # Hence we need to move kappa, kappa_phi first.
-            HWR.beamline.diffractometer.move_motors(pos_dict)
+            HWR.beamline.diffractometer.set_value_motors(pos_dict)
         if motor_positions:
             # Move the rest of the motors, if needed
-            HWR.beamline.diffractometer.move_motors(motor_positions)
+            HWR.beamline.diffractometer.set_value_motors(motor_positions)
 
         HWR.beamline.xray_centring.pre_execute(self)
 


### PR DESCRIPTION
This PR contains some changes necessary after the move to AbstractDiffractometer mostly concerning the split of diffractometer - sample view and method name changes:

   - run_script -> run_custom_script
   - move_motors -> set_value_motors
  
