### PR TITLE
Extend abstract collect classes to allow custom diffraction viewer

### DIFF
--- a/mxcubecore/HardwareObjects/abstract/AbstractCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractCollect.py
@@ -935,3 +935,14 @@ class AbstractCollect(HardwareObject, object):
             )
         except OSError:
             self.log.exception("ADXV: Failed to load image '%s'", image_filename)
+
+    def display_image(self, image_filename: str, image_num: int = 1):
+        """
+        Site specific call to a diffraction viewer, defaults to adxv notify
+
+        Args:
+           image_filename: full path to image file
+           image_num: image number within image file to open (if it contains
+                      multiple images i.e HDF5)
+        """
+        self.adxv_notify(image_filename=image_filename, image_num=image_num)

--- a/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractMultiCollect.py
@@ -471,7 +471,7 @@ class AbstractMultiCollect(object):
             data_collect_parameters["status"] = "failed"
 
             logging.getLogger("user_level_log").info("Storing data collection in LIMS")
-            (self.collection_id, detector_id) = HWR.beamline.lims.store_data_collection(
+            self.collection_id, detector_id = HWR.beamline.lims.store_data_collection(
                 data_collect_parameters, self.bl_config
             )
 
@@ -1342,3 +1342,14 @@ class AbstractMultiCollect(object):
         self.mesh_total_nb_frames = total_nb_frames
         self.mesh_range = mesh_range_param
         self.mesh_center = mesh_center_param
+
+    def display_image(self, image_filename: str, image_num: int = 1):
+        """
+        Site specific call to a diffraction viewer, defaults to adxv notify
+
+        Args:
+           image_filename: full path to image file
+           image_num: image number within image file to open (if it contains
+                      multiple images i.e HDF5)
+        """
+        self.adxv_notify(image_filename=image_filename, image_num=image_num)


### PR DESCRIPTION
I am adding a `site_diffraction_viewer` method to the AbstractCollect classes in order to extend the [display_image](https://github.com/mxcube/mxcubeweb/blob/develop/mxcubeweb/core/adapter/detector_adapter.py#L43) call to accept a site specific diffraction viewer implementation. Defaults to `adxv_notify` for compatibility