### PR TITLE
Implement LNLSSampleChanger and LNLSBeamlineActions

### DIFF
--- a/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSActuator.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSActuator.py
@@ -158,11 +158,13 @@ class LNLSEnergy(AbstractEnergy, EPICSActuatorBluesky):
 
     pass
 
+
 class EPICSRestrictedMovement:
     """
     This class is meant for devices that should not move while
     the LNLSStaubli is moving.
     """
+
     def init(self):
         super().init()
         self.sc = HWR.beamline.get_object_by_role("sample_changer")

--- a/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSActuator.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSActuator.py
@@ -7,6 +7,7 @@ import numpy as np
 from mxcubecore import HardwareRepository as HWR
 from mxcubecore.HardwareObjects.abstract.AbstractActuator import AbstractActuator
 from mxcubecore.HardwareObjects.abstract.AbstractEnergy import AbstractEnergy
+from mxcubecore.HardwareObjects.abstract.AbstractSampleChanger import SampleChangerState
 
 
 class EPICSActuator(AbstractActuator):
@@ -155,4 +156,22 @@ class LNLSEnergy(AbstractEnergy, EPICSActuatorBluesky):
     default_lim
     """
 
+    pass
+
+class EPICSRestrictedMovement:
+    """
+    This class is meant for devices that should not move while
+    the LNLSStaubli is moving.
+    """
+    def init(self):
+        super().init()
+        self.sc = HWR.beamline.get_object_by_role("sample_changer")
+
+    def set_value(self, value, timeout: float = 0):
+        if self.sc.get_state() != SampleChangerState.Ready:
+            return
+        super().set_value(value, timeout)
+
+
+class LNLSRestrictedActuator(EPICSRestrictedMovement, EPICSActuator):
     pass

--- a/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSMotor.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSMotor.py
@@ -4,7 +4,10 @@ from typing import Optional
 import gevent
 
 from mxcubecore.HardwareObjects.abstract.AbstractMotor import AbstractMotor
-from mxcubecore.HardwareObjects.LNLS.EPICS.EPICSActuator import EPICSActuator, EPICSRestrictedMovement
+from mxcubecore.HardwareObjects.LNLS.EPICS.EPICSActuator import (
+    EPICSActuator,
+    EPICSRestrictedMovement,
+)
 
 
 class EPICSMotor(EPICSActuator, AbstractMotor):
@@ -163,6 +166,7 @@ class ResolutionVirtualMotor(EPICSMotor):
 
 class LNLSRestrictedMotor(EPICSRestrictedMovement, EPICSMotor):
     pass
+
 
 class LNLSRestrictedMotorDetachable(EPICSRestrictedMovement, EPICSMotorDetachable):
     pass

--- a/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSMotor.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSMotor.py
@@ -4,7 +4,7 @@ from typing import Optional
 import gevent
 
 from mxcubecore.HardwareObjects.abstract.AbstractMotor import AbstractMotor
-from mxcubecore.HardwareObjects.LNLS.EPICS.EPICSActuator import EPICSActuator
+from mxcubecore.HardwareObjects.LNLS.EPICS.EPICSActuator import EPICSActuator, EPICSRestrictedMovement
 
 
 class EPICSMotor(EPICSActuator, AbstractMotor):
@@ -131,10 +131,13 @@ class EPICSMotorDetachable(EPICSMotor):
         super().init()
         self.get_value()
 
-    def get_value(self):
+    def check_is_absent(self):
         value = self.get_property("is_absent_value")
         current_value = int(self.get_channel_value(self.MOTOR_PRESENCE_RBV))
-        if current_value == value:
+        return current_value == value
+
+    def get_value(self):
+        if self.check_is_absent():
             self.update_state(self.STATES.OFF)
         return super().get_value()
 
@@ -156,3 +159,10 @@ class ResolutionVirtualMotor(EPICSMotor):
 
     def get_limits_for_wavelength(self, wavelength):
         return self.get_limits()
+
+
+class LNLSRestrictedMotor(EPICSRestrictedMovement, EPICSMotor):
+    pass
+
+class LNLSRestrictedMotorDetachable(EPICSRestrictedMovement, EPICSMotorDetachable):
+    pass

--- a/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSNState.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSNState.py
@@ -4,7 +4,10 @@ from mxcubecore.HardwareObjects.abstract.AbstractNState import (
     AbstractNState,
     BaseValueEnum,
 )
-from mxcubecore.HardwareObjects.LNLS.EPICS.EPICSActuator import EPICSActuator, EPICSRestrictedMovement
+from mxcubecore.HardwareObjects.LNLS.EPICS.EPICSActuator import (
+    EPICSActuator,
+    EPICSRestrictedMovement,
+)
 
 
 class EPICSNState(EPICSActuator, AbstractNState):
@@ -158,6 +161,7 @@ class EPICSToggle(EPICSNState):
 
 class LNLSRestrictedNState(EPICSRestrictedMovement, EPICSNState):
     pass
+
 
 class LNLSRestrictedNStateInterval(EPICSRestrictedMovement, EPICSNStateInterval):
     pass

--- a/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSNState.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSNState.py
@@ -4,7 +4,7 @@ from mxcubecore.HardwareObjects.abstract.AbstractNState import (
     AbstractNState,
     BaseValueEnum,
 )
-from mxcubecore.HardwareObjects.LNLS.EPICS.EPICSActuator import EPICSActuator
+from mxcubecore.HardwareObjects.LNLS.EPICS.EPICSActuator import EPICSActuator, EPICSRestrictedMovement
 
 
 class EPICSNState(EPICSActuator, AbstractNState):
@@ -154,3 +154,10 @@ class EPICSToggle(EPICSNState):
 
     def _set_value(self, value):  # noqa: ARG002
         super()._set_value(self.input_value)
+
+
+class LNLSRestrictedNState(EPICSRestrictedMovement, EPICSNState):
+    pass
+
+class LNLSRestrictedNStateInterval(EPICSRestrictedMovement, EPICSNStateInterval):
+    pass

--- a/mxcubecore/HardwareObjects/LNLS/LNLSBeamlineActions.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSBeamlineActions.py
@@ -1,0 +1,139 @@
+from mxcubecore import HardwareRepository as HWR
+from mxcubecore.BaseHardwareObjects import HardwareObjectState
+from mxcubecore.HardwareObjects.abstract import AbstractSampleChanger
+from mxcubecore.HardwareObjects.BeamlineActions import BeamlineActions
+
+class LNLSBaseAction:
+    """
+    Base class for both LNLSBeamlineActions and LNLSSampleChangerAction
+    """
+    def __init__(self):
+        self._bluesky_api = HWR.beamline.get_object_by_role("bluesky")
+        self.sc = HWR.beamline.get_object_by_role("sample_changer")
+        self.diffractometer = HWR.beamline.get_object_by_role("diffractometer")
+        self.STATES = HardwareObjectState
+        self.ROBOT_READY = AbstractSampleChanger.SampleChangerState.Ready
+        self.ROBOT_MOVING = AbstractSampleChanger.SampleChangerState.Moving
+
+    def update_diffractometer_states(self, state_value):
+        """
+        Turn off all motors while robot is moving
+        Make them ready again if robot is ready
+        """
+        d = self.diffractometer
+
+        if not d.kappa.check_is_absent():
+            d.kappa.update_state(state_value)
+
+        if not d.kappa_phi.check_is_absent():
+            d.kappa_phi.update_state(state_value)
+
+        d.omega.update_state(state_value)
+        d.phiy.update_state(state_value)
+        d.phiz.update_state(state_value)
+        d.sampx.update_state(state_value)
+        d.sampy.update_state(state_value)
+        d.sampz.update_state(state_value)
+
+    def change_robot_state(self, robot_state, motor_state):
+        self.sc._set_state(robot_state)
+        self.update_diffractometer_states(motor_state)
+
+
+class LNLSBeamlineActions(LNLSBaseAction, BeamlineActions):
+    """
+    This class allows sample changer actions to be accessible from other classes
+    of mxcubecore or from the 'Beamline Ations' options at frontend. To use it
+    at mxcubecore code:
+
+    from mxcubecore.HardwareObjects.LNLS.LNLSBeamlineActions import Mount
+    mount = Mount()
+    mount.mount(1)
+
+    To implement a button that performs these actions at 'Beamline Actions',
+    implement the command at the yaml file.
+
+    YAML Example
+    ------------
+
+    %YAML 1.2
+    ---
+    class: LNLS.LNLSBeamlineActions.LNLSBeamlineActions
+    configuration:
+    commands: [{
+                "type": "controller",
+                "name": "Soak",
+                "command": "HardwareObjects.LNLS.LNLSBeamlineActions.Soak"
+                },
+                {
+                "type": "controller",
+                "name": "Dry",
+                "command": "HardwareObjects.LNLS.LNLSBeamlineActions.Dry"
+                },
+                {
+                "type": "controller",
+                "name": "Home",
+                "command": "HardwareObjects.LNLS.LNLSBeamlineActions.Home"
+                },
+                ]
+    """
+    def __init__(self, name):
+        BeamlineActions.__init__(self, name)
+        LNLSBaseAction.__init__(self)
+
+    def abort_command(self, cmd_name):
+        """
+        For the cases of Dry, Home and Soak, if robot
+        movement gets aborted, call the bluesky API and
+        allow motor movement after.
+        There is no abort option for mount/unmount in the UI.
+        """
+        self._bluesky_api.abort()
+        self.change_robot_state(self.ROBOT_READY, self.STATES.READY)
+
+
+class LNLSSampleChangerAction(LNLSBaseAction):
+    def __init__(self, movement_option):
+        super().__init__()
+        self.movement_option = movement_option
+
+    def __call__(self, *args, **kwargs):
+        """
+        Turn off all motors while robot is moving
+        Wait for bluesky plan to end
+        Make motors ready when bluesky plan finishes
+        """
+        self.change_robot_state(self.ROBOT_MOVING, self.STATES.OFF)
+        self._bluesky_api.execute_plan(
+            plan_name="run_sample_changer_command",
+            kwargs={"movement_option": self.movement_option, **kwargs},
+        )
+        self.change_robot_state(self.ROBOT_READY, self.STATES.READY)
+        return args
+
+
+class Soak(LNLSSampleChangerAction):
+    def __init__(self):
+        super().__init__("soak")
+
+
+class Home(LNLSSampleChangerAction):
+    def __init__(self):
+        super().__init__("home")
+
+
+class Dry(LNLSSampleChangerAction):
+    def __init__(self):
+        super().__init__("dry")
+
+
+class MountAction(LNLSSampleChangerAction):
+    def __init__(self):
+        super().__init__("mount")
+
+    def mount(self, sample_value):
+        return self(sample_value=sample_value)
+
+    def unmount(self):
+        self.movement_option = "unmount"
+        return self()

--- a/mxcubecore/HardwareObjects/LNLS/LNLSBeamlineActions.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSBeamlineActions.py
@@ -3,10 +3,12 @@ from mxcubecore.BaseHardwareObjects import HardwareObjectState
 from mxcubecore.HardwareObjects.abstract import AbstractSampleChanger
 from mxcubecore.HardwareObjects.BeamlineActions import BeamlineActions
 
+
 class LNLSBaseAction:
     """
     Base class for both LNLSBeamlineActions and LNLSSampleChangerAction
     """
+
     def __init__(self):
         self._bluesky_api = HWR.beamline.get_object_by_role("bluesky")
         self.sc = HWR.beamline.get_object_by_role("sample_changer")
@@ -77,6 +79,7 @@ class LNLSBeamlineActions(LNLSBaseAction, BeamlineActions):
                 },
                 ]
     """
