### PR TITLE
Added the possiblity to use soft interlcok for n-state devices such as the back light

### DIFF
--- a/mxcubecore/HardwareObjects/ESRF/MD2MultiCollect.py
+++ b/mxcubecore/HardwareObjects/ESRF/MD2MultiCollect.py
@@ -70,6 +70,9 @@ class MD2MultiCollect(ESRFMultiCollect):
         diffr.frontlightswitch.set_value(diffr.frontlightswitch.VALUES.IN)
         # diffr.frontlight.set_value(2)
 
+        back_light_switch = diffr.get_object_by_role("BackLightSwitch")
+        back_light_switch.disable()
+
         # move to DataCollection phase
         logging.getLogger("user_level_log").info("Moving MD2 to DataCollection")
         # AB next line to speed up the data collection
@@ -79,6 +82,7 @@ class MD2MultiCollect(ESRFMultiCollect):
     def data_collection_cleanup(self):
         HWR.beamline.diffractometer.wait_status_ready(10)
         self.close_fast_shutter()
+        HWR.beamline.diffractometer.get_object_by_role("BackLightSwitch").enable()
 
     @task
     def oscil(self, start, end, exptime, number_of_images, wait=True):

--- a/mxcubecore/HardwareObjects/ESRF/MD2MultiCollect.py
+++ b/mxcubecore/HardwareObjects/ESRF/MD2MultiCollect.py
@@ -72,7 +72,7 @@ class MD2MultiCollect(ESRFMultiCollect):
 
         back_light_switch = diffr.get_object_by_role("BackLightSwitch")
         back_light_switch.disable()
-
+        diffr.backlightswitch.disable()
         # move to DataCollection phase
         logging.getLogger("user_level_log").info("Moving MD2 to DataCollection")
         # AB next line to speed up the data collection

--- a/mxcubecore/HardwareObjects/ESRF/MD2MultiCollect.py
+++ b/mxcubecore/HardwareObjects/ESRF/MD2MultiCollect.py
@@ -70,8 +70,6 @@ class MD2MultiCollect(ESRFMultiCollect):
         diffr.frontlightswitch.set_value(diffr.frontlightswitch.VALUES.IN)
         # diffr.frontlight.set_value(2)
 
-        back_light_switch = diffr.get_object_by_role("BackLightSwitch")
-        back_light_switch.disable()
         diffr.backlightswitch.disable()
         # move to DataCollection phase
         logging.getLogger("user_level_log").info("Moving MD2 to DataCollection")

--- a/mxcubecore/HardwareObjects/ESRF/MD2MultiCollect.py
+++ b/mxcubecore/HardwareObjects/ESRF/MD2MultiCollect.py
@@ -82,7 +82,7 @@ class MD2MultiCollect(ESRFMultiCollect):
     def data_collection_cleanup(self):
         HWR.beamline.diffractometer.wait_status_ready(10)
         self.close_fast_shutter()
-        HWR.beamline.diffractometer.get_object_by_role("BackLightSwitch").enable()
+        HWR.beamline.diffractometer.backlightswitch.enable()
 
     @task
     def oscil(self, start, end, exptime, number_of_images, wait=True):

--- a/mxcubecore/HardwareObjects/ExporterNState.py
+++ b/mxcubecore/HardwareObjects/ExporterNState.py
@@ -37,6 +37,9 @@ from gevent import (
     sleep,
 )
 
+import logging
+
+from mxcubecore import HardwareRepository as HWR
 from mxcubecore.Command.Exporter import Exporter
 from mxcubecore.Command.exporter.ExporterStates import ExporterStates
 from mxcubecore.HardwareObjects.abstract.AbstractNState import AbstractNState
@@ -157,6 +160,24 @@ class ExporterNState(AbstractNState):
         Args:
             value (str, int, float or enum): Value to be set.
         """
+
+        # Soft interlock for Microdiff DataCollection phase, prevents
+        # moving backlight IN during data collection
+        value_channel_name = self.get_property("value_channel_name")
+
+        if (
+            value_channel_name == "BackLightIsOn"
+            and HWR.beamline.diffractometer.get_current_phase() == "DataCollection"
+            and value == self.VALUES.IN
+        ):
+            logging.getLogger("user_level_log").exception(
+                (
+                    "MicroDiff: MXCuBE Soft interlock, cannot move backlight while in"
+                    " DataCollection phase"
+                )
+            )
+            return
+
         # NB Workaround because diffractomer does not send event on
         # change of actuators (light, scintillator, cryostream...)
         self.update_state(self.STATES.BUSY)

--- a/mxcubecore/HardwareObjects/ExporterNState.py
+++ b/mxcubecore/HardwareObjects/ExporterNState.py
@@ -30,6 +30,7 @@ Example xml file:
 </object>
 """
 
+import logging
 from enum import Enum
 
 from gevent import (
@@ -37,9 +38,6 @@ from gevent import (
     sleep,
 )
 
-import logging
-
-from mxcubecore import HardwareRepository as HWR
 from mxcubecore.Command.Exporter import Exporter
 from mxcubecore.Command.exporter.ExporterStates import ExporterStates
 from mxcubecore.HardwareObjects.abstract.AbstractNState import AbstractNState
@@ -59,6 +57,7 @@ class ExporterNState(AbstractNState):
         self.value_channel = None
         self.state_channel = None
         self.use_value_as_state = None
+        self._disabled = False
 
     def init(self):
         """Initialise the device"""
@@ -93,6 +92,12 @@ class ExporterNState(AbstractNState):
 
         self.state_channel.connect_signal("update", self._update_state)
         self.update_state()
+
+    def disable(self):
+        self._disabled = True
+
+    def enable(self):
+        self._disabled = False
 
     def _wait_hardware(self, value, timeout=None):
         """Wait timeout seconds till hardware in place.
@@ -163,13 +168,9 @@ class ExporterNState(AbstractNState):
 
         # Soft interlock for Microdiff DataCollection phase, prevents
         # moving backlight IN during data collection
-        value_channel_name = self.get_property("value_channel_name")
+        self.get_property("value_channel_name")
 
-        if (
-            value_channel_name == "BackLightIsOn"
-            and HWR.beamline.diffractometer.get_current_phase() == "DataCollection"
-            and value == self.VALUES.IN
-        ):
+        if self._disabled:
             logging.getLogger("user_level_log").exception(
                 (
                     "MicroDiff: MXCuBE Soft interlock, cannot move backlight while in"

--- a/mxcubecore/HardwareObjects/Microdiff.py
+++ b/mxcubecore/HardwareObjects/Microdiff.py
@@ -594,11 +594,6 @@ class Microdiff(MiniDiff.MiniDiff):
 
         current_phase = self.get_current_phase()
 
-        if current_phase == phase:
-            msg = f"Already in {current_phase}, not moving"
-            logging.getLogger("user_level_log").info(msg)
-            return
-
         msg = f"Current phase is {current_phase} and moving to {phase}"
         logging.getLogger("user_level_log").info(msg)
 


### PR DESCRIPTION
The MD does not interlock the back-light in data collection phase which allows the user to move the back light in while collecting.

This PR adds a simple why of disabling a n-state device such as a backlight so that it can be enabled/disabled during data collection.