### PR TITLE
Moved queue methods beloning to `mxcubecore` from `mxcubeweb` to `mxubecore`

### DIFF
--- a/mxcubecore/HardwareObjects/QueueManager.py
+++ b/mxcubecore/HardwareObjects/QueueManager.py
@@ -12,8 +12,10 @@ import logging
 
 import gevent
 
+from mxcubecore import HardwareRepository as HWR
 from mxcubecore import queue_entry
 from mxcubecore.BaseHardwareObjects import HardwareObject
+from mxcubecore.model import queue_model_objects
 from mxcubecore.model.queue_model_enumerables import CENTRING_METHOD
 from mxcubecore.queue_entry import base_queue_entry
 from mxcubecore.queue_entry.base_queue_entry import QUEUE_ENTRY_STATUS
@@ -406,6 +408,181 @@ class QueueManager(HardwareObject, QueueEntryContainer):
 
                 if result:
                     return result
+
+    def get_entry(self, node_id):
+        """
+        Retrieve the model and the queue entry for the model node with id
+        <node_id>.
+
+        :param int node_id: Node id of node to retrieve
+        :returns: The tuple (model, entry)
+        :rtype: Tuple
+        """
+        if node_id is None:
+            dummy_variable = "Cannot retrieve entry without a node id"
+            raise ValueError(dummy_variable)
+
+        model = HWR.beamline.queue_model.get_node(int(node_id))
+        entry = self.get_entry_with_model(model)
+        return model, entry
+
+    def get_entry_status(self, node_id):
+        """
+        Get the current execution status for the queue entry associated
+        with the model node <node_id>.
+
+        :param int node_id: Node id of the model node, or None.
+        :returns: (enabled, is_executed, is_running, status), where status
+                  is one of the QUEUE_ENTRY_STATUS values.
+        :rtype: Tuple
+        """
+        if node_id is None:
+            return True, False, False, None
+
+        model, entry = self.get_entry(node_id)
+
+        enabled = model.is_enabled()
+        curr_entry = self.get_current_entry()
+        running = self.is_executing() and (
+            curr_entry == entry or curr_entry == entry._parent_container
+        )
+
+        return enabled, model.is_executed(), running, entry.status
+
+    def enable_entry(self, id_or_qentry, flag):
+        """
+        Helper function that sets the enabled flag for one or more entries
+        and their models.
+
+        Accepts a single item, or a list of items, where each item is
+        either a model node id or a QueueEntry object.
+
+        :param object id_or_qentry: Node id, QueueEntry object, or a list
+                                     of either.
+        :param bool flag: True for enabled False for disabled
+        """
+        items = id_or_qentry if isinstance(id_or_qentry, list) else [id_or_qentry]
+
+        for item in items:
+            if isinstance(item, base_queue_entry.BaseQueueEntry):
+                entry, model = item, item.get_data_model()
+            else:
+                model, entry = self.get_entry(item)
+
+            entry.set_enabled(flag)
+            model.set_enabled(flag)
+
+    def _delete_entry(self, entry):
+        """Helper function that deletes an entry and its model from the queue."""
+        parent_entry = entry.get_container()
+        parent_entry.dequeue(entry)
+        model = entry.get_data_model()
+        HWR.beamline.queue_model.del_child(model.get_parent(), model)
+        logging.getLogger("HWR").info(
+            "[DELETE QUEUE] FROM:\n%s " % model.get_parent().get_name()
+        )
+
+    def delete_entry_at(self, item_pos_list):
+        """
+        Deletes the queue entries at the given (sample_id, task_index)
+        positions.
+
+        :param list item_pos_list: List of [sample_id, task_index] pairs.
+                                    task_index may be None/"undefined" to
+                                    refer to the sample entry itself.
+        """
+        for sid, tindex in item_pos_list:
+            if tindex in ("undefined", None):
+                model = HWR.beamline.queue_model.get_sample_by_loc_str(sid)
+            else:
+                model = HWR.beamline.queue_model.get_node_at_task_index(
+                    sid, int(tindex)
+                )
+
+            entry = self.get_entry_with_model(model)
+
+            if tindex not in ("undefined", None) and not isinstance(
+                entry, queue_entry.TaskGroupQueueEntry
+            ):
+                # Get the TaskGroup of the item, there is currently only one
+                # task per TaskGroup so we have to remove the entire
+                # TaskGroup with its task.
+                entry = entry.get_container()
+
+            self._delete_entry(entry)
+
+    def swap_task_entry(self, sid, ti1, ti2):
+        """
+        Swap order of two queue entries in the queue, with the same sample
+        <sid> as parent.
+
+        :param str sid: Sample id
+        :param int ti1: Position of task1 (old position)
+        :param int ti2: Position of task2 (new position)
+        """
+        sample_model = HWR.beamline.queue_model.get_sample_by_loc_str(sid)
+        sentry = self.get_entry_with_model(sample_model)
+
+        # Swap the order in the queue model
+        ti2_temp_model = sample_model.get_children()[ti2]
+        sample_model._children[ti2] = sample_model._children[ti1]
+        sample_model._children[ti1] = ti2_temp_model
+
+        # Swap queue entry order
+        ti2_temp_entry = sentry._queue_entry_list[ti2]
+        sentry._queue_entry_list[ti2] = sentry._queue_entry_list[ti1]
+        sentry._queue_entry_list[ti1] = ti2_temp_entry
+
+    def enable_sample_entries(self, sample_id_list, flag):
+        """
+        Sets the enabled flag for the entries of the samples in
+        <sample_id_list>.
+
+        :param list sample_id_list: List of sample location strings.
+        :param bool flag: True for enabled, False for disabled.
+        """
+        node_ids = [
+            HWR.beamline.queue_model.get_sample_by_loc_str(sample_id)._node_id
+            for sample_id in sample_id_list
+        ]
+        self.enable_entry(node_ids, flag)
+
+    def set_auto_add_diff_plan_for_characterisations(self, autoadd):
+        """
+        Propagates the auto add diffraction plan flag to the queue entries
+        of all Characterisation nodes currently in the queue.
+
+        :param bool autoadd: True autoadd, False wait for user
+        """
+        for node in HWR.beamline.queue_model.get_nodes():
+            if isinstance(node, queue_model_objects.Characterisation):
+                entry = self.get_entry_with_model(node)
+
+                if entry is not None:
+                    entry.auto_add_diff_plan = autoadd
+
+    def last_queue_node(self):
+        """
+        Gets the node index information for the node currently being
+        executed.
+
+        :returns: dict as returned by QueueModel.node_index, plus "node".
+        :rtype: dict
+        """
+        node = self._current_queue_entries[-1].get_data_model()
+
+        # Reference collections (created for a Characterisation) are
+        # orphans in the flattened task list - the node of interest there is
+        # the Characterisation itself, not the reference collection.
+
+        if "ref" in node.get_name():
+            parent = node.get_parent()
+            node = parent._children[0]
+
+        res = HWR.beamline.queue_model.node_index(node)
+        res["node"] = node
+
+        return res
 
     def execute_entry(self, entry, use_async=False):
         """

--- a/mxcubecore/HardwareObjects/QueueManager.py
+++ b/mxcubecore/HardwareObjects/QueueManager.py
@@ -61,22 +61,18 @@ class QueueManager(HardwareObject, QueueEntryContainer):
     def current_queue_entries(self):
         return self._current_queue_entries
 
-    def enqueue(self, queue_entry):
+    def enqueue(self, queue_entry: base_queue_entry.BaseQueueEntry) -> None:
         """
         Method inherited from QueueEntryContainer, enqueues the QueueEntry
         object <queue_entry>.
 
         :param queue_entry: QueueEntry to add