+
     def __init__(self, name):
         BeamlineActions.__init__(self, name)
         LNLSBaseAction.__init__(self)

--- a/mxcubecore/HardwareObjects/LNLS/LNLSSampleChanger.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSSampleChanger.py
@@ -1,8 +1,12 @@
 import logging
 
 from mxcubeweb.app import MXCUBEApplication
+
 from mxcubecore import HardwareRepository as HWR
-from mxcubecore.HardwareObjects.abstract.AbstractSampleChanger import SampleChanger, SampleChangerState
+from mxcubecore.HardwareObjects.abstract.AbstractSampleChanger import (
+    SampleChanger,
+    SampleChangerState,
+)
 from mxcubecore.HardwareObjects.abstract.sample_changer import Container
 from mxcubecore.HardwareObjects.LNLS.LNLSBeamlineActions import MountAction
 
@@ -38,6 +42,7 @@ class LNLSSampleChanger(SampleChanger):
         no_of_baskets: 3
         no_of_samples_in_basket: 16
     """
+
     __TYPE__ = "Sample Changer"
 
     def __init__(self, name):
@@ -151,7 +156,7 @@ class LNLSSampleChanger(SampleChanger):
         state = {
             "ready": SampleChangerState.Ready,
             "loading": SampleChangerState.Loading,
-            "unloading": SampleChangerState.Unloading
+            "unloading": SampleChangerState.Unloading,
         }[state]
         self._set_state(state)
 
@@ -167,9 +172,7 @@ class LNLSSampleChanger(SampleChanger):
     def configure_baskets(self):
         for idx in range(self.no_of_baskets):
             basket = self.get_components()[idx]
-            present = (
-                self.sc_channels[f"puck_id_{idx + 1}"].get_value() != "None"
-            )
+            present = self.sc_channels[f"puck_id_{idx + 1}"].get_value() != "None"
             basket._set_info(present, None, False)  # noqa: SLF001
 
     def get_name_from_address(self, address):

--- a/mxcubecore/HardwareObjects/LNLS/LNLSSampleChanger.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSSampleChanger.py
@@ -1,0 +1,227 @@
+import logging
+
+from mxcubeweb.app import MXCUBEApplication
+from mxcubecore import HardwareRepository as HWR
+from mxcubecore.HardwareObjects.abstract.AbstractSampleChanger import SampleChanger, SampleChangerState
+from mxcubecore.HardwareObjects.abstract.sample_changer import Container
+from mxcubecore.HardwareObjects.LNLS.LNLSBeamlineActions import MountAction
+
+
+class LNLSSampleChanger(SampleChanger):
+    """
+    This class calls the mount and unmount beamline actions, handles the
+    logic of which sample is mounted and gives access to which samples
+    are accessible from the 'get samples from SC' button.
+
+    YAML Example
+    ------------
+
+    %YAML 1.2
+    ---
+    class: LNLS.LNLSSampleChanger.LNLSSampleChanger
+    epics:
+    "MNC:B:ROBCS801:":
+        channels:
+            get_loop:
+                suffix: "GetLoop"
+            puck_id_1:
+                suffix: "PuckID1"
+            puck_id_2:
+                suffix: "PuckID2"
+            puck_id_3:
+                suffix: "PuckID3"
+    "MNC:B:SoftIOC:SP:1:SampPres_RBV":
+        channels:
+            sample_present:
+                suffix : ""
+    configuration:
+        no_of_baskets: 3
+        no_of_samples_in_basket: 16
+    """
+    __TYPE__ = "Sample Changer"
+
+    def __init__(self, name):
+        super().__init__(self.__TYPE__, scannable=False, name=name)
+        self._bluesky_api = HWR.beamline.get_object_by_role("bluesky")
+
+    def init(self):
+        self.frontend_application = MXCUBEApplication
+        self._selected_sample = -1
+        self._selected_basket = -1
+        self.previous_get_loop_value = 0
+        self.sc_channels = self._CommandContainer__channels
+        self.no_of_baskets = self.get_property("no_of_baskets")
+        self.no_of_samples_in_basket = self.get_property("no_of_samples_in_basket")
+        self.add_baskets()
+        self._init_sc_contents()
+        SampleChanger.init(self)
+        self.set_sample_changer_state("ready")
+        self.log_filename = None
+
+    def get_log_filename(self):
+        return self.log_filename
+
+    def sample_basket_to_index(self, basket, sample):
+        return (int(basket) - 1) * 16 + int(sample)
+
+    def index_to_sample_basket(self, index):
+        sample = (index - 1) % 16 + 1
+        basket = (index - 1) // 16 + 1
+        self._selected_basket = basket
+        self._selected_sample = sample
+
+    def load(self, sample, wait=False):  # noqa: FBT002, ARG002
+        self.emit("fsmConditionChanged", "sample_mounting_sample_changer", True)  # noqa: FBT003
+        previous_sample = self.get_loaded_sample()
+        self._reset_loaded_sample()
+        if isinstance(sample, tuple):
+            basket, sample = sample
+        else:
+            basket, sample = sample.split(":")
+        basket = int(basket)
+        sample = int(sample)
+        self._selected_basket = basket
+        self._selected_sample = sample
+        msg_text = f"Loading sample {basket}:{sample}"
+        logging.getLogger("user_level_log").info(
+            f"Sample changer: {msg_text}. Please wait..."
+        )
+        self.emit("progressInit", (msg_text, 100))
+        frontend_msg = {
+            "signal": "loadingSample",
+            "location": f"{basket}:{sample}",
+            "message": "Please wait, loading sample",
+        }
+        self.frontend_application.server.emit("sc", frontend_msg, namespace="/hwr")
+        sc_value = self.sample_basket_to_index(basket, sample)
+        mount_action = MountAction()
+        mount_action.mount(int(sc_value))
+        self.emit("progressStep", 100)
+        mounted_sample = self.get_component_by_address(
+            Container.Pin.get_sample_address(basket, sample)
+        )
+        if mounted_sample is not previous_sample:
+            self._trigger_loaded_sample_changed_event(mounted_sample)
+        self.update_info()
+        logging.getLogger("user_level_log").info("Sample changer: Sample loaded")
+        self.emit("progressStop", ())
+        self.emit("fsmConditionChanged", "sample_is_loaded", True)
+        self.emit("fsmConditionChanged", "sample_mounting_sample_changer", False)
+        return self.get_loaded_sample()
+
+    def unload(self, sample_slot=None, wait=None):  # noqa: ARG002
+        logging.getLogger("user_level_log").info("Unloading sample")
+        sample = self.get_loaded_sample()
+        mount_action = MountAction()
+        mount_action.unmount()
+        sample._set_loaded(False, True)  # noqa: SLF001
+        self._selected_basket = -1
+        self._selected_sample = -1
+        new_sample = self.get_loaded_sample()
+        self._trigger_loaded_sample_changed_event(new_sample)
+        self.emit("fsmConditionChanged", "sample_is_loaded", False)
+
+    def get_loaded_sample(self):
+        """
+        This fucntion is called periodically
+        """
+        get_loop = int(self.sc_channels["get_loop"].get_value())
+        sample_present = self.sc_channels["sample_present"].get_value()
+
+        if get_loop and sample_present and (1 <= get_loop <= 48):
+            self.index_to_sample_basket(get_loop)
+        else:
+            self._selected_basket = -1
+            self._selected_sample = -1
+
+        value = self.get_component_by_address(
+            Container.Pin.get_sample_address(
+                self._selected_basket,
+                self._selected_sample,
+            )
+        )
+
+        if get_loop != self.previous_get_loop_value:
+            self.previous_get_loop_value = get_loop
+            self._trigger_loaded_sample_changed_event(value)
+
+        return value
+
+    def set_sample_changer_state(self, state):
+        state = {
+            "ready": SampleChangerState.Ready,
+            "loading": SampleChangerState.Loading,
+            "unloading": SampleChangerState.Unloading
+        }[state]
+        self._set_state(state)
+
+    def add_baskets(self):
+        for idx in range(self.no_of_baskets):
+            basket = Container.Basket(
+                self,
+                idx + 1,
+                samples_num=self.no_of_samples_in_basket,
+            )
+            self._add_component(basket)
+
+    def configure_baskets(self):
+        for idx in range(self.no_of_baskets):
+            basket = self.get_components()[idx]
+            present = (
+                self.sc_channels[f"puck_id_{idx + 1}"].get_value() != "None"
+            )
+            basket._set_info(present, None, False)  # noqa: SLF001
+
+    def get_name_from_address(self, address):
+        puck = address.split(":")[0]
+        name = self.sc_channels[f"puck_id_{puck}"].get_value()
+        if name == "None":
+            return None
+        return f"{name}-{address}"
+
+    def configure_samples(self):
+        """
+        This function configures the current samples based
+        on EPICS PVs that are set using an application
+        outside of MXCuBE
+        """
+        sample_list = []
+
+        for basket_idx in range(self.no_of_baskets):
+            puck_id = self.sc_channels[f"puck_id_{basket_idx + 1}"].get_value()
+
+            if puck_id == "None":
+                continue
+
+            for sample_idx in range(self.no_of_samples_in_basket):
+                sample_list.append(
+                    (
+                        "",
+                        basket_idx + 1,
+                        sample_idx + 1,
+                        1,
+                        Container.Pin.STD_HOLDERLENGTH,
+                    )
+                )
+
+        for _, basket, sample, _, holder_length in sample_list:
+            address = Container.Pin.get_sample_address(basket, sample)
+            sample_obj = self.get_component_by_address(address)
+
+            sample_name = self.get_name_from_address(address)
+            if sample_name is not None:
+                sample_obj._name = sample_name  # noqa: SLF001
+
+            datamatrix = f"matr{basket}_{sample}"
+
+            sample_obj._set_info(False, datamatrix, False)  # noqa: SLF001
+            sample_obj._set_loaded(False, False)  # noqa: SLF001
+            sample_obj._set_holder_length(holder_length)  # noqa: SLF001
+
+    def _init_sc_contents(self):
+        self.configure_baskets()
+        self.configure_samples()
+
+    def get_sample_list(self):
+        self._init_sc_contents()
+        return super().get_sample_list()

--- a/mxcubecore/HardwareObjects/LNLS/LNLSSampleChanger.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSSampleChanger.py
@@ -178,8 +178,6 @@ class LNLSSampleChanger(SampleChanger):
     def get_name_from_address(self, address):
         puck = address.split(":")[0]
         name = self.sc_channels[f"puck_id_{puck}"].get_value()
-        if name == "None":
-            return None
         return f"{name}-{address}"
 
     def configure_samples(self):
@@ -191,11 +189,6 @@ class LNLSSampleChanger(SampleChanger):
         sample_list = []
 
         for basket_idx in range(self.no_of_baskets):
-            puck_id = self.sc_channels[f"puck_id_{basket_idx + 1}"].get_value()
-
-            if puck_id == "None":
-                continue
-
             for sample_idx in range(self.no_of_samples_in_basket):
                 sample_list.append(
                     (


### PR DESCRIPTION
This PR implements the classes necessary for operating our sample changer Staubli robot. I started with SampleChangerMockup and BeamlineActionsMockup.

The Home, Soak and Dry actions are meant to be available at this tab with LNLSBeamlineActions :
<img width="181" height="174" alt="image" src="https://github.com/user-attachments/assets/32503e3e-9760-4754-8306-c9d93c4ecdfe" />

I realized that when the user is running a beamline action, in other words, when the UI is in this moment:
<img width="1852" height="1037" alt="image" src="https://github.com/user-attachments/assets/810f6f43-55e0-4dbc-8ec0-4d2845ce74f9" />

it is possible for the user to press F5 to get rid of this modal component, and then try to move a motor or the backlight. If this happens, the robot stops its movement and a staff member needs to manually operate it back to a safe position. `update_diffractometer_states` and the `EPICSRetsrictedMovement` class are security measurements for that :)

All the 5 actions inherit form the same class, LNLSSampleChangerAction, because they are all bluesky plans. For the Home, Soak, and Dry, there is the Abort option, and that is implemented via LNLSBeamlineActions. LNLSSampleChanger class is the one that calls Mount and Unmount actions, and they don't seem to have an abort option.

I also saw that unmount triggered this modal at UI:
<img width="800" height="441" alt="image" src="https://github.com/user-attachments/assets/af31efb6-cf12-416e-816d-d56997de2f4f" />

But mount does trigger anything at UI. This the reason I did `self.frontend_application.server.emit("sc", frontend_msg, namespace="/hwr")` at LNLSSampleChanger, so that I could trigger this modal when a sample is being mounted:

<img width="1850" height="1019" alt="image" src="https://github.com/user-attachments/assets/9f09f3ce-2d95-4a72-b305-ec3714c581aa" />

In both mount and unmount, the same problem applies: user could simply press F5 (or click cancel) and then try to move a motor. Again, this is why `update_diffractometer_states` and the EPICSRetsrictedMovement class are being used

The remainng functions at LNLSSampleChanger are basically functions that allows us to get the Puck names from our EPICS PVs (they are configured at an external application), and if they are changed, clicking on the button "Get Samples from SC" will always update them in the UI.