### PR TITLE
Implement LNLSCamera

### DIFF
--- a/mxcubecore/HardwareObjects/LNLS/LNLSCamera.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSCamera.py
@@ -17,6 +17,7 @@ class LNLSCamera(HardwareObject):
         height: 1024
         scale: 1
     """
+
     def init(self):
         super().init()
         self.stream_hash = ""

--- a/mxcubecore/HardwareObjects/LNLS/LNLSCamera.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSCamera.py
@@ -1,0 +1,38 @@
+from mxcubecore.BaseHardwareObjects import HardwareObject
+
+
+class LNLSCamera(HardwareObject):
+    """
+    A class for LNLS camera. Video streaming is configured
+    outside of mxcube.
+
+    YAML Example
+    ------------
+
+    %YAML 1.2
+    ---
+    class: LNLS.LNLSCamera.LNLSCamera
+    configuration:
+        width: 1280
+        height: 1024
+        scale: 1
+    """
+    def init(self):
+        super().init()
+        self.stream_hash = ""
+        self._current_stream_size = (0, 0)
+        self.width = self.get_property("width", 0)
+        self.height = self.get_property("height", 0)
+        self.scale = self.get_property("scale", 1)
+
+    def get_width(self) -> int:
+        return self.width
+
+    def get_height(self) -> int:
+        return self.height
+
+    def get_available_stream_sizes(self):
+        return []
+
+    def get_stream_size(self):
+        return (self.width, self.height, self.scale)


### PR DESCRIPTION
This PR Implements LNLSCamera class. We stream the camera content from outside of mxcube using https://github.com/mxcube/video-streamer and define the IP with VIDEO_STREAM_URL and VIDEO_STREAM_FORMAT at server.yaml.
We are currently working on a new video-streamer camera class that works for EPICS (https://github.com/cnpem/mxcube-video-streamer/pull/1), and we should create a PR for the official repo when its ready.