-        :type queue_entry: QueueEntry
-
-        :returns: None
-        :rtype: NoneType
         """
 
         queue_entry.set_queue_controller(self)
         super(QueueManager, self).enqueue(queue_entry)
 
-    def execute(self, entry=None):
+    def execute(self, entry: base_queue_entry.BaseQueueEntry | None = None):
         """
         Starts execution of the queue.
 
@@ -85,7 +81,6 @@ class QueueManager(HardwareObject, QueueEntryContainer):
         and "stopped".
 
         :param entry: Optional, queue_entry to run
-        :type entry: QueueEntry
         :raises: RuntimeError, if the queue is already running when called
         """
         if self._running:
@@ -140,10 +135,9 @@ class QueueManager(HardwareObject, QueueEntryContainer):
         #    msg += str(entry) + " (in_queue=%s) " % entry.in_queue
         # logging.getLogger('queue_exec').info(msg)
 
-    def is_executing(self, node_id=None):
+    def is_executing(self, node_id=None) -> bool:
         """
         :returns: True if the queue is executing otherwise False
-        :rtype: bool
         """
         status = self._running
 
@@ -263,12 +257,11 @@ class QueueManager(HardwareObject, QueueEntryContainer):
             self.set_current_entry(None)
             self._current_queue_entries.pop(self._current_queue_entries.index(entry))
 
-    def stop(self):
+    def stop(self) -> None:
         """
         Stops the queue execution.
 
         :returns: None
-        :rtype: NoneType
         """
         if self._queue_entry_list:
             for qe in self._current_queue_entries:
@@ -295,16 +288,14 @@ class QueueManager(HardwareObject, QueueEntryContainer):
         self.emit("statusMessage", ("status", "", "Queue stopped"))
         self.emit("queue_stopped", (None,))
 
-    def set_pause(self, state):
+    def set_pause(self, state: bool) -> None:
         """
         Sets the queue in paused state <state>. Emits the signal queue_paused
         with the current state as parameter.
 
         :param state: Paused if True running if False
-        :type state: bool
 
         :returns: None
-        :rtype: NoneType
         """
         self.emit("queue_paused", (state,))
         self.emit("statusMessage", ("status", "Queue paused", "action_req"))
@@ -314,91 +305,78 @@ class QueueManager(HardwareObject, QueueEntryContainer):
         else:
             self._paused_event.set()
 
-    def is_paused(self):
+    def is_paused(self) -> bool:
         """
         Returns the pause state, see the method set_pause().
