### PR TITLE
Handle session at LNLS

### DIFF
--- a/mxcubecore/HardwareObjects/LNLS/LNLSLIMS.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSLIMS.py
@@ -1,7 +1,3 @@
-"""
-A client for ISPyB Webservices.
-"""
-
 from pyicat_plus.client.main import IcatClient
 
 from mxcubecore.HardwareObjects.ICATLIMS import ICATLIMS
@@ -15,7 +11,7 @@ class LNLSLIMS(ICATLIMS):
         self.samples = []
 
         self.icatClient = IcatClient(
-            icatplus_restricted_url="https://icat-plus.cnpem.br"
+            icatplus_restricted_url="https://icat-plus2.cnpem.br"
         )
 
     def is_single_session_available(self):
@@ -35,6 +31,7 @@ class LNLSLIMS(ICATLIMS):
 
     def login(self, user_name, token, is_local_host):
         self.is_local_host = is_local_host
+        self.session_manager.active_session = None
         session_manager, lims_username, sessions = super().login(
             user_name, token, self.session_manager
         )
@@ -44,4 +41,11 @@ class LNLSLIMS(ICATLIMS):
             single_session = self.session_manager.sessions[0]
             self.set_active_session_by_id(single_session.session_id)
 
+        self.session_manager.active_session = None
         return session_manager
+
+    def get_active_lims(self):
+        return self.get_lims_name()[0]
+
+    def finalize_data_collection(self, data_collect_parameters):
+        return

--- a/mxcubecore/HardwareObjects/LNLS/LNLSLIMS.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSLIMS.py
@@ -11,7 +11,7 @@ class LNLSLIMS(ICATLIMS):
         self.samples = []
 
         self.icatClient = IcatClient(
-            icatplus_restricted_url="https://icat-plus2.cnpem.br"
+            icatplus_restricted_url=self.get_property("icatplus_restricted_url")
         )
 
     def is_single_session_available(self):

--- a/mxcubecore/HardwareObjects/LNLS/LNLSSession.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSSession.py
@@ -1,0 +1,28 @@
+import os
+import time
+
+from mxcubecore import HardwareRepository as HWR
+from mxcubecore.HardwareObjects.Session import Session
+
+
+class LNLSSession(Session):
+    def get_proposal(self):
+        proposal = super().get_proposal()
+        return proposal.replace("sc", "").replace("rap", "").replace("industrial", "")
+
+    def get_base_image_directory(self):
+        start_time = time.strftime("%Y%m%d")
+        proposal = self.get_proposal()
+        directory = os.path.join(
+            self.base_directory,
+            proposal,
+            "data",
+            start_time,
+        )
+        return directory
+
+    def clear_session(self):
+        HWR.beamline.session.session_id = None
+        HWR.beamline.session.proposal_number = None
+        HWR.beamline.session.proposal_code = None
+        HWR.beamline.session.proposal_id = None


### PR DESCRIPTION
This PR:
- Updates our icat URL
- Adjusts the functions `finalize_data_collection`, `get_proposal` and `get_base_image_directory` to work for our cases
- Every time user A logins and selects a proposal, logging out would not clear that selected proposal. If user B tries to login, either that user also has access to the proposal  previously selected by user A, or user B login would not work. What I did at `clear_session` and `login` fixes this, but maybe there is a better way to handle this.