### PR TITLE
Set Diffractometer to ready once all motors have moved

### DIFF
--- a/mxcubecore/HardwareObjects/abstract/AbstractDiffractometer.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractDiffractometer.py
@@ -315,7 +315,7 @@ class AbstractDiffractometer(HardwareObject):
         if simultaneous:
             for key in motors_positions_dict:
                 mot_hwobj_dict[key].wait_ready(timeout)
-        self.update_state(HardwareObjectState.READY)
+        self.update_state()
 
     def get_value_motors(self, motors_list: list | None = None) -> dict:
         """Get the positions of diffractometer motors. If the motors_list is

--- a/mxcubecore/HardwareObjects/abstract/AbstractDiffractometer.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractDiffractometer.py
@@ -315,7 +315,7 @@ class AbstractDiffractometer(HardwareObject):
         if simultaneous:
             for key in motors_positions_dict:
                 mot_hwobj_dict[key].wait_ready(timeout)
-        self.update_state()
+        self.update_state(HardwareObjectState.READY)
 
     def get_value_motors(self, motors_list: list | None = None) -> dict:
         """Get the positions of diffractometer motors. If the motors_list is

--- a/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
@@ -71,7 +71,9 @@ class DiffractometerMockup(AbstractDiffractometer):
     def abort(self):
         self.update_state(HardwareObjectState.READY)
 
-    def wait_status_ready(self, timeout=None):
+    def wait_status_ready(self, timeout: float | None = None) -> bool:
+        """Always finish wait as READY."""
+        self.update_state(HardwareObjectState.READY)
         return True
 
     def save_centring_positions(self):
@@ -119,5 +121,5 @@ class DiffractometerMockup(AbstractDiffractometer):
         self.current_phase = value
         self.update_state(self.STATES.READY)
 
-    def _set_constraint(self, value):
+    def _set_constraint(self, value: DiffractometerConstraint):
         self.current_constraint = value

--- a/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
@@ -123,3 +123,12 @@ class DiffractometerMockup(AbstractDiffractometer):
 
     def _set_constraint(self, value: DiffractometerConstraint):
         self.current_constraint = value
+
+    def set_value_motors(self,
+                         motors_positions_dict: dict,
+                         simultaneous: bool = True,
+                         timeout: float | None = None,
+                         ):
+        """Move specified motors to the requested positions."""
+        super().set_value_motors(motors_positions_dict, simultaneous, timeout)
+        self.update_state(HardwareObjectState.READY)

--- a/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
+++ b/mxcubecore/HardwareObjects/mockup/DiffractometerMockup.py
@@ -124,11 +124,12 @@ class DiffractometerMockup(AbstractDiffractometer):
     def _set_constraint(self, value: DiffractometerConstraint):
         self.current_constraint = value
 
-    def set_value_motors(self,
-                         motors_positions_dict: dict,
-                         simultaneous: bool = True,
-                         timeout: float | None = None,
-                         ):
+    def set_value_motors(
+        self,
+        motors_positions_dict: dict,
+        simultaneous: bool = True,
+        timeout: float | None = None,
+    ):
         """Move specified motors to the requested positions."""
         super().set_value_motors(motors_positions_dict, simultaneous, timeout)
         self.update_state(HardwareObjectState.READY)

--- a/test/test_diffractometer.py
+++ b/test/test_diffractometer.py
@@ -78,3 +78,8 @@ class TestDiffarctometer(TestHardwareObjectBase):
         assert test_object.get_constraint() == constraint_enum.RELEASE
         test_object.set_constraint(constraint_enum.STILL)
         assert test_object.get_constraint() == constraint_enum.STILL
+
+    def test_set_value_motors(self, test_object):
+        motors_positions_dict = {"omega": 220, "phiy": 1.5, "sampx": 0.5}
+        test_object.set_value_motors(motors_positions_dict, True)
+        assert test_object.get_state() == test_object.STATES.READY


### PR DESCRIPTION
In my (mock) execution, the diffractometer remains BUSY when motors have moved. This change makes it go back to being READY