-
-        :returns: None
-        :rtype: NoneType
         """
         return not self._paused_event.is_set()
 
-    def pause(self, state):
+    def pause(self, state: bool) -> None:
         """
         Sets the queue in paused state <state> (and waits), paused if True
         running if False.
 
         :param state: Paused if True running if False
-        :type state: bool
 
         :returns: None
-        :rtype: NoneType
         """
         self.set_pause(state)
         self._paused_event.wait()
 
-    def wait_for_pause_event(self):
+    def wait_for_pause_event(self) -> None:
         """
         Wait for the queue to be set to running set_pause(False) or continue if
         it already was running.
 
         :returns: None
-        :rtype: NoneType
         """
         self._paused_event.wait()
 
-    def disable(self, state):
+    def disable(self, state: bool) -> None:
         """
         Sets the disable state to <state>, disables the possibility
         to call execute if True enables if False.
 
         :param state: The disabled state, True, False.
-        :type state: bool
 
         :returns: None
-        :rtype: NoneType
-
         """
         self._disable_collect = state
 
-    def is_disabled(self):
+    def is_disabled(self) -> bool:
         """
         :returns: True if the queue is disabled, (calling execute
                   will do nothing).
-        :rtype: bool
         """
         return self._disable_collect
 
-    def set_current_entry(self, entry):
+    def set_current_entry(self, entry: base_queue_entry.BaseQueueEntry | None) -> None:
         """
         Sets the currently executing QueueEntry to <entry>.
 
         :param entry: The entry.
-        :type entry: QeueuEntry
 
         :returns: None
-        :rtype: NoneType
         """
         self._current_queue_entry = entry
 
-    def get_current_entry(self):
+    def get_current_entry(self) -> base_queue_entry.BaseQueueEntry | None:
         """
         Gets the currently executing QueueEntry.
 
         :returns: The currently executing QueueEntry:
-        :rtype: QueueEntry
         """
         return self._current_queue_entry
 
-    def get_entry_with_model(self, model, root_queue_entry=None):
+    def get_entry_with_model(
+        self, model: queue_model_objects.TaskNode, root_queue_entry=None
+    ) -> base_queue_entry.BaseQueueEntry | None:
         """
         Find the entry with the data model model.
 
         :param model: The model to look for.
-        :type model: TaskNode
 
         :returns: The QueueEntry with the model <model>
-        :rtype: QueueEntry
         """
         if not root_queue_entry:
             root_queue_entry = self
@@ -412,14 +390,13 @@ class QueueManager(HardwareObject, QueueEntryContainer):
                 if result:
                     return result
 
-    def get_entry(self, node_id):
+    def get_entry(self, node_id: int) -> tuple:
         """
         Retrieve the model and the queue entry for the model node with id
         <node_id>.
 
-        :param int node_id: Node id of node to retrieve
+        :param node_id: Node id of node to retrieve
         :returns: The tuple (model, entry)
-        :rtype: Tuple
         """
         if node_id is None:
             dummy_variable = "Cannot retrieve entry without a node id"
@@ -429,15 +406,14 @@ class QueueManager(HardwareObject, QueueEntryContainer):
         entry = self.get_entry_with_model(model)
         return model, entry
 
-    def get_entry_status(self, node_id):
+    def get_entry_status(self, node_id: int) -> tuple:
         """
         Get the current execution status for the queue entry associated
         with the model node <node_id>.
 
-        :param int node_id: Node id of the model node, or None.
+        :param node_id: Node id of the model node, or None.
         :returns: (enabled, is_executed, is_running, status), where status
                   is one of the QUEUE_ENTRY_STATUS values.
-        :rtype: Tuple
         """
         if node_id is None:
             return True, False, False, None
@@ -452,7 +428,9 @@ class QueueManager(HardwareObject, QueueEntryContainer):
 
         return enabled, model.is_executed(), running, entry.status
 
-    def enable_entry(self, id_or_qentry, flag):
+    def enable_entry(
+        self, id_or_qentry: int | base_queue_entry.BaseQueueEntry | list, flag: bool
+    ):
         """
         Helper function that sets the enabled flag for one or more entries
         and their models.
@@ -460,9 +438,9 @@ class QueueManager(HardwareObject, QueueEntryContainer):
         Accepts a single item, or a list of items, where each item is
         either a model node id or a QueueEntry object.
 
-        :param object id_or_qentry: Node id, QueueEntry object, or a list
-                                     of either.
-        :param bool flag: True for enabled False for disabled
+        :param id_or_qentry: Node id, QueueEntry object, or a list of
+                              either.
+        :param flag: True for enabled False for disabled
         """
         items = id_or_qentry if isinstance(id_or_qentry, list) else [id_or_qentry]
 
@@ -485,14 +463,14 @@ class QueueManager(HardwareObject, QueueEntryContainer):
             "[DELETE QUEUE] FROM:\n%s " % model.get_parent().get_name()
         )
 
-    def delete_entry_at(self, item_pos_list):
+    def delete_entry_at(self, item_pos_list: list):
         """
         Deletes the queue entries at the given (sample_id, task_index)
         positions.
 
