### PR TITLE
Always sending the diffraction plan to the client even if `auto_add_diff_plan=True`.

### DIFF
--- a/mxcubecore/HardwareObjects/EDNACharacterisation.py
+++ b/mxcubecore/HardwareObjects/EDNACharacterisation.py
@@ -81,7 +81,12 @@ class EDNACharacterisation(AbstractCharacterisation):
         self.characterisationResult = None
         args = (self.start_edna_command, input_file, results_file, process_directory)
         # subprocess.call("%s %s %s %s" % args, shell=True)
-        p = subprocess.Popen("%s %s %s %s --verbose --debug" % args, shell=True)
+        p = subprocess.Popen(
+            "%s %s %s %s --verbose --debug" % args,
+            shell=True,
+            stdin=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
 
         do_continue = True
         self.result = None

--- a/mxcubecore/queue_entry/characterisation.py
+++ b/mxcubecore/queue_entry/characterisation.py
@@ -175,15 +175,18 @@ class CharacterisationQueueEntry(BaseQueueEntry):
                     if collection_plan:
                         if char.auto_add_diff_plan:
                             # default action
-                            self.handle_diffraction_plan(self.edna_result, None)
+                            collections = self.handle_diffraction_plan(
+                                self.edna_result, None
+                            )
                         else:
                             collections = HWR.beamline.characterisation.dc_from_output(
                                 self.edna_result, char.reference_image_collection
                             )
-                            char.diffraction_plan.append(collections)
-                            HWR.beamline.queue_model.emit(
-                                "diff_plan_available", (char, collections)
-                            )
+
+                        char.diffraction_plan.append(collections)
+                        HWR.beamline.queue_model.emit(
+                            "diff_plan_available", (char, collections)
+                        )
 
                         self.get_view().setText(1, "Done")
                     else:
@@ -225,7 +228,6 @@ class CharacterisationQueueEntry(BaseQueueEntry):
             path_template = edna_dc.acquisitions[0].path_template
             run_number = HWR.beamline.queue_model.get_next_run_number(path_template)
             path_template.run_number = run_number
-            path_template.compression = char.diff_plan_compression
 
             edna_dc.set_enabled(char.run_diffraction_plan)
             edna_dc.set_name(path_template.get_prefix())


### PR DESCRIPTION
The characterization result is currently never sent to the client of `auto_add_diff_plan=True` which can be a bit confusing. Now we are both sending the results for manual addition and automatically adding a data collection corresponding to the results.