### PR TITLE
Added warning when `overlap` is used

### DIFF
--- a/mxcubecore/HardwareObjects/Beamline.py
+++ b/mxcubecore/HardwareObjects/Beamline.py
@@ -336,6 +336,18 @@ class Beamline(HardwareObject):
             else:
                 params.update(dd0)
 
+        if "overlap" in params:
+            self.log.warning(
+                "The 'overlap' parameter is deprecated. Please use 'offset' instead."
+            )
+
+            overlap = params.pop("overlap")
+
+            if overlap:
+                overlap = -overlap
+
+            params["offset"] = overlap
+
         for tag, val in params.items():
             setattr(acq_parameters, tag, val)
 


### PR DESCRIPTION
This PR adds a warning `overlap` is used