-        :param list item_pos_list: List of [sample_id, task_index] pairs.
-                                    task_index may be None/"undefined" to
-                                    refer to the sample entry itself.
+        :param item_pos_list: List of [sample_id, task_index] pairs.
+                               task_index may be None/"undefined" to
+                               refer to the sample entry itself.
         """
         for sid, tindex in item_pos_list:
             if tindex in ("undefined", None):
@@ -514,14 +492,14 @@ class QueueManager(HardwareObject, QueueEntryContainer):
 
             self._delete_entry(entry)
 
-    def swap_task_entry(self, sid, ti1, ti2):
+    def swap_task_entry(self, sid: str, ti1: int, ti2: int):
         """
         Swap order of two queue entries in the queue, with the same sample
         <sid> as parent.
 
-        :param str sid: Sample id
-        :param int ti1: Position of task1 (old position)
-        :param int ti2: Position of task2 (new position)
+        :param sid: Sample id
+        :param ti1: Position of task1 (old position)
+        :param ti2: Position of task2 (new position)
         """
         sample_model = HWR.beamline.queue_model.get_sample_by_loc_str(sid)
         sentry = self.get_entry_with_model(sample_model)
@@ -536,13 +514,13 @@ class QueueManager(HardwareObject, QueueEntryContainer):
         sentry._queue_entry_list[ti2] = sentry._queue_entry_list[ti1]
         sentry._queue_entry_list[ti1] = ti2_temp_entry
 
-    def enable_sample_entries(self, sample_id_list, flag):
+    def enable_sample_entries(self, sample_id_list: list, flag: bool):
         """
         Sets the enabled flag for the entries of the samples in
         <sample_id_list>.
 
-        :param list sample_id_list: List of sample location strings.
-        :param bool flag: True for enabled, False for disabled.
+        :param sample_id_list: List of sample location strings.
+        :param flag: True for enabled, False for disabled.
         """
         node_ids = [
             HWR.beamline.queue_model.get_sample_by_loc_str(sample_id)._node_id
@@ -550,12 +528,12 @@ class QueueManager(HardwareObject, QueueEntryContainer):
         ]
         self.enable_entry(node_ids, flag)
 
-    def set_auto_add_diff_plan(self, autoadd):
+    def set_auto_add_diff_plan(self, autoadd: bool):
         """
         Sets the auto add diffraction plan flag, and propagates it to the
         queue entries of all Characterisation nodes currently in the queue.
 
-        :param bool autoadd: True autoadd, False wait for user
+        :param autoadd: True autoadd, False wait for user
         """
         self.auto_add_diff_plan = autoadd
 
@@ -566,13 +544,12 @@ class QueueManager(HardwareObject, QueueEntryContainer):
                 if entry is not None:
                     entry.auto_add_diff_plan = autoadd
 
-    def last_queue_node(self):
+    def last_queue_node(self) -> dict:
         """
         Gets the node index information for the node currently being
         executed.
 
         :returns: dict as returned by QueueModel.node_index, plus "node".
-        :rtype: dict
         """
         node = self._current_queue_entries[-1].get_data_model()
 
@@ -589,16 +566,14 @@ class QueueManager(HardwareObject, QueueEntryContainer):
 
         return res
 
-    def execute_entry(self, entry, use_async=False):
+    def execute_entry(self, entry: base_queue_entry.BaseQueueEntry, use_async=False):
         """
         Executes the queue entry once the queue has been started <entry>.
 
         :param entry: The entry to execute.
-        :type entry: QueueEntry
 
         :raises: RuntimeError if the queue is not already running when called
         :returns: None
-        :rtype: NoneType
         """
         if not self._running:
             raise RuntimeError(
@@ -610,12 +585,11 @@ class QueueManager(HardwareObject, QueueEntryContainer):
         else:
             self.__execute_entry(entry)
 
-    def clear(self):
+    def clear(self) -> None:
         """
         Clears the queue (removes all entries).
 
         :returns: None
-        :rtype: NoneType
         """
         self._queue_entry_list = []
 

--- a/mxcubecore/HardwareObjects/QueueManager.py
+++ b/mxcubecore/HardwareObjects/QueueManager.py
@@ -28,6 +28,7 @@ class QueueManager(HardwareObject, QueueEntryContainer):
         HardwareObject.__init__(self, name)
         QueueEntryContainer.__init__(self)
         self.centring_method = CENTRING_METHOD.NONE
+        self.auto_add_diff_plan = False
         self._root_task = None
         self._paused_event = gevent.event.Event()
         self._paused_event.set()
@@ -43,6 +44,8 @@ class QueueManager(HardwareObject, QueueEntryContainer):
             queue_entry.import_queue_entries(site_entry_path.split(","))
         else:
             queue_entry.import_queue_entries()
+
+        self.auto_add_diff_plan = self.get_property("auto_add_diff_plan", False)
 
     def __getstate__(self):
         d = dict(self.__dict__)
@@ -547,13 +550,15 @@ class QueueManager(HardwareObject, QueueEntryContainer):
         ]
         self.enable_entry(node_ids, flag)
 
-    def set_auto_add_diff_plan_for_characterisations(self, autoadd):
+    def set_auto_add_diff_plan(self, autoadd):
         """
