### PR TITLE
[Harvester] Set crystal UUID via set_id so get_id() returns it correctly

### DIFF
--- a/mxcubecore/HardwareObjects/EMBLFlexHarvester.py
+++ b/mxcubecore/HardwareObjects/EMBLFlexHarvester.py
@@ -114,7 +114,7 @@ class EMBLFlexHarvester(EMBLFlexHCD):
             img_target_y = self._harvester_hwo.get_image_target_y(x_tal_uuid)
 
             # Enrich sample object in MXCuBE
-            sample.id = x_tal_uuid
+            sample.set_id(x_tal_uuid)
             sample.state = ha_sample_states[index]
 
             sample._set_image_url(img_url)
@@ -369,9 +369,8 @@ class EMBLFlexHarvester(EMBLFlexHCD):
         samples_list = self.get_sample_list()
         sample_uuid = None
         for s in samples_list:
-            # it seems get_id() was broken
-            if s.get_address() == sample_loc_str or s.id == sample_loc_str:
-                sample_uuid = s.id
+            if s.get_address() == sample_loc_str or s.get_id() == sample_loc_str:
+                sample_uuid = s.get_id()
 
                 return sample_uuid
         return sample_uuid

--- a/mxcubecore/HardwareObjects/abstract/sample_changer/Component.py
+++ b/mxcubecore/HardwareObjects/abstract/sample_changer/Component.py
@@ -32,6 +32,10 @@ class Component(object):
         """
         return self._id
 
+    def set_id(self, id):
+        """Sets the ID of the component"""
+        self._id = id
+
     def get_address(self):
         """
         Returns a unique identifier of the slot of the element ()


### PR DESCRIPTION
sample.id = x_tal_uuid was setting a dynamic attribute, causing get_id() to return None since it reads self._id

Fix: Add public set_id() to Component
 use sample.set_id(x_tal_uuid) so get_id() returns the crystal UUID consistently