### PR TITLE
Adding possibility to set end-station name

### DIFF
--- a/mxcubecore/HardwareObjects/ESRF/ESRFSession.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFSession.py
@@ -29,6 +29,16 @@ class ESRFSession(Session.Session):
                 archive_base_directory, archive_folder
             )
 
+    def set_endstation_name(self, name: str) -> None:
+        name = name.lower().replace("-", "")
+        name = {
+            "id231": "id23eh1",
+            "id232": "id23eh2",
+        }.get(name, name)
+
+        self.log.info(f"Setting end-station name to {name}")
+        self._endstation_name = name
+
     def get_full_paths(self, subdir: str, tag: str) -> Tuple[str, str]:
         """
         Returns the full path to both image and processed data.

--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -524,7 +524,18 @@ class ICATLIMS(AbstractLims):
                 "Session not found in the local list of sessions. session_id="
                 + session_id
             )
+
         self.session_manager.active_session = session_list[0]
+
+        self.use_set_endstation_name = self.get_property(
+            "use_set_endstation_name",
+            False,  # noqa: FBT003
+        )
+
+        if self.use_set_endstation_name:
+            HWR.beamline.session.set_endstation_name(
+                self.session_manager.active_session.beamline_name.lower()
+            )
 
         return self.session_manager.active_session
 

--- a/mxcubecore/HardwareObjects/Session.py
+++ b/mxcubecore/HardwareObjects/Session.py
@@ -52,7 +52,7 @@ class Session(HardwareObject):
     def endstation_name(self) -> str:
         return self._endstation_name
 
-    def set_endstation_name(self, name) -> None:
+    def set_endstation_name(self, name: str) -> None:
         self.log.info(f"Setting end-station name to {name}")
         self._endstation_name = name
 


### PR DESCRIPTION
Added the possibility to change the end station name, used when moving an experiment from one beamline to another.