-        Propagates the auto add diffraction plan flag to the queue entries
-        of all Characterisation nodes currently in the queue.
+        Sets the auto add diffraction plan flag, and propagates it to the
+        queue entries of all Characterisation nodes currently in the queue.
 
         :param bool autoadd: True autoadd, False wait for user
         """
+        self.auto_add_diff_plan = autoadd
+
         for node in HWR.beamline.queue_model.get_nodes():
             if isinstance(node, queue_model_objects.Characterisation):
                 entry = self.get_entry_with_model(node)

--- a/mxcubecore/HardwareObjects/QueueModel.py
+++ b/mxcubecore/HardwareObjects/QueueModel.py
@@ -26,8 +26,10 @@ retrieving nodes are all done via this object. It is possible to
 handle several models by using register_model and select_model.
 """
 
+import contextlib
 import json
 import logging
+from unittest.mock import Mock
 
 import jsonpickle
 
@@ -166,6 +168,16 @@ class QueueModel(HardwareObject):
             parent._children.append(child)
             child._set_name(child._name)
             self.emit("child_added", (parent, child))
+
+            # A more specific signal than child_added, for listeners that
+            # only care about samples entering the queue (e.g. mxcubeweb
+            # registering a manually-added sample in the web UI's sample
+            # list) regardless of which code path added it. Fired after
+            # child_added, so any child_added listener that creates this
+            # sample's QueueEntry (see queue_model_child_added) has already
+            # run by the time sample_added listeners see it.
+            if isinstance(child, queue_model_objects.Sample):
+                self.emit("sample_added", (child,))
         else:
             raise TypeError("Expected type TaskNode, got %s " % str(type(child)))
 
@@ -210,6 +222,93 @@ class QueueModel(HardwareObject):
 
                 if result:
                     return result
+
+    def get_sample_by_loc_str(self, loc_str):
+        """
+        Finds the Sample node with location string <loc_str>, directly
+        under the selected model's root.
+
+        :param loc_str: The sample's location string (Sample.loc_str).
+        :type loc_str: str
+
+        :returns: The Sample node, or None if not found.
+        :rtype: Sample
+        """
+        for child in self.get_model_root().get_children():
+            if (
+                isinstance(child, queue_model_objects.Sample)
+                and child.loc_str == loc_str
+            ):
+                return child
+
+        return None
+
+    def _get_flattened_task_list(self, sample_model):
+        """
+        Builds the "flattened" task list for <sample_model> used by
+        node_index and get_node_at_task_index
+        """
+        tlist = []
+
+        for group in sample_model.get_children():
+            # interleaved TaskGroups count as a single task,
+            if group.interleave_num_images:
+                tlist.append(group)
+            else:
+                tlist.extend(group.get_children())
+
+        return tlist
+
+    def get_node_at_task_index(self, loc_str, tindex):
+        """
+        Finds the node at position <tindex> in the task list of
+        the sample with location string <loc_str>
+
+        :param loc_str: The sample's location string.
+        :type loc_str: str
+
+        :param tindex: Index into the sample's task list.
+        :type tindex: int
+
+        :returns: The node at position tindex.
+        :rtype: TaskNode
+        """
+        sample_model = self.get_sample_by_loc_str(loc_str)
+        return self._get_flattened_task_list(sample_model)[tindex]
+
+    def node_index(self, node):
+        """
+        Get the position (index) in the queue, sample and node id of node
+        <node>.
+
+        :returns: dictionary on the form:
+                {'sample': sample, 'idx': index, 'queue_id': node_id}
+        """
+        sample, index, sample_model = None, None, None
+
+        # RootNode nothing to return
+        if isinstance(node, queue_model_objects.RootNode):
+            sample = None
+        # For samples simply return the sampleID
+        elif isinstance(node, queue_model_objects.Sample):
+            sample = node.loc_str
+        # TaskGroup just return the sampleID
+        elif node.get_parent():
+            # NB under GPhL workflow, nodes do not have predictable distance
+            # to their sample node
+            sample_model = node.get_sample_node()
+            sample = sample_model.loc_str
+            tlist = self._get_flattened_task_list(sample_model)
+
+            with contextlib.suppress(Exception):
+                index = tlist.index(node)
+
+        return {
+            "sample": sample,
+            "idx": index,
+            "queue_id": node._node_id,
+            "sample_node": sample_model,
+        }
 
     def del_child(self, parent, child):
         """
@@ -287,6 +386,61 @@ class QueueModel(HardwareObject):
             # else:
             view_item.parent().get_queue_entry().enqueue(qe)
         view_item.update_tool_tip()
+
+    def clear_queue(self):
+        """
+        Clears all models (ispyb, free-pin, plate) and resets the selected
+        model to 'ispyb'.
+        """
+        self.diffraction_plan = {}
+        self.clear_model("ispyb")
+        self.clear_model("free-pin")
+        self.clear_model("plate")
+        self.select_model("ispyb")
+
+    def _get_parent_entry_for_child_added(self, parent):
+        if parent is self.get_model_root():
+            return HWR.beamline.queue_manager
+
+        node_id = parent._node_id
+
+        if node_id is None:
+            dummy_variable = "Trying to add child to unenqueued parent %s" % parent
+            raise ValueError(dummy_variable)
+
+        _, parent_entry = HWR.beamline.queue_manager.get_entry(node_id)
+        return parent_entry
+
+    def queue_model_child_added(self, parent, child):
+        """
+        Listen to the addition of models to the queue model
+        via the 'child_added' event.
+
+        This is the single place a QueueEntry is created for a model
+        node:
+
+        Callers only ever call add_child() to place a model in the
+        tree. Its not necassary to construct or enqueue an entry themselves.
+
+        This method handles the creation of a queue entry for every model
+        type registred in mxcubecore.queue_entry.MODEL_QUEUE_ENTRY_MAPPINGS
+        """
+        entry_cls = queue_entry.MODEL_QUEUE_ENTRY_MAPPINGS.get(type(child))
+
+        if entry_cls is None:
+            return
+
+        parent_entry = self._get_parent_entry_for_child_added(parent)
+        entry = entry_cls(Mock(), child)
+        HWR.beamline.queue_manager.enable_entry(entry, True)
+
+        # DataCollection children (e.g. diffraction-plan collections) can
+        # be added to a TaskGroup that was just created for them and is
+        # not yet enabled - enable the parent entry too in that case.
+        if isinstance(child, queue_model_objects.DataCollection):
+            HWR.beamline.queue_manager.enable_entry(parent_entry, True)
+
+        parent_entry.enqueue(entry)
 
     def get_next_run_number(self, new_path_template, exclude_current=True):
         """
