### PR TITLE
Make ICATLIMS work for both Generic and Abstract Diffractometer

### DIFF
--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -1240,14 +1240,16 @@ class ICATLIMS(AbstractLims):
             proposal = f"{HWR.beamline.session.proposal_code}"
             proposal += f"{HWR.beamline.session.proposal_number}"
 
-            diffractometer_hwobj = HWR.beamline.diffractometer
-            motor_positions = diffractometer_hwobj.get_positions()
-            if "kappa" in motor_positions:
-                kappa_pos = round(float(motor_positions["kappa"]), 1)
-                kappa_phi_pos = round(float(motor_positions["kappa_phi"]), 1)
-                mx_kappa_settings_id = f"Kappa: {kappa_pos}, Phi: {kappa_phi_pos}"
-            else:
-                mx_kappa_settings_id = None
+            mx_kappa_settings_id = None
+            diffr = HWR.beamline.diffractometer
+            kappa_pos = diffr.kappa.get_value() if hasattr(diffr, "kappa") else None
+            kappa_phi_pos = (
+                diffr.kappa_phi.get_value() if hasattr(diffr, "kappa_phi") else None
+            )
+            if kappa_pos and kappa_phi_pos:
+                mx_kappa_settings_id = (
+                    f"Kappa: {kappa_pos:0.1f}, Phi: {kappa_phi_pos:0.1f}"
+                )
 
             metadata.update(
                 {


### PR DESCRIPTION
Remove the get_positions call and replace it by get_values for the kappa and kappa_phi motors.