### PR TITLE
[ESRFSession] - Removed check that will always end up with an exception

### DIFF
--- a/mxcubecore/HardwareObjects/ESRF/ESRFSession.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFSession.py
@@ -1,5 +1,4 @@
 import glob
-import logging
 import os
 import time
 from pathlib import Path
@@ -56,11 +55,6 @@ class ESRFSession(Session.Session):
         """
         subdir = Path(self._sanitize_subdir(subdir))
 
-        if not subdir.is_relative_to(self.get_base_image_directory()):
-            error_message = "Invalid subdirectory"
-            logging.getLogger("user_level_log").error(error_message)
-            raise PermissionError(error_message)
-
         folders = glob.glob(
             os.path.join(self.get_base_image_directory(), subdir) + "/run*"
         )
@@ -89,11 +83,6 @@ class ESRFSession(Session.Session):
         full_path = os.path.join(
             self.get_base_image_directory(), subdir, f"run_{run_num:02d}_{tag}/"
         )
-
-        if not subdir.is_relative_to(self.get_base_process_directory()):
-            error_message = "Invalid subdirectory"
-            logging.getLogger("user_level_log").error(error_message)
-            raise PermissionError(error_message)
 
         process_path = os.path.join(
             self.get_base_process_directory(), subdir, f"run_{run_num:02d}_{tag}/"


### PR DESCRIPTION
Removed fix that will always end up with an exception. The statement `subdir.is_relative_to(self.get_base_image_directory()):` will always raise as `subdir` is simply a string without the root/base `directory`