@@ -419,6 +573,18 @@ class QueueModel(HardwareObject):
                 result.append(item)
 
         return result
+
+    def update_dependent_field(self, task_name, data):
+        try:
+            qentry_cls = queue_entry.get_queue_entry_from_task_name(task_name)
+            data_model = getattr(qentry_cls, "DATA_MODEL", None)
+            new_data = json.dumps(data_model.update_dependent_fields(data))
+        except Exception:
+            logging.getLogger("MX3.HWR").exception(
+                f"Could not update depedant fields for {task_name}"
+            )
+
+        return new_data
 
     def save_queue(self, filename=None):
         """Saves queue in the file. Current selected model is saved as a list

--- a/mxcubecore/HardwareObjects/QueueModel.py
+++ b/mxcubecore/HardwareObjects/QueueModel.py
@@ -82,36 +82,31 @@ class QueueModel(HardwareObject):
         """
         pass
 
-    def select_model(self, name):
+    def select_model(self, name: str) -> None:
         """
         Selects the model with the name <name>
 
         :param name: The name of the model to select.
-        :type name: str
 
         :returns: None
-        :rtype: NoneType
         """
         self._selected_model = self._models[name]
         HWR.beamline.queue_manager.clear()
         self._re_emit(self._selected_model)
 
-    def get_model_root(self):
+    def get_model_root(self) -> queue_model_objects.TaskNode:
         """
         :returns: The selected model root.
-        :rtype: TaskNode
         """
         return self._selected_model
 
-    def clear_model(self, name=None):
+    def clear_model(self, name: str | None = None) -> None:
         """
         Clears the model with name <name>, clears all if name is None
 
         :param name: The name of the model to clear.
-        :type name: str
 
         :returns: None
-        :rtype: NoneType
         """
         self._models[name] = queue_model_objects.RootNode()
 
@@ -121,18 +116,17 @@ class QueueModel(HardwareObject):
 
         HWR.beamline.queue_manager.clear()
 
-    def register_model(self, name, root_node):
+    def register_model(
+        self, name: str, root_node: queue_model_objects.RootNode
+    ) -> None:
         """
         Register a new model with name <name> and root node <root_node>.
 
         :param name: The name of the 'new' model.
-        :type name: str
 
         :param root_node: The root of the model.
-        :type root_node: RootNode
 
         :returns: None
-        :rtype: NoneType
         """
         if name in self._models:
             raise KeyError("The key %s is already registered" % name)
@@ -147,7 +141,7 @@ class QueueModel(HardwareObject):
             self.emit("child_added", (parent_node, child_node))
             self._re_emit(child_node)
 
