### PR TITLE
Replaced 'overlap' with '-offset'. First pass

### DIFF
--- a/mxcubecore/HardwareObjects/ESRF/BlissMultiCollect.py
+++ b/mxcubecore/HardwareObjects/ESRF/BlissMultiCollect.py
@@ -82,7 +82,7 @@ class BlissMultiCollect(ESRFMultiCollect):
             oscillation_parameters["number_of_images"],
             oscillation_parameters["range"],
             subwedge_size,
-            oscillation_parameters["overlap"],
+            oscillation_parameters["offset"],
         )
 
         run_number = data_collect_parameters["fileinfo"]["run_number"]

--- a/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
+++ b/mxcubecore/HardwareObjects/Gphl/GphlWorkflow.py
@@ -2327,9 +2327,9 @@ class GphlWorkflow(HardwareObject):
                 acq_parameters.num_images_per_trigger = acq_parameters.num_images
                 acq_parameters.num_images *= scan_count
                 # NB this assumes sweepOffset is the offset between starting points
-                acq_parameters.overlap = (
-                    acq_parameters.num_images_per_trigger * acq_parameters.osc_range
-                    - sweep_offset
+                acq_parameters.offset = (
+                    sweep_offset
+                    - acq_parameters.num_images_per_trigger * acq_parameters.osc_range
                 )
             data_collection = queue_model_objects.DataCollection([acq], crystal)
             # Workflow parameters for ICAT / external workflow

--- a/mxcubecore/HardwareObjects/SOLEIL/PX2/PX2Collect.py
+++ b/mxcubecore/HardwareObjects/SOLEIL/PX2/PX2Collect.py
@@ -318,8 +318,7 @@ class PX2Collect(AbstractCollect, HardwareObject):
                 self.store_image_in_lims_by_frame_num(last_frame)
             if (
                 self.current_dc_parameters["experiment_type"] in ("OSC", "Helical")
-                and self.current_dc_parameters["oscillation_sequence"][0]["offset"]
-                == 0
+                and self.current_dc_parameters["oscillation_sequence"][0]["offset"] == 0
                 and last_frame > 19
             ):
                 self.trigger_auto_processing("after", self.current_dc_parameters, 0)

--- a/mxcubecore/HardwareObjects/SOLEIL/PX2/PX2Collect.py
+++ b/mxcubecore/HardwareObjects/SOLEIL/PX2/PX2Collect.py
@@ -138,29 +138,20 @@ class PX2Collect(AbstractCollect, HardwareObject):
 
         osc_seq = parameters["oscillation_sequence"][0]
         fileinfo = parameters["fileinfo"]
-        sample_reference = parameters["sample_reference"]
         experiment_type = parameters["experiment_type"]
         energy = parameters["energy"]
         transmission = parameters["transmission"]
         resolution = parameters["resolution"]
 
         exposure_time = osc_seq["exposure_time"]
-        in_queue = parameters["in_queue"] != False
 
-        overlap = osc_seq["overlap"]
         angle_per_frame = osc_seq["range"]
         scan_start_angle = osc_seq["start"]
         number_of_images = osc_seq["number_of_images"]
         image_nr_start = osc_seq["start_image_number"]
 
         directory = fileinfo["directory"]
-        prefix = fileinfo["prefix"]
         template = fileinfo["template"]
-        run_number = fileinfo["run_number"]
-        process_directory = fileinfo["process_directory"]
-
-        # space_group = str(sample_reference['space_group'])
-        # unit_cell = list(eval(sample_reference['cell']))
 
         self.emit("collectStarted", (self.owner, 1))
         self.emit("progressInit", ("Data collection", 100))
@@ -191,14 +182,14 @@ class PX2Collect(AbstractCollect, HardwareObject):
         elif experiment_type == "Characterization":
             number_of_wedges = osc_seq["number_of_images"]
             wedge_size = osc_seq["wedge_size"]
-            overlap = osc_seq["overlap"]
+            offset = osc_seq["offset"]
             scan_start_angles = []
             scan_exposure_time = exposure_time * wedge_size
             scan_range = angle_per_frame * wedge_size
 
             for k in range(number_of_wedges):
                 scan_start_angles.append(
-                    scan_start_angle + k * -overlap + k * scan_range
+                    scan_start_angle + k * offset + k * scan_range
                 )
 
             experiment = reference_images(
@@ -267,22 +258,6 @@ class PX2Collect(AbstractCollect, HardwareObject):
             )
             experiment.execute()
 
-        # for image in range(number_of_images):
-        # if self.aborted_by_user:
-        # self.ready_event.set()
-        # return
-
-        # Uncomment to test collection failed
-        # if image == 5:
-        # self.emit("collectOscillationFailed", (self.owner, False,
-        # "Failed on 5", parameters.get("collection_id")))
-        # self.ready_event.set()
-        # return
-
-        # gevent.sleep(exposure_time)
-        # self.emit("collectImageTaken", image)
-        # self.emit("progressStep", (int(float(image) / number_of_images * 100)))
-
         self.emit_collection_finished()
 
     def translate_position(self, position):
@@ -343,7 +318,7 @@ class PX2Collect(AbstractCollect, HardwareObject):
                 self.store_image_in_lims_by_frame_num(last_frame)
             if (
                 self.current_dc_parameters["experiment_type"] in ("OSC", "Helical")
-                and self.current_dc_parameters["oscillation_sequence"][0]["overlap"]
+                and self.current_dc_parameters["oscillation_sequence"][0]["offset"]
                 == 0
                 and last_frame > 19
             ):

--- a/mxcubecore/HardwareObjects/SOLEIL/PX2/PX2Collect.py
+++ b/mxcubecore/HardwareObjects/SOLEIL/PX2/PX2Collect.py
@@ -188,9 +188,7 @@ class PX2Collect(AbstractCollect, HardwareObject):
             scan_range = angle_per_frame * wedge_size
 
             for k in range(number_of_wedges):
-                scan_start_angles.append(
-                    scan_start_angle + k * offset + k * scan_range
-                )
+                scan_start_angles.append(scan_start_angle + k * offset + k * scan_range)
 
             experiment = reference_images(
                 name_pattern,

--- a/mxcubecore/HardwareObjects/SOLEIL/PX2/PX2Collect.py
+++ b/mxcubecore/HardwareObjects/SOLEIL/PX2/PX2Collect.py
@@ -138,12 +138,14 @@ class PX2Collect(AbstractCollect, HardwareObject):
 
         osc_seq = parameters["oscillation_sequence"][0]
         fileinfo = parameters["fileinfo"]
+        sample_reference = parameters["sample_reference"]
         experiment_type = parameters["experiment_type"]
         energy = parameters["energy"]
         transmission = parameters["transmission"]
         resolution = parameters["resolution"]
 
         exposure_time = osc_seq["exposure_time"]
+        in_queue = parameters["in_queue"] != False
 
         angle_per_frame = osc_seq["range"]
         scan_start_angle = osc_seq["start"]
@@ -151,7 +153,13 @@ class PX2Collect(AbstractCollect, HardwareObject):
         image_nr_start = osc_seq["start_image_number"]
 
         directory = fileinfo["directory"]
+        prefix = fileinfo["prefix"]
         template = fileinfo["template"]
+        run_number = fileinfo["run_number"]
+        process_directory = fileinfo["process_directory"]
+
+        # space_group = str(sample_reference['space_group'])
+        # unit_cell = list(eval(sample_reference['cell']))
 
         self.emit("collectStarted", (self.owner, 1))
         self.emit("progressInit", ("Data collection", 100))

--- a/mxcubecore/HardwareObjects/abstract/AbstractCharacterisation.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractCharacterisation.py
@@ -74,7 +74,7 @@ class AbstractCharacterisation(HardwareObject):
                 'num_images',
                 'osc_start',
                 'osc_range',
-                'overlap',
+                'offset',
                 'exp_time',
                 'num_passes',
                 'comments',

--- a/mxcubecore/HardwareObjects/abstract/AbstractCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractCollect.py
@@ -351,8 +351,7 @@ class AbstractCollect(HardwareObject, object):
                 self.store_image_in_lims_by_frame_num(last_frame)
             if (
                 self.current_dc_parameters["experiment_type"] in ("OSC", "Helical")
-                and self.current_dc_parameters["oscillation_sequence"][0]["offset"]
-                == 0
+                and self.current_dc_parameters["oscillation_sequence"][0]["offset"] == 0
                 and last_frame > 19
             ):
                 self.trigger_auto_processing("after", 0)

--- a/mxcubecore/HardwareObjects/abstract/AbstractCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractCollect.py
@@ -351,7 +351,7 @@ class AbstractCollect(HardwareObject, object):
                 self.store_image_in_lims_by_frame_num(last_frame)
             if (
                 self.current_dc_parameters["experiment_type"] in ("OSC", "Helical")
-                and self.current_dc_parameters["oscillation_sequence"][0]["overlap"]
+                and self.current_dc_parameters["oscillation_sequence"][0]["offset"]
                 == 0
                 and last_frame > 19
             ):

--- a/mxcubecore/HardwareObjects/abstract/AbstractLims.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractLims.py
@@ -300,7 +300,7 @@ class AbstractLims(HardwareObject, abc.ABC):
             "oscillation_sequence":[{}
                 "start": float,
                 "range": float,
-                "overlap": float,
+                "offset": float,
                 "number_of_images": float,
                 "start_image_number": float
                 "exposure_time", float,

--- a/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
@@ -356,9 +356,9 @@ class AbstractMultiCollect(object):
         pass
 
     def prepare_wedges_to_collect(
-        self, start, nframes, osc_range, subwedge_size=1, overlap=0
+        self, start, nframes, osc_range, subwedge_size=1, offset=0
     ):
-        if overlap == 0:
+        if offset == 0:
             wedge_sizes_list = [nframes // subwedge_size] * subwedge_size
         else:
             wedge_sizes_list = [subwedge_size] * (nframes // subwedge_size)
@@ -370,7 +370,7 @@ class AbstractMultiCollect(object):
 
         for wedge_size in wedge_sizes_list:
             wedges_to_collect.append((start, wedge_size))
-            start += wedge_size * osc_range - overlap
+            start += wedge_size * osc_range + offset
 
         return wedges_to_collect
 
@@ -685,7 +685,7 @@ class AbstractMultiCollect(object):
             oscillation_parameters["number_of_images"],
             oscillation_parameters["range"],
             subwedge_size,
-            oscillation_parameters["overlap"],
+            oscillation_parameters["offset"],
         )
         nframes = sum([wedge_size for _, wedge_size in wedges_to_collect])
 

--- a/mxcubecore/HardwareObjects/abstract/ISPyBValueFactory.py
+++ b/mxcubecore/HardwareObjects/abstract/ISPyBValueFactory.py
@@ -209,7 +209,7 @@ class ISPyBValueFactory:
             ) * float(osc_seq["number_of_images"])
 
             data_collection.axisRange = osc_seq["range"]
-            data_collection.offset = osc_seq["offset"]
+            data_collection.overlap = -osc_seq["offset"]
             data_collection.numberOfImages = osc_seq["number_of_images"]
             data_collection.startImageNumber = osc_seq["start_image_number"]
             data_collection.numberOfPasses = osc_seq["number_of_passes"]

--- a/mxcubecore/HardwareObjects/abstract/ISPyBValueFactory.py
+++ b/mxcubecore/HardwareObjects/abstract/ISPyBValueFactory.py
@@ -205,11 +205,11 @@ class ISPyBValueFactory:
             data_collection.axisStart = osc_seq["start"]
 
             data_collection.axisEnd = float(osc_seq["start"]) + (
-                float(osc_seq["range"]) - float(osc_seq["overlap"])
+                float(osc_seq["range"]) + float(osc_seq["offset"])
             ) * float(osc_seq["number_of_images"])
 
             data_collection.axisRange = osc_seq["range"]
-            data_collection.overlap = osc_seq["overlap"]
+            data_collection.offset = osc_seq["offset"]
             data_collection.numberOfImages = osc_seq["number_of_images"]
             data_collection.startImageNumber = osc_seq["start_image_number"]
             data_collection.numberOfPasses = osc_seq["number_of_passes"]

--- a/mxcubecore/HardwareObjects/mockup/CollectMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/CollectMockup.py
@@ -93,8 +93,7 @@ class CollectMockup(AbstractCollect):
                 self.store_image_in_lims_by_frame_num(last_frame)
             if (
                 self.current_dc_parameters["experiment_type"] in ("OSC", "Helical")
-                and self.current_dc_parameters["oscillation_sequence"][0]["offset"]
-                == 0
+                and self.current_dc_parameters["oscillation_sequence"][0]["offset"] == 0
                 and last_frame > 19
             ):
                 self.trigger_auto_processing("after", 0)

--- a/mxcubecore/HardwareObjects/mockup/CollectMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/CollectMockup.py
@@ -93,7 +93,7 @@ class CollectMockup(AbstractCollect):
                 self.store_image_in_lims_by_frame_num(last_frame)
             if (
                 self.current_dc_parameters["experiment_type"] in ("OSC", "Helical")
-                and self.current_dc_parameters["oscillation_sequence"][0]["overlap"]
+                and self.current_dc_parameters["oscillation_sequence"][0]["offset"]
                 == 0
                 and last_frame > 19
             ):

--- a/mxcubecore/model/common.py
+++ b/mxcubecore/model/common.py
@@ -27,6 +27,7 @@ class LegacyParameters(BaseModel):
     take_dark_current: int
     inverse_beam: bool
     num_passes: int
+    offset: float
 
     class Config:
         extra = "ignore"

--- a/mxcubecore/model/common.py
+++ b/mxcubecore/model/common.py
@@ -27,7 +27,6 @@ class LegacyParameters(BaseModel):
     take_dark_current: int
     inverse_beam: bool
     num_passes: int
-    overlap: float
 
     class Config:
         extra = "ignore"

--- a/mxcubecore/model/queue_model_objects.py
+++ b/mxcubecore/model/queue_model_objects.py
@@ -1686,7 +1686,7 @@ class AcquisitionParameters(object):
         self.osc_start = float()
         self.osc_range = float()
         self.osc_total_range = float()
-        self.overlap = float()
+        self.offset = float()
         self.kappa = float()
         self.kappa_phi = float()
         self.exp_time = float()
@@ -1737,7 +1737,7 @@ class AcquisitionParameters(object):
             "osc_start": self.osc_start,
             "osc_range": self.osc_range,
             "osc_total_range": self.osc_total_range,
-            "overlap": self.overlap,
+            "offset": self.offset,
             "kappa": self.kappa,
             "kappa_phi": self.kappa_phi,
             "exp_time": self.exp_time,
@@ -2684,7 +2684,7 @@ def to_collect_dict(data_collection, sample, centred_pos=None):
                                     'phiStart': 0.0,
                                     'start_image_number': 1,
                                     'number_of_images': 1,
-                                    'overlap': 0.0,
+                                    'offset': 0.0,
                                     'start': 0.0,
                                     'range': 1.0,
                                     'number_of_passes': 1}],
@@ -2744,7 +2744,7 @@ def to_collect_dict(data_collection, sample, centred_pos=None):
                     "phiStart": acq_params.kappa_phi,
                     "start_image_number": acq_params.first_image,
                     "number_of_images": acq_params.num_images,
-                    "overlap": acq_params.overlap,
+                    "offset": acq_params.offset,
                     "start": acq_params.osc_start,
                     "range": acq_params.osc_range,
                     "number_of_passes": acq_params.num_passes,


### PR DESCRIPTION
This is a first pass of replacing overlap with o0ffset, essentially a renaming and taking offset == -overlap.
The following files have been skipped as being probably coupled to code outside MXCuBE:
EMBLCollect, EMBLXrayImaging, ESRFMetadataManagerClient, ICATLIMS, XSDataMXCuBEv1_3, XSDataMXCuBEv1_4, XSDataMXv1.
The EMBL files coudl likely be ignored until such a time as P14 again cyncs back to the mainstream, but the rest of these files would have to be addressed by someone who understands them before we move ahead with the PR. 

The rest shoudl not be a problem:

Config files for embl-hh and config files in mxcubecore.configuration have also been skipped.
Changes in configuration files should be simple to carry out, but as the config files in the repositories have little connection to the ones actually in use it seemed simpler to leave those changes to the individual beamlines.

There should maybe be a consequential change in MXLIMS as well, but I can handle that easily enough.