### PR TITLE
[Harvester] Wait for diffractometer between centring focus and vertic…

### DIFF
--- a/mxcubecore/HardwareObjects/SampleView.py
+++ b/mxcubecore/HardwareObjects/SampleView.py
@@ -463,7 +463,9 @@ class SampleView(AbstractSampleView):
 
         # next two motors are not part of the centring motors
         # we move them separately
-        diffr.motors_hwobj_dict["sample_focus"].set_value_relative(_offsets[1])
+        diffr.motors_hwobj_dict["sample_focus"].set_value_relative(
+            _offsets[1], timeout=60
+        )
         diffr.motors_hwobj_dict["sample_vertical"].set_value_relative(_offsets[2])
 
         diffr.wait_status_ready(10)


### PR DESCRIPTION
diffractometer has not settled before moving the next motor
Add a wait_status_ready(60) call between the sample_focus and sample_vertical relative moves in start_harvester_centring. 