-    def add_child(self, parent, child):
+    def add_child(self, parent, child: queue_model_objects.TaskNode) -> None:
         """
         Adds the child node <child>. Raises the exception TypeError
         if child is not of type TaskNode.
@@ -155,10 +149,8 @@ class QueueModel(HardwareObject):
         Moves the child (re-parents it) if it already has a parent.
 
         :param child: TaskNode to add
-        :type child: TaskNode
 
         :returns: None
-        :rtype: None
         """
         if True:
             # if isinstance(child, queue_model_objects.TaskNode):
@@ -181,35 +173,31 @@ class QueueModel(HardwareObject):
         else:
             raise TypeError("Expected type TaskNode, got %s " % str(type(child)))
 
-    def add_child_at_id(self, _id, child):
+    def add_child_at_id(self, _id: int, child: queue_model_objects.TaskNode) -> int:
         """
         Adds a child <child> at the node with the node id <_id>
 
         :param _id: The id of the parent node.
-        :type _id: int
 
         :param child: The child node to add.
-        :type child: TaskNode
 
         :returns: The id of the child.
-        :rtype: int
         """
         parent = self.get_node(_id)
         self.add_child(parent, child)
         return child._node_id
 
-    def get_node(self, _id, parent=None):
+    def get_node(
+        self, _id: int, parent: queue_model_objects.TaskNode | None = None
+    ) -> queue_model_objects.TaskNode | None:
         """
         Retrieves the node with the node id <_id>
 
         :param _id: The id of the node to retrieve.
-        :type _id: int
 
         :param parent: parent node to search in.
-        :type parent: TaskNode
 
         :returns: The node with the id <_id>
-        :rtype: TaskNode
         """
         if parent is None:
             parent = self._selected_model
@@ -223,16 +211,13 @@ class QueueModel(HardwareObject):
                 if result:
                     return result
 
-    def get_sample_by_loc_str(self, loc_str):
+    def get_sample_by_loc_str(self, loc_str: str) -> queue_model_objects.Sample | None:
         """
         Finds the Sample node with location string <loc_str>, directly
         under the selected model's root.
 
         :param loc_str: The sample's location string (Sample.loc_str).
-        :type loc_str: str
-
         :returns: The Sample node, or None if not found.
-        :rtype: Sample
         """
         for child in self.get_model_root().get_children():
             if (
@@ -259,19 +244,16 @@ class QueueModel(HardwareObject):
 
         return tlist
 
-    def get_node_at_task_index(self, loc_str, tindex):
+    def get_node_at_task_index(
+        self, loc_str: str, tindex: int
+    ) -> queue_model_objects.TaskNode:
         """
         Finds the node at position <tindex> in the task list of
         the sample with location string <loc_str>
 
         :param loc_str: The sample's location string.
-        :type loc_str: str
-
         :param tindex: Index into the sample's task list.
-        :type tindex: int
-
         :returns: The node at position tindex.
-        :rtype: TaskNode
         """
         sample_model = self.get_sample_by_loc_str(loc_str)
         return self._get_flattened_task_list(sample_model)[tindex]
@@ -310,42 +292,42 @@ class QueueModel(HardwareObject):
             "sample_node": sample_model,
         }
 
-    def del_child(self, parent, child):
+    def del_child(self, parent, child: queue_model_objects.TaskNode) -> None:
         """
         Removes <child>
 
         :param child: Child to remove.
-        :type child: TaskNode
 
         :returns: None
-        :rtype: None
         """
         if child in parent._children:
             parent._children.remove(child)
             self.emit("child_removed", (parent, child))
 
-    def _detach_child(self, parent, child):
+    def _detach_child(
+        self, parent, child: queue_model_objects.TaskNode
+    ) -> queue_model_objects.TaskNode:
         """
         Detaches the child <child>
 
         :param child: Child to detach.
-        :type child: TaskNode
 
-        :returns: None
-        :rtype: None
+        :returns: The detached child.
         """
         child = parent._children.pop(child)
         return child
 
-    def set_parent(self, parent, child):
+    def set_parent(
+        self,
+        parent: queue_model_objects.TaskNode,
+        child: queue_model_objects.TaskNode,
+    ):
         """
         Sets the parent of the child <child> to <parent>
 
         :param parent: The parent.
-        :type parent: TaskNode Object
 
         :param child: The child
-        :type child: TaskNode Object
         """
         if child._parent:
             self._detach_child(parent, child)
@@ -353,19 +335,16 @@ class QueueModel(HardwareObject):
         else:
             child._parent = parent
 
-    def view_created(self, view_item, task_model):
+    def view_created(self, view_item, task_model: queue_model_objects.TaskNode) -> None:
         """
         Method that should be called by the routine that adds
         the view <view_item> for the model <task_model>
 
         :param view_item: The view item that was added.
-        :type view_item: ViewItem
 
         :param task_model: The associated task model.
-        :type task_model: TaskModel
 
         :returns: None
-        :rtype: None
         """
         view_item._data_model = task_model
         cls = queue_entry.MODEL_QUEUE_ENTRY_MAPPINGS[task_model.__class__]
@@ -442,20 +421,21 @@ class QueueModel(HardwareObject):
 
         parent_entry.enqueue(entry)
 
