### PR TITLE
Removing obsolete dict for resolution - upper and lower values

### DIFF
--- a/mxcubecore/HardwareObjects/Gphl/CollectEmulator.py
+++ b/mxcubecore/HardwareObjects/Gphl/CollectEmulator.py
@@ -155,12 +155,9 @@ class CollectEmulator(CollectMockup):
         # get resolution limit and detector distance
         detector_distance = data_collect_parameters.get("detector_distance", 0.0)
         if not detector_distance:
-            dd = data_collect_parameters.get("resolution")
-            # resolution may not be set - if so you should take the current value
-            if dd:
-                resolution = dd.get("upper")
-                if resolution:
-                    self.set_resolution(resolution)
+            resolution = data_collect_parameters.get("resolution")
+            if resolution:
+                self.set_resolution(resolution)
             detector_distance = HWR.beamline.detector.distance.get_value()
         # Add sweeps
         sweeps = []

--- a/mxcubecore/HardwareObjects/abstract/AbstractCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractCollect.py
@@ -236,7 +236,7 @@ class AbstractCollect(HardwareObject, object):
             energy = self.current_dc_parameters.get("energy")
             detector_distance = self.current_dc_parameters.get("detector_distance")
             try:
-                resolution = self.current_dc_parameters.get("resolution").get("upper")
+                resolution = self.current_dc_parameters.get("resolution")
             except AttributeError:
                 resolution = None
 

--- a/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
@@ -764,7 +764,7 @@ class AbstractMultiCollect(object):
                 raise
 
         if "resolution" in data_collect_parameters:
-            resolution = data_collect_parameters["resolution"]["upper"]
+            resolution = data_collect_parameters["resolution"]
             logging.getLogger("user_level_log").info(
                 "Setting resolution to %f", resolution
             )

--- a/mxcubecore/HardwareObjects/abstract/ISPyBValueFactory.py
+++ b/mxcubecore/HardwareObjects/abstract/ISPyBValueFactory.py
@@ -248,15 +248,10 @@ class ISPyBValueFactory:
 
         res_at_edge = None
         try:
-            try:
-                res_at_edge = float(mx_collect_dict["resolution"])
-            except Exception:
-                res_at_edge = float(mx_collect_dict["resolution"]["lower"])
+            res_at_edge = float(mx_collect_dict["resolution"])
         except KeyError:
-            try:
-                res_at_edge = float(mx_collect_dict["resolution"]["upper"])
-            except Exception:
-                pass
+            res_at_edge = None
+
         if res_at_edge is not None:
             data_collection.resolution = res_at_edge
 

--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -2722,7 +2722,7 @@ def to_collect_dict(data_collection, sample, centred_pos=None):
             "residues": proc_params.num_residues,
             "dark": acq_params.take_dark_current,
             "detector_distance": acq_params.detector_distance,
-            "resolution": {"upper": acq_params.resolution or 0.0},
+            "resolution": acq_params.resolution or None,
             "transmission": acq_params.transmission,
             "energy": acq_params.energy,
             "oscillation_sequence": [
@@ -2768,7 +2768,7 @@ def to_collect_dict(data_collection, sample, centred_pos=None):
         if tag in dd and not dd[tag]:
             del dd[tag]
     resolution = dd.get("resolution")
-    if resolution is not None and not resolution.get("upper"):
+    if resolution is not None:
         del dd["resolution"]
     return result
 


### PR DESCRIPTION
The resolution values have for historical reasons been passed in a dictionary with the following format

```
{
"upper": x,
"lower": y,
}
```

However, in practice only `data_collect_parameters["resolution"]["upper"]` is used. Replacing all occurrences of `["upper"]` or similair with  `data_collect_parameters["resolution"]`

closes #1565 