-    def get_next_run_number(self, new_path_template, exclude_current=True):
+    def get_next_run_number(
+        self,
+        new_path_template: queue_model_objects.PathTemplate,
+        exclude_current: bool = True,
+    ) -> int:
         """
         Iterates through all the path templates of the tasks
         in the model and returns the next available run number
         for the path template <new_path_template>.
 
         :param new_path_template: PathTempalte to match with.
-        :type new_path_template: PathTemplate
         :param exclude_current: Skips it self when iterating through
                                 the model, default Tree.
-        :type exlcude_current: bool
 
         :returns: The next available run number for the given path_template.
-        :rtype: int
         """
         all_path_templates = self.get_path_templates()
         conflicting_path_templates = [0]
@@ -513,15 +493,15 @@ class QueueModel(HardwareObject):
 
         return result
 
-    def copy_node(self, node):
+    def copy_node(
+        self, node: queue_model_objects.TaskNode
+    ) -> queue_model_objects.TaskNode:
         """
         Copies the node <node> and returns it.
 
         :param node: The node to copy.
-        :type node: TaskModel
 
         :returns: A copy of the node.
-        :rtype: TaskModel
         """
         new_node = node.copy()
 

--- a/mxcubecore/HardwareObjects/QueueModel.py
+++ b/mxcubecore/HardwareObjects/QueueModel.py
@@ -29,7 +29,6 @@ handle several models by using register_model and select_model.
 import contextlib
 import json
 import logging
-from unittest.mock import Mock
 
 import jsonpickle
 
@@ -37,6 +36,7 @@ from mxcubecore import HardwareRepository as HWR
 from mxcubecore import queue_entry
 from mxcubecore.BaseHardwareObjects import HardwareObject
 from mxcubecore.model import queue_model_objects
+from mxcubecore.utils.view_delegate import ViewDelegate
 
 
 class Serializer(object):
@@ -431,7 +431,7 @@ class QueueModel(HardwareObject):
             return
 
         parent_entry = self._get_parent_entry_for_child_added(parent)
-        entry = entry_cls(Mock(), child)
+        entry = entry_cls(ViewDelegate(self, child._node_id), child)
         HWR.beamline.queue_manager.enable_entry(entry, True)
 
         # DataCollection children (e.g. diffraction-plan collections) can

--- a/mxcubecore/utils/view_delegate.py
+++ b/mxcubecore/utils/view_delegate.py
@@ -1,0 +1,79 @@
+#
+#  Project name: MXCuBE
+#  https://github.com/mxcube
+#
+#  This file is part of MXCuBE software.
+#
+#  MXCuBE is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  MXCuBE is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+
+class ViewDelegate:
+    """
+    View item proxy/delegate, used to decouple the QueueEntry object from
+    the UI attached. Can replace the Qt View item
+
+    Implements methods queue entries call on their view and emits a singal
+    with the node id and method called so client (mxcubeweb/qt) can react
+    to whatever the entry intended to show, without mxcubecore depending on
+    any UI toolkit.
+    """
+
+    def __init__(self, queue_model, node_id):
+        self.queue_model = queue_model
+        self.node_id = node_id
+        self._data_model = None
+
+    def _notify(self, method_name):
+        self.queue_model.emit("view_delegate_called", (self.node_id, method_name))
+
+    def setText(self, column, text):
+        self._notify("setText")
+
+    def setOn(self, state):
+        self._notify("setOn")
+
+    def setHighlighted(self, state):
+        self._notify("setHighlighted")
+
+    def set_checkable(self, state):
+        self._notify("set_checkable")
+
+    def set_background_color(self, color_index):
+        self._notify("set_background_color")
+
+    def update_tool_tip(self):
+        self._notify("update_tool_tip")
+
+    def __getattr__(self, name):
+        """Guards against view methods this class hasn't been taught yet.
+
+        Reached only for names not defined above (normal attribute lookup
+        always wins first), so a queue entry calling an unmodelled view
+        method logs it instead of raising AttributeError or silently
+        pretending the call was handled via an emit.
+        """
+
+        def _unhandled(*args, **kwargs):
+            logging.getLogger("HWR").warning(
+                "ViewDelegate: unhandled view method '%s' called with "
+                "args=%s kwargs=%s (node_id=%s)",
+                name,
+                args,
+                kwargs,
+                self.node_id,
+            )
+
+        return _unhandled


### PR DESCRIPTION
This PR moves a few methods that really belong to `mxcubecore` but has lived in `mxcubeweb`. Since `mxcubeweb` is decoupled from `mxcubcore` and the client runs in a separate process, these methods almost all operate on node IDs instead of actual instances of entries and models

It also introduces a object `ViewDelegate` that replaces the use of the `Mock` object as a QView item replacement. The `ViewDeleage` gives a more fine grained control of what methods that are actually called and emits signal that can be used if needed. This can effectively also replace the QView item for the Qt application,  which would be a good step towards removing the `mxcubecore` depdency on Qt. At the moment the `ViewDelegate` is only used by `mxcubeweb`