### PR TITLE
ICATLIMS: use the pyicat-plus client and use models for ICAT fields

### DIFF
--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -7,16 +7,9 @@ from pathlib import Path
 from typing import Any, List, Optional
 from zoneinfo import ZoneInfo
 
-from icat_esrf_definitions.models import IcatDatasetParameters
-from icat_plus_client.exceptions import ApiException, ForbiddenException
-from icat_plus_client.models.investigation import Investigation
-from icat_plus_client.models.item import Item
-from icat_plus_client.models.item_experiment_plan_inner import ItemExperimentPlanInner
-from icat_plus_client.models.resourceinformation import Resourceinformation
-from icat_plus_client.models.sample import Sample
-from icat_plus_client.models.sampleinformation import Sampleinformation
-from icat_plus_client.models.session import Session as IcatSession
 from pydantic import ValidationError
+from pyicat_plus import errors as icat_errors
+from pyicat_plus.client import models as icat_models
 from pyicat_plus.client.main import IcatClient
 
 from mxcubecore import HardwareRepository as HWR
@@ -93,7 +86,9 @@ class ICATLIMS(AbstractLims):
             ),
         ]
 
-    def _create_icat_session(self, user_name: str, password: str) -> IcatSession:
+    def _create_icat_session(
+        self, user_name: str, password: str
+    ) -> icat_models.AuthSession:
         try:
             logger.debug(f"Authenticating {user_name}")
             icat_session = self.icatClient.do_log_in(
@@ -101,10 +96,10 @@ class ICATLIMS(AbstractLims):
                 username=user_name,
                 plugin=self.authentication_icat_plugin,
             )
-        except ForbiddenException as e:
+        except icat_errors.ForbiddenException as e:
             logger.error(f" Error occurred while authenticating. Access forbidden {e}")
             raise
-        except ApiException as e:
+        except icat_errors.ApiException as e:
             logger.error(f"Error occurred while authenticating {user_name}: {e}")
             raise
         return icat_session
@@ -115,7 +110,7 @@ class ICATLIMS(AbstractLims):
         password: str,
         session_manager: Optional[LimsSessionManager],
     ) -> LimsSessionManager:
-        self.icat_session: IcatSession = self._create_icat_session(
+        self.icat_session: icat_models.AuthSession = self._create_icat_session(
             user_name=user_name, password=password
         )
 
@@ -246,7 +241,7 @@ class ICATLIMS(AbstractLims):
                 len(self.loaded_pucks),
             )
 
-            sampleInformationList: List[Sampleinformation] = []
+            sampleInformationList: List[icat_models.SampleInformation] = []
             # Download all sampleInformation for the investigation
             # This makes to perform a single call to the server instead of one per sample
             try:
@@ -291,7 +286,9 @@ class ICATLIMS(AbstractLims):
         return hex(i)[2:].zfill(24)
 
     def __add_download_path_to_processing_plan(
-        self, processing_plan: List[ItemExperimentPlanInner], downloads: List[Download]
+        self,
+        processing_plan: List[icat_models.ExperimentPlanEntry],
+        downloads: List[Download],
     ):
         file_path_lookup = {}
         group_paths = defaultdict(list)
@@ -336,7 +333,7 @@ class ICATLIMS(AbstractLims):
             return str(json_str)
 
     def __extract_sample_identifiers(
-        self, tracking_sample: Sample, puck: LoadedPuck
+        self, tracking_sample: icat_models.Sample, puck: LoadedPuck
     ) -> dict:
         # Basic identifiers
         sample_name = tracking_sample.name
@@ -377,16 +374,16 @@ class ICATLIMS(AbstractLims):
         return sample_sheet.name if sample_sheet else sample_name
 
     def __experiment_plan_to_dict(
-        self, experiment_plan: List[ItemExperimentPlanInner] | None
+        self, experiment_plan: List[icat_models.ExperimentPlanEntry] | None
     ) -> dict[str, Any]:
         """Extract experiment plan values into a dictionary, using each item's key."""
         return {item.key: item.value.actual_instance for item in experiment_plan or []}
 
     def __prepare_processing_plan(
         self,
-        tracking_sample: Item,
+        tracking_sample: icat_models.ParcelItem,
         protein_acronym: str,
-        sample_information: Sampleinformation | None,
+        sample_information: icat_models.SampleInformation | None,
     ) -> dict[str, Any]:
         if not tracking_sample.processing_plan or tracking_sample.processing_plan == []:
             return {}
@@ -408,7 +405,7 @@ class ICATLIMS(AbstractLims):
         self,
         sample_sheet_id: str,
         protein_acronym: str,
-        sample_information: Sampleinformation | None,
+        sample_information: icat_models.SampleInformation | None,
     ) -> List[Download]:
         cache_key = (sample_sheet_id, protein_acronym)
         logger.debug(f"Getting sample information for {protein_acronym}")
@@ -449,9 +446,9 @@ class ICATLIMS(AbstractLims):
 
     def __to_sample(
         self,
-        tracking_sample: Item,
+        tracking_sample: icat_models.ParcelItem,
         puck: LoadedPuck,
-        sample_information_list: List[Sampleinformation],
+        sample_information_list: List[icat_models.SampleInformation],
     ) -> dict[str, Any]:
         """
         Convert a tracking sample and associated metadata into the internal
@@ -470,7 +467,7 @@ class ICATLIMS(AbstractLims):
         """
         sample_id_info = self.__extract_sample_identifiers(tracking_sample, puck)
 
-        # converts experiment plan from list of ItemExperimentPlanInner to a dictionary
+        # converts experiment plan from list of icat_models.ExperimentPlanEntry to a dictionary
         experiment_plan = self.__experiment_plan_to_dict(
             tracking_sample.experiment_plan
         )
@@ -632,7 +629,7 @@ class ICATLIMS(AbstractLims):
         logger.warning("No investigation found")
         return None
 
-    def __get_all_investigations(self) -> List[Investigation]:
+    def __get_all_investigations(self) -> List[icat_models.InvestigationDetails]:
         """Returns all investigations by user. An investigation corresponds to
         one experimental session. It returns an empty array in case of error"""
         self.investigations = []
@@ -689,7 +686,9 @@ class ICATLIMS(AbstractLims):
 
         return self.investigations
 
-    def _get_data_portal_url(self, investigation: Investigation) -> str:
+    def _get_data_portal_url(
+        self, investigation: icat_models.InvestigationDetails
+    ) -> str:
         try:
             return (
                 self.data_portal_url.replace("{id}", str(investigation.id))
@@ -699,7 +698,7 @@ class ICATLIMS(AbstractLims):
         except Exception:
             return ""
 
-    def _get_logbook_url(self, investigation: Investigation) -> str:
+    def _get_logbook_url(self, investigation: icat_models.InvestigationDetails) -> str:
         try:
             return (
                 self.logbook_url.replace("{id}", str(investigation.id))
@@ -709,7 +708,9 @@ class ICATLIMS(AbstractLims):
         except Exception:
             return ""
 
-    def _get_user_portal_url(self, investigation: Investigation) -> str:
+    def _get_user_portal_url(
+        self, investigation: icat_models.InvestigationDetails
+    ) -> str:
         try:
             return (
                 self.user_portal_url.replace(
@@ -723,7 +724,7 @@ class ICATLIMS(AbstractLims):
             return ""
 
     def __get_proposal_number_by_investigation(
-        self, investigation: Investigation
+        self, investigation: icat_models.InvestigationDetails
     ) -> str:
         """
         Given an investigation it returns the proposal number.
@@ -734,7 +735,7 @@ class ICATLIMS(AbstractLims):
         """
         return investigation.name.replace(investigation.type.name, "").replace("-", "")
 
-    def __to_session(self, investigation: Investigation) -> Session:
+    def __to_session(self, investigation: icat_models.InvestigationDetails) -> Session:
         """This methods converts a ICAT investigation into a session"""
         actual_start_date = (
             investigation.parameters["__actualStartDate"]
@@ -786,14 +787,18 @@ class ICATLIMS(AbstractLims):
     def get_user_name(self):
         return self.icat_session.username
 
-    def to_sessions(self, investigations: List[Investigation]) -> List[Session]:
+    def to_sessions(
+        self, investigations: List[icat_models.InvestigationDetails]
+    ) -> List[Session]:
         return [self.__to_session(investigation) for investigation in investigations]
 
-    def get_samples_by_investigation(self, investigation_id: str) -> List[Sample]:
+    def get_samples_by_investigation(
+        self, investigation_id: str
+    ) -> List[icat_models.Sample]:
         """Return the sample records associated with an investigation."""
         samples_List = []
         try:
-            samples_List: List[Sample] = self.icatClient.get_samples_by(
+            samples_List: List[icat_models.Sample] = self.icatClient.get_samples_by(
                 investigation_id=investigation_id
             )
             msg = f"Successfully retrieved {len(samples_List)} samples"
@@ -888,7 +893,7 @@ class ICATLIMS(AbstractLims):
 
     def store_common_data(
         self, datacollection_dict: dict
-    ) -> tuple[IcatDatasetParameters, dict]:
+    ) -> tuple[icat_models.IcatDatasetParameters, dict]:
         """Fill in the pydantic model fields common to all the data
         collection techniques.
         Args:
@@ -896,7 +901,7 @@ class ICATLIMS(AbstractLims):
 
         Returns:
             A tuple ``(params, extra)``.
-            ``params`` is a partially-filled ``IcatDatasetParameters.blank()`` instance.
+            ``params`` is a partially-filled ``icat_models.IcatDatasetParameters.blank()`` instance.
             ``extra`` holds flat ICAT keys with no corresponding model field.
         """
         sample_id = datacollection_dict.get("blSampleId")
@@ -983,7 +988,7 @@ class ICATLIMS(AbstractLims):
         if cryo_temperature == "room temperature":
             extra["InstrumentCryostat01_value"] = cryo_temperature
 
-        params = IcatDatasetParameters.blank()
+        params = icat_models.IcatDatasetParameters.blank()
         params.sample.name = sample_name
         params.start_time = start_time
         params.end_time = end_time
@@ -1168,7 +1173,7 @@ class ICATLIMS(AbstractLims):
 
     def __get_sample_information_by(
         self, sample_id: str
-    ) -> Optional[Sampleinformation]:
+    ) -> Optional[icat_models.SampleInformation]:
         """
         Fetches sample metadata and associated resources based on the sample ID.
 
@@ -1179,14 +1184,14 @@ class ICATLIMS(AbstractLims):
             Optional[SampleInformation]: Returns a SampleInformation object or None.
         """
         try:
-            sampleInformationList: List[Sampleinformation] = (
+            sampleInformationList: List[icat_models.SampleInformation] = (
                 self.icatClient.get_sample_information_list_by(sample_id=str(sample_id))
             )
             if sampleInformationList is not None and len(sampleInformationList) > 0:
                 return sampleInformationList[0]
             return None
 
-        except ApiException as e:
+        except icat_errors.ApiException as e:
             if e.status == 404:
                 logger.info("Sample %s not found (404)", sample_id)
             else:
@@ -1198,7 +1203,7 @@ class ICATLIMS(AbstractLims):
     def _download_resources(
         self,
         sample_id: str,
-        resources: List[Resourceinformation] | None,
+        resources: List[icat_models.FileResource] | None,
         output_folder: str,
         sample_name: str,
     ) -> List[Download]:
@@ -1237,7 +1242,7 @@ class ICATLIMS(AbstractLims):
                 downloaded_files.append(downloaded)
                 logger.info("Downloaded %s to %s", resource.filename, downloaded.path)
 
-            except ApiException:
+            except icat_errors.ApiException:
                 logger.exception("Failed to download %s", resource.filename)
 
         return downloaded_files

--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -7,10 +7,8 @@ from pathlib import Path
 from typing import Any, List, Optional
 from zoneinfo import ZoneInfo
 
-import icat_plus_client
-import requests
-from icat_plus_client.exceptions import ForbiddenException
-from icat_plus_client.models.credentials import Credentials
+from icat_esrf_definitions.models import IcatDatasetParameters
+from icat_plus_client.exceptions import ApiException, ForbiddenException
 from icat_plus_client.models.investigation import Investigation
 from icat_plus_client.models.item import Item
 from icat_plus_client.models.item_experiment_plan_inner import ItemExperimentPlanInner
@@ -18,7 +16,6 @@ from icat_plus_client.models.resourceinformation import Resourceinformation
 from icat_plus_client.models.sample import Sample
 from icat_plus_client.models.sampleinformation import Sampleinformation
 from icat_plus_client.models.session import Session as IcatSession
-from icat_plus_client.rest import ApiException
 from pydantic import ValidationError
 from pyicat_plus.client.main import IcatClient
 
@@ -35,6 +32,8 @@ from mxcubecore.model.tracking_model_objects import LoadedPuck
 
 logger = logging.getLogger("HWR")
 
+# Attribute names read off the beamline_config object in
+# add_beamline_configuration_metadata(). Not ICAT schema keys.
 PROTEIN_ACRONYM_KEY = "proteinAcronym"
 DETECTOR_PX_KEY = "detector_px"
 DETECTOR_PY_KEY = "detector_py"
@@ -47,84 +46,18 @@ SYNCHROTRON_NAME_KEY = "synchrotron_name"
 MONOCHROMATOR_TYPE_KEY = "monochromator_type"
 DETECTOR_TYPE_KEY = "detector_type"
 
-INSTRUMENT_DETECTOR_BEAM_CENTER_X_KEY = "InstrumentDetector01_beam_center_x"
-INSTRUMENT_DETECTOR_BEAM_CENTER_Y_KEY = "InstrumentDetector01_beam_center_y"
-INSTRUMENT_BEAM_VERTICAL_DIVERGENCE_KEY = (
-    "InstrumentBeam_vertical_incident_beam_divergence"
-)
-INSTRUMENT_BEAM_HORIZONTAL_DIVERGENCE_KEY = (
-    "InstrumentBeam_horizontal_incident_beam_divergence"
-)
-INSTRUMENT_BEAM_FINAL_POLARIZATION_KEY = "InstrumentBeam_final_polarization"
-INSTRUMENT_DETECTOR_MODEL_KEY = "InstrumentDetector01_model"
-INSTRUMENT_DETECTOR_MANUFACTURER_KEY = "InstrumentDetector01_manufacturer"
-INSTRUMENT_SOURCE_NAME_KEY = "InstrumentSource_name"
-INSTRUMENT_MONOCHROMATOR_CRYSTAL_TYPE_KEY = "InstrumentMonochromatorCrystal_type"
-INSTRUMENT_DETECTOR_TYPE_KEY = "InstrumentDetector01_type"
-
-SCAN_TYPE_KEY = "scanType"
-MX_DIRECTORY_KEY = "MX_directory"
-MX_EXPOSURE_TIME_KEY = "MX_exposureTime"
-INSTRUMENT_DETECTOR_MODEL_KEY = "InstrumentDetector01_model"
-MX_ELEMENT_KEY = "MX_element"
-MX_EDGE_ENERGY_KEY = "MX_edgeEnergy"
-MX_START_ENERGY_KEY = "MX_startEnergy"
-MX_END_ENERGY_KEY = "MX_endEnergy"
-MX_PEAK_ENERGY_KEY = "MX_peakEnergy"
-MX_INFLECTION_ENERGY_KEY = "MX_inflectioEnergy"
-MX_REMOTE_ENERGY_KEY = "MX_remoteEnergy"
-MX_PEAK_F_PRIME_KEY = "MX_peakFPrime"
-MX_PEAK_F_DOUBLE_PRIME_KEY = "MX_peakFDoublePrime"
-MX_INFLECTION_F_PRIME_KEY = "MX_inflectionFPrime"
-MX_INFLECTION_F_DOUBLE_PRIME_KEY = "MX_inflectionFDoublePrime"
-MX_COMMENTS_KEY = "MX_comments"
-MX_DATA_COLLECTION_ID_KEY = "MX_dataCollectionId"
-MX_DETECTOR_DISTANCE_KEY = "MX_detectorDistance"
-MX_DIRECTORY_KEY = "MX_directory"
-MX_EXPOSURE_TIME_KEY = "MX_exposureTime"
-MX_POSITION_NAME_KEY = "MX_positionName"
-MX_NUMBER_OF_IMAGES_KEY = "MX_numberOfImages"
-MX_OSCILLATION_RANGE_KEY = "MX_oscillationRange"
-MX_AXIS_START_KEY = "MX_axis_start"
-MX_OSCILLATION_OVERLAP_KEY = "MX_oscillationOverlap"
-MX_RESOLUTION_KEY = "MX_resolution"
-MX_RESOLUTION_AT_CORNER_KEY = "MX_resolution_at_corner"
-MX_START_IMAGE_NUMBER_KEY = "MX_startImageNumber"
-MX_TEMPLATE_KEY = "MX_template"
-SAMPLE_NAME_KEY = "Sample_name"
-WORKFLOW_NAME_KEY = "Workflow_name"
-WORKFLOW_TYPE_KEY = "Workflow_type"
-WORKFLOW_ID_KEY = "Workflow_id"
-WORKFLOW_NOTE_KEY = "Workflow_note"
-MX_KAPPA_SETTINGS_ID_KEY = "MX_kappa_settings_id"
-MX_CHARACTERISATION_ID_KEY = "MX_characterisation_id"
-MX_POSITION_ID_KEY = "MX_position_id"
-GROUP_BY_KEY = "group_by"
-SAMPLE_TRACKING_CONTAINER_TYPE_KEY = "SampleTrackingContainer_type"
-SAMPLE_TRACKING_CONTAINER_CAPACITY_KEY = "SampleTrackingContainer_capacity"
-SAMPLE_CHANGER_POSITION_KEY = "SampleChanger_position"
-SAMPLE_TRACKING_CONTAINER_POSITION_KEY = "SampleTrackingContainer_position"
-SAMPLE_TRACKING_CONTAINER_ID_KEY = "SampleTrackingContainer_id"
-SAMPLE_TRACKING_PARCEL_ID_KEY = "SampleTrackingParcel_id"
-SAMPLE_TRACKING_PARCEL_NAME_KEY = "SampleTrackingParcel_name"
-START_DATE_KEY = "startDate"
-END_DATE_KEY = "endDate"
-INVESTIGATION_ID_KEY = "investigationId"
-PROPOSAL_KEY = "proposal"
-MX_BEAM_SHAPE_KEY = "MX_beamShape"
-MX_BEAM_SIZE_AT_SAMPLE_X_KEY = "MX_beamSizeAtSampleX"
-MX_BEAM_SIZE_AT_SAMPLE_Y_KEY = "MX_beamSizeAtSampleY"
-MX_X_BEAM_KEY = "MX_xBeam"
-MX_Y_BEAM_KEY = "MX_yBeam"
-MX_FLUX_KEY = "MX_flux"
-MX_FLUX_END_KEY = "MX_fluxEnd"
-MX_TRANSMISSION_KEY = "MX_transmission"
-INSTRUMENT_MONOCHROMATOR_WAVELENGTH_KEY = "InstrumentMonochromator_wavelength"
-INSTRUMENT_MONOCHROMATOR_ENERGY_KEY = "InstrumentMonochromator_energy"
-INSTRUMENT_SOURCE_CURRENT_KEY = "InstrumentSource_current"
-INSTRUMENT_SOURCE_MODE_KEY = "InstrumentSource_mode"
-INSTRUMENT_CRYOSTAT_VALUE_KEY = "InstrumentCryostat01_value"
+# No icat_esrf_definitions field exists for these yet.
 ACTUAL_INSTRUMENT_KEY = "__actualInstrument"
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    """Coerce a value for an ICAT model field typed as plain ``str``.
+
+    Unlike its quantity-typed fields, icat_esrf_definitions' plain ``str``
+    fields don't coerce numbers, so numeric values (e.g. a detector position
+    or a database id) must be stringified explicitly before assignment.
+    """
+    return None if value is None else str(value)
 
 
 class ICATLIMS(AbstractLims):
@@ -152,13 +85,6 @@ class ICATLIMS(AbstractLims):
             reschedule_investigation_urls=[self.activemq_url],
         )
 
-        api_client = icat_plus_client.ApiClient(
-            icat_plus_client.Configuration(host=self.url)
-        )
-        self.tracking_api_instance = icat_plus_client.TrackingApi(api_client)
-        self.catalogue_api_instance = icat_plus_client.CatalogueApi(api_client)
-        self.session_api_instance = icat_plus_client.SessionApi(api_client)
-
     def get_lims_name(self) -> List[Lims]:
         return [
             Lims(
@@ -170,17 +96,18 @@ class ICATLIMS(AbstractLims):
     def _create_icat_session(self, user_name: str, password: str) -> IcatSession:
         try:
             logger.debug(f"Authenticating {user_name}")
-            credentials = Credentials(
-                plugin=self.authentication_icat_plugin, password=password
+            icat_session = self.icatClient.do_log_in(
+                password=password,
+                username=user_name,
+                plugin=self.authentication_icat_plugin,
             )
-            icat_session = self.session_api_instance.session_post(credentials)
         except ForbiddenException as e:
             logger.error(f" Error occurred while authenticating. Access forbidden {e}")
             raise
         except ApiException as e:
             logger.error(f"Error occurred while authenticating {user_name}: {e}")
             raise
-        return icat_session  # response.model_dump(by_alias=True)
+        return icat_session
 
     def login(
         self,
@@ -244,14 +171,12 @@ class ICATLIMS(AbstractLims):
 
         return self.lims_rest.to_sessions(self.lims_rest.investigations)
 
-    def _get_loaded_pucks(
-        self, icat_token: str, investigation_id: str
-    ) -> List[LoadedPuck]:
+    def _get_loaded_pucks(self, investigation_id: str) -> List[LoadedPuck]:
         """Return pucks with a defined sample changer location."""
         self.parcels = []
         try:
-            self.parcels = self.tracking_api_instance.tracking_session_id_parcel_get(
-                icat_token, investigation_id=investigation_id
+            self.parcels = self.icatClient.get_parcels_by(
+                investigation_id=investigation_id
             )
             logger.debug(
                 "Successfully retrieved %d parcels for investigation %s",
@@ -296,7 +221,6 @@ class ICATLIMS(AbstractLims):
         try:
             session = self.session_manager.active_session
             investigation_id = session.session_id
-            icat_token = self.icat_session.session_id
 
             logger.debug(
                 "[ICATClient] get_samples: investigation_id=%s, proposal_name=%s",
@@ -305,7 +229,6 @@ class ICATLIMS(AbstractLims):
             )
 
             self.sample_sheets = self.get_samples_by_investigation(
-                icat_token,
                 investigation_id,
             )
 
@@ -316,7 +239,6 @@ class ICATLIMS(AbstractLims):
 
             # Filter for loaded pucks
             self.loaded_pucks = self._get_loaded_pucks(
-                icat_token,
                 investigation_id,
             )
             logger.debug(
@@ -328,10 +250,8 @@ class ICATLIMS(AbstractLims):
             # Download all sampleInformation for the investigation
             # This makes to perform a single call to the server instead of one per sample
             try:
-                sampleInformationList = (
-                    self.catalogue_api_instance.catalogue_session_id_files_get(
-                        icat_token, investigation_id=str(investigation_id)
-                    )
+                sampleInformationList = self.icatClient.get_sample_information_list_by(
+                    investigation_id=str(investigation_id)
                 )
             except Exception as e:
                 logger.exception(
@@ -346,7 +266,7 @@ class ICATLIMS(AbstractLims):
                 logger.debug(msg)
                 for tracking_sample in tracking_samples:
                     sample = self.__to_sample(
-                        tracking_sample, puck, icat_token, sampleInformationList
+                        tracking_sample, puck, sampleInformationList
                     )
                     self.samples.append(sample)
 
@@ -464,7 +384,6 @@ class ICATLIMS(AbstractLims):
 
     def __prepare_processing_plan(
         self,
-        icat_token: str,
         tracking_sample: Item,
         protein_acronym: str,
         sample_information: Sampleinformation | None,
@@ -473,7 +392,7 @@ class ICATLIMS(AbstractLims):
             return {}
 
         downloads: List[Download] = self.__download_resource(
-            icat_token, tracking_sample.sample_id, protein_acronym, sample_information
+            tracking_sample.sample_id, protein_acronym, sample_information
         )
 
         if downloads:
@@ -487,7 +406,6 @@ class ICATLIMS(AbstractLims):
 
     def __download_resource(
         self,
-        icat_token: str,
         sample_sheet_id: str,
         protein_acronym: str,
         sample_information: Sampleinformation | None,
@@ -519,7 +437,6 @@ class ICATLIMS(AbstractLims):
         )
 
         downloads = self._download_resources(
-            icat_token,
             sample_sheet_id,
             sample_information.resources,
             destination_folder,
@@ -534,7 +451,6 @@ class ICATLIMS(AbstractLims):
         self,
         tracking_sample: Item,
         puck: LoadedPuck,
-        icat_token: str,
         sample_information_list: List[Sampleinformation],
     ) -> dict[str, Any]:
         """
@@ -568,7 +484,6 @@ class ICATLIMS(AbstractLims):
             None,
         )
         processing_plan = self.__prepare_processing_plan(
-            icat_token,
             tracking_sample,
             sample_id_info[PROTEIN_ACRONYM_KEY],
             sample_information,
@@ -735,19 +650,12 @@ class ICATLIMS(AbstractLims):
                 or self.icat_session.is_instrument_scientist
             ):
                 # Setting up of the session done by admin or staff
-                self.investigations = (
-                    self.catalogue_api_instance.catalogue_session_id_investigation_get(
-                        self.icat_session.session_id,
-                        start_date=(
-                            datetime.today()
-                            - timedelta(days=float(self.before_offset_days))
-                        ).strftime("%Y-%m-%d"),
-                        end_date=(
-                            datetime.today()
-                            + timedelta(days=float(self.after_offset_days))
-                        ).strftime("%Y-%m-%d"),
-                        instrument_name=self.compatible_beamlines,
-                    )
+                self.investigations = self.icatClient.get_investigations_by(
+                    start_date=datetime.today()
+                    - timedelta(days=float(self.before_offset_days)),
+                    end_date=datetime.today()
+                    + timedelta(days=float(self.after_offset_days)),
+                    instrument_name=self.compatible_beamlines,
                 )
 
             elif self.only_staff_session_selection:
@@ -759,27 +667,17 @@ class ICATLIMS(AbstractLims):
                     )
                     return []
 
-                self.investigations = (
-                    self.catalogue_api_instance.catalogue_session_id_investigation_get(
-                        self.icat_session.session_id,
-                        ids=[self.session_manager.active_session.session_id],
-                    )
+                self.investigations = self.icatClient.get_investigations_by(
+                    ids=[self.session_manager.active_session.session_id],
                 )
             else:
-                self.investigations = (
-                    self.catalogue_api_instance.catalogue_session_id_investigation_get(
-                        self.icat_session.session_id,
-                        filter=self.filter,
-                        instrument_name=self.compatible_beamlines,
-                        start_date=(
-                            datetime.today()
-                            - timedelta(days=float(self.before_offset_days))
-                        ).strftime("%Y-%m-%d"),
-                        end_date=(
-                            datetime.today()
-                            + timedelta(days=float(self.after_offset_days))
-                        ).strftime("%Y-%m-%d"),
-                    )
+                self.investigations = self.icatClient.get_investigations_by(
+                    filter=self.filter,
+                    instrument_name=self.compatible_beamlines,
+                    start_date=datetime.today()
+                    - timedelta(days=float(self.before_offset_days)),
+                    end_date=datetime.today()
+                    + timedelta(days=float(self.after_offset_days)),
                 )
         except Exception:
             self.investigations = []
@@ -891,16 +789,12 @@ class ICATLIMS(AbstractLims):
     def to_sessions(self, investigations: List[Investigation]) -> List[Session]:
         return [self.__to_session(investigation) for investigation in investigations]
 
-    def get_samples_by_investigation(
-        self, icat_token: str, investigation_id: str
-    ) -> List[Sample]:
+    def get_samples_by_investigation(self, investigation_id: str) -> List[Sample]:
         """Return the sample records associated with an investigation."""
         samples_List = []
         try:
-            samples_List: List[Sample] = (
-                self.catalogue_api_instance.catalogue_session_id_samples_get(
-                    icat_token, investigation_id=investigation_id
-                )
+            samples_List: List[Sample] = self.icatClient.get_samples_by(
+                investigation_id=investigation_id
             )
             msg = f"Successfully retrieved {len(samples_List)} samples"
             logger.debug(msg)
@@ -916,28 +810,43 @@ class ICATLIMS(AbstractLims):
     def is_connected(self):
         return self.login_ok
 
-    def add_beamline_configuration_metadata(self, metadata, beamline_config):
+    def add_beamline_configuration_metadata(self, instrument, beamline_config):
         """
-        This is the mapping betweeh the beamline_config dict and the ICAt keys
-        in case they exist then they will be added to the metadata of the dataset
+        This is the mapping between the beamline_config dict and the ICAT
+        instrument model fields. Fields that exist on beamline_config are
+        added to the dataset's instrument metadata.
         """
-        if beamline_config is not None:
-            key_mapping = {
-                DETECTOR_PX_KEY: INSTRUMENT_DETECTOR_BEAM_CENTER_X_KEY,
-                DETECTOR_PY_KEY: INSTRUMENT_DETECTOR_BEAM_CENTER_Y_KEY,
-                BEAM_DIVERGENCE_VERTICAL_KEY: INSTRUMENT_BEAM_VERTICAL_DIVERGENCE_KEY,
-                BEAM_DIVERGENCE_HORIZONTAL_KEY: INSTRUMENT_BEAM_HORIZONTAL_DIVERGENCE_KEY,
-                POLARISATION_KEY: INSTRUMENT_BEAM_FINAL_POLARIZATION_KEY,
-                DETECTOR_MODEL_KEY: INSTRUMENT_DETECTOR_MODEL_KEY,
-                DETECTOR_MANUFACTURER_KEY: INSTRUMENT_DETECTOR_MANUFACTURER_KEY,
-                SYNCHROTRON_NAME_KEY: INSTRUMENT_SOURCE_NAME_KEY,
-                MONOCHROMATOR_TYPE_KEY: INSTRUMENT_MONOCHROMATOR_CRYSTAL_TYPE_KEY,
-                DETECTOR_TYPE_KEY: INSTRUMENT_DETECTOR_TYPE_KEY,
-            }
+        if beamline_config is None:
+            return
 
-            for config_key, metadata_key in key_mapping.items():
-                if hasattr(beamline_config, config_key):
-                    metadata[metadata_key] = getattr(beamline_config, config_key)
+        key_mapping = {
+            DETECTOR_PX_KEY: (instrument.detector01, "beam_center_x"),
+            DETECTOR_PY_KEY: (instrument.detector01, "beam_center_y"),
+            BEAM_DIVERGENCE_VERTICAL_KEY: (
+                instrument.beam,
+                "vertical_incident_beam_divergence",
+            ),
+            BEAM_DIVERGENCE_HORIZONTAL_KEY: (
+                instrument.beam,
+                "horizontal_incident_beam_divergence",
+            ),
+            POLARISATION_KEY: (instrument.beam, "final_polarization"),
+            DETECTOR_MODEL_KEY: (instrument.detector01, "model"),
+            DETECTOR_MANUFACTURER_KEY: (instrument.detector01, "manufacturer"),
+            SYNCHROTRON_NAME_KEY: (instrument.source, "name"),
+            MONOCHROMATOR_TYPE_KEY: (instrument.monochromator.crystal, "type"),
+            DETECTOR_TYPE_KEY: (instrument.detector01, "type"),
+        }
+
+        # beam_center_x/y are plain str fields (not quantities): stringify
+        # explicitly since the config value is typically numeric.
+        str_only_attrs = {"beam_center_x", "beam_center_y"}
+        for config_key, (target, attr_name) in key_mapping.items():
+            if hasattr(beamline_config, config_key):
+                value = getattr(beamline_config, config_key)
+                if attr_name in str_only_attrs:
+                    value = _optional_str(value)
+                setattr(target, attr_name, value)
 
     def find_sample_by_sample_id(self, sample_id):
         return next(
@@ -977,11 +886,18 @@ class ICATLIMS(AbstractLims):
     def store_image(self, image_dict: dict):
         pass
 
-    def store_common_data(self, datacollection_dict: dict) -> dict:
-        """Fill in a dictionary with the common for all the
-        data collection techniques meta data.
+    def store_common_data(
+        self, datacollection_dict: dict
+    ) -> tuple[IcatDatasetParameters, dict]:
+        """Fill in the pydantic model fields common to all the data
+        collection techniques.
         Args:
             datacollection_dict(dict): dictionarry from the data collection.
+
+        Returns:
+            A tuple ``(params, extra)``.
+            ``params`` is a partially-filled ``IcatDatasetParameters.blank()`` instance.
+            ``extra`` holds flat ICAT keys with no corresponding model field.
         """
         sample_id = datacollection_dict.get("blSampleId")
         msg = f"SampleId is: {sample_id}"
@@ -1058,30 +974,37 @@ class ICATLIMS(AbstractLims):
             except RuntimeError:
                 cryo_temperature = None
 
-        result = {
-            SAMPLE_NAME_KEY: sample_name,
-            START_DATE_KEY: start_time,
-            END_DATE_KEY: end_time,
-            INVESTIGATION_ID_KEY: investigation_id,
-            PROPOSAL_KEY: investigation_name,
-            MX_BEAM_SHAPE_KEY: shape.value,
-            MX_BEAM_SIZE_AT_SAMPLE_X_KEY: bsx,
-            MX_BEAM_SIZE_AT_SAMPLE_Y_KEY: bsy,
-            MX_X_BEAM_KEY: xbeam,
-            MX_Y_BEAM_KEY: ybeam,
-            MX_FLUX_KEY: datacollection_dict.get("flux"),
-            MX_FLUX_END_KEY: flux_end,
-            MX_TRANSMISSION_KEY: transmission,
-            INSTRUMENT_MONOCHROMATOR_WAVELENGTH_KEY: wavelength,
-            INSTRUMENT_MONOCHROMATOR_ENERGY_KEY: energy,
-            INSTRUMENT_SOURCE_CURRENT_KEY: machine_info.get("current"),
-            INSTRUMENT_SOURCE_MODE_KEY: machine_info.get("fill_mode"),
-            INSTRUMENT_CRYOSTAT_VALUE_KEY: cryo_temperature,
-        }
+        extra = {}
         if actual_instrument is not None:
-            result[ACTUAL_INSTRUMENT_KEY] = actual_instrument
+            extra[ACTUAL_INSTRUMENT_KEY] = actual_instrument
 
-        return result
+        # IcatCryostat.value is a numeric quantity: the "room temperature"
+        # sentinel string can't go through it, so it's sent as a plain key.
+        if cryo_temperature == "room temperature":
+            extra["InstrumentCryostat01_value"] = cryo_temperature
+
+        params = IcatDatasetParameters.blank()
+        params.sample.name = sample_name
+        params.start_time = start_time
+        params.end_time = end_time
+        params.investigationId = investigation_id
+        params.proposal = investigation_name
+        params.instrument.monochromator.wavelength = wavelength
+        params.instrument.monochromator.energy = energy
+        params.instrument.source.current = machine_info.get("current")
+        params.instrument.source.mode = machine_info.get("fill_mode")
+        if cryo_temperature is not None and cryo_temperature != "room temperature":
+            params.instrument.cryostat01.value = cryo_temperature
+        params.MX.beamShape = shape.value
+        params.MX.beamSizeAtSampleX = bsx
+        params.MX.beamSizeAtSampleY = bsy
+        params.MX.xBeam = xbeam
+        params.MX.yBeam = ybeam
+        params.MX.flux = datacollection_dict.get("flux")
+        params.MX.fluxEnd = flux_end
+        params.MX.transmission = transmission
+
+        return params, extra
 
     def __format_datetime(self, value: str) -> str:
         try:
@@ -1096,7 +1019,7 @@ class ICATLIMS(AbstractLims):
 
     def store_energy_scan(self, energyscan_dict: dict):
         try:
-            metadata = self.store_common_data(energyscan_dict)
+            params, extra = self.store_common_data(energyscan_dict)
             try:
                 beamline = self._get_scheduled_beamline()
                 msg = f"Dataset Beamline={beamline} "
@@ -1115,53 +1038,44 @@ class ICATLIMS(AbstractLims):
             end_time = energyscan_dict.get("endTime", "")
 
             if start_time:
-                metadata["startDate"] = self.__format_datetime(start_time)
+                params.start_time = self.__format_datetime(start_time)
 
             if end_time:
-                metadata["endDate"] = self.__format_datetime(end_time)
+                params.end_time = self.__format_datetime(end_time)
 
-            if start_time:
-                try:
-                    dt_aware = datetime.strptime(
-                        start_time, "%Y-%m-%d %H:%M:%S"
-                    ).replace(tzinfo=ZoneInfo("Europe/Paris"))
-                    start_time = dt_aware.isoformat(timespec="microseconds")
-                    metadata.update({"startDate": start_time})
-                except (ValueError, TypeError):
-                    self.log.exception("Cannot parse start time")
+            params.title = str(directory.name)
+            params.folder_path = str(directory)
 
-            if end_time:
-                try:
-                    dt_aware = datetime.strptime(end_time, "%Y-%m-%d %H:%M:%S").replace(
-                        tzinfo=ZoneInfo("Europe/Paris")
-                    )
-                    end_time = dt_aware.isoformat(timespec="microseconds")
-                    metadata.update({"endDate": end_time})
-                except (ValueError, TypeError):
-                    self.log.exception("Cannot parse end time")
+            mx = params.MX
+            mx.directory = str(directory)
+            mx.exposureTime = energyscan_dict.get("exposureTime")
+            mx.scanType = "energy_scan"
 
+            params.instrument.detector01.model = energyscan_dict.get(
+                "fluorescenceDetector"
+            )
+
+            params = params.finalize()
+            metadata = params.to_icat_dict()
+            metadata.update(extra)
+            # No icat_esrf_definitions model field exists yet for these
+            # energy-scan-specific values, so they stay as plain flat keys.
             metadata.update(
                 {
-                    SCAN_TYPE_KEY: "energy_scan",
-                    MX_DIRECTORY_KEY: str(directory),
-                    MX_EXPOSURE_TIME_KEY: energyscan_dict.get("exposureTime"),
-                    INSTRUMENT_DETECTOR_MODEL_KEY: energyscan_dict.get(
-                        "fluorescenceDetector"
-                    ),
-                    MX_ELEMENT_KEY: energyscan_dict.get("element"),
-                    MX_EDGE_ENERGY_KEY: energyscan_dict.get("edgeEnergy"),
-                    MX_START_ENERGY_KEY: energyscan_dict.get("startEnergy"),
-                    MX_END_ENERGY_KEY: energyscan_dict.get("endEnergy"),
-                    MX_PEAK_ENERGY_KEY: energyscan_dict.get("endEnergy"),
-                    MX_INFLECTION_ENERGY_KEY: energyscan_dict.get("inflectioEnergy"),
-                    MX_REMOTE_ENERGY_KEY: energyscan_dict.get("remoteEnergy"),
-                    MX_PEAK_F_PRIME_KEY: energyscan_dict.get("peakFPrime"),
-                    MX_PEAK_F_DOUBLE_PRIME_KEY: energyscan_dict.get("peakFDoublePrime"),
-                    MX_INFLECTION_F_PRIME_KEY: energyscan_dict.get("inflectionFPrime"),
-                    MX_INFLECTION_F_DOUBLE_PRIME_KEY: energyscan_dict.get(
+                    "MX_element": energyscan_dict.get("element"),
+                    "MX_edgeEnergy": energyscan_dict.get("edgeEnergy"),
+                    "MX_startEnergy": energyscan_dict.get("startEnergy"),
+                    "MX_endEnergy": energyscan_dict.get("endEnergy"),
+                    "MX_peakEnergy": energyscan_dict.get("endEnergy"),
+                    "MX_inflectioEnergy": energyscan_dict.get("inflectioEnergy"),
+                    "MX_remoteEnergy": energyscan_dict.get("remoteEnergy"),
+                    "MX_peakFPrime": energyscan_dict.get("peakFPrime"),
+                    "MX_peakFDoublePrime": energyscan_dict.get("peakFDoublePrime"),
+                    "MX_inflectionFPrime": energyscan_dict.get("inflectionFPrime"),
+                    "MX_inflectionFDoublePrime": energyscan_dict.get(
                         "inflectionFDoublePrime"
                     ),
-                    MX_COMMENTS_KEY: energyscan_dict.get("comments"),
+                    "MX_comments": energyscan_dict.get("comments"),
                 }
             )
 
@@ -1178,7 +1092,7 @@ class ICATLIMS(AbstractLims):
     def store_xfe_spectrum(self, xfespectrum_dict: dict):
         status = {"xfeFluorescenceSpectrumId": -1}
         try:
-            metadata = self.store_common_data(xfespectrum_dict)
+            params, extra = self.store_common_data(xfespectrum_dict)
             try:
                 beamline = self._get_scheduled_beamline()
                 msg = f"Dataset Beamline={beamline} "
@@ -1196,15 +1110,22 @@ class ICATLIMS(AbstractLims):
             start_time = xfespectrum_dict.get("startTime", "")
             end_time = xfespectrum_dict.get("endTime", "")
 
-            metadata.update(
-                {
-                    SCAN_TYPE_KEY: "xrf",
-                    MX_DIRECTORY_KEY: str(directory),
-                    MX_EXPOSURE_TIME_KEY: xfespectrum_dict.get("exposureTime"),
-                    "startDate": start_time,
-                    "endDate": end_time,
-                }
-            )
+            if start_time:
+                params.start_time = start_time
+            if end_time:
+                params.end_time = end_time
+
+            params.title = str(directory.name)
+            params.folder_path = str(directory)
+
+            mx = params.MX
+            mx.directory = str(directory)
+            mx.exposureTime = xfespectrum_dict.get("exposureTime")
+            mx.scanType = "xrf"
+
+            params = params.finalize()
+            metadata = params.to_icat_dict()
+            metadata.update(extra)
 
             self.icatClient.store_dataset(
                 beamline=beamline,
@@ -1246,7 +1167,7 @@ class ICATLIMS(AbstractLims):
         return "Phi"
 
     def __get_sample_information_by(
-        self, icat_token: str, sample_id: str
+        self, sample_id: str
     ) -> Optional[Sampleinformation]:
         """
         Fetches sample metadata and associated resources based on the sample ID.
@@ -1259,28 +1180,23 @@ class ICATLIMS(AbstractLims):
         """
         try:
             sampleInformationList: List[Sampleinformation] = (
-                self.catalogue_api_instance.catalogue_session_id_files_get(
-                    icat_token, sample_id=str(sample_id)
-                )
+                self.icatClient.get_sample_information_list_by(sample_id=str(sample_id))
             )
             if sampleInformationList is not None and len(sampleInformationList) > 0:
                 return sampleInformationList[0]
             return None
 
-        except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 404:
+        except ApiException as e:
+            if e.status == 404:
                 logger.info("Sample %s not found (404)", sample_id)
             else:
                 logger.exception("HTTP error for sample %s", sample_id)
-        except requests.exceptions.RequestException:
-            logger.exception("Request error for sample %s", sample_id)
         except ValidationError:
             logger.exception("Invalid response format for sample %s", sample_id)
         return None
 
     def _download_resources(
         self,
-        icat_token: str,
         sample_id: str,
         resources: List[Resourceinformation] | None,
         output_folder: str,
@@ -1307,11 +1223,7 @@ class ICATLIMS(AbstractLims):
             )  # Make sure the folder exists
 
             try:
-                result = (
-                    self.catalogue_api_instance.catalogue_session_id_files_download_get(
-                        icat_token, str(sample_id), resource.id
-                    )
-                )
+                result = self.icatClient.download_file_by(str(sample_id), resource.id)
                 output_path = Path(resource_folder / resource.filename)
                 with output_path.open("wb") as f:
                     f.write(result)
@@ -1325,7 +1237,7 @@ class ICATLIMS(AbstractLims):
                 downloaded_files.append(downloaded)
                 logger.info("Downloaded %s to %s", resource.filename, downloaded.path)
 
-            except requests.exceptions.RequestException:
+            except ApiException:
                 logger.exception("Failed to download %s", resource.filename)
 
         return downloaded_files
@@ -1333,7 +1245,7 @@ class ICATLIMS(AbstractLims):
     def finalize_data_collection(self, datacollection_dict):
         logger.info("Storing datacollection in ICAT")
 
-        metadata = self.store_common_data(datacollection_dict)
+        params, extra = self.store_common_data(datacollection_dict)
 
         try:
             fileinfo = datacollection_dict["fileinfo"]
@@ -1349,7 +1261,7 @@ class ICATLIMS(AbstractLims):
             if scan_type == "characterisation":
                 # The "complete" entry in metadata must be set to False in order to
                 # group multi-wedge reference image data collection for characterisation
-                metadata["complete"] = False
+                params.complete = False
             elif scan_type == "OSC":
                 # In case the experiment_type is "OSC" and doesn't have
                 # "datacollection" in the dataset name, we set it to "datacollection".
@@ -1392,45 +1304,47 @@ class ICATLIMS(AbstractLims):
                     f"Kappa: {kappa_pos:0.1f}, Phi: {kappa_phi_pos:0.1f}"
                 )
 
-            metadata.update(
-                {
-                    MX_DATA_COLLECTION_ID_KEY: datacollection_dict.get("collection_id"),
-                    MX_DETECTOR_DISTANCE_KEY: distance,
-                    MX_DIRECTORY_KEY: str(directory),
-                    MX_EXPOSURE_TIME_KEY: oscillation_sequence["exposure_time"],
-                    MX_POSITION_NAME_KEY: datacollection_dict.get("position_name"),
-                    MX_NUMBER_OF_IMAGES_KEY: oscillation_sequence["number_of_images"],
-                    MX_OSCILLATION_RANGE_KEY: oscillation_sequence["range"],
-                    MX_AXIS_START_KEY: oscillation_sequence["start"],
-                    MX_OSCILLATION_OVERLAP_KEY: oscillation_sequence["overlap"],
-                    MX_RESOLUTION_KEY: datacollection_dict.get("resolution"),
-                    MX_RESOLUTION_AT_CORNER_KEY: datacollection_dict.get(
-                        "resolutionAtCorner"
-                    ),
-                    SCAN_TYPE_KEY: scan_type,
-                    MX_START_IMAGE_NUMBER_KEY: oscillation_sequence[
-                        "start_image_number"
-                    ],
-                    MX_TEMPLATE_KEY: fileinfo["template"],
-                    SAMPLE_NAME_KEY: sample_name,
-                    WORKFLOW_NAME_KEY: workflow_params.get("workflow_name"),
-                    WORKFLOW_TYPE_KEY: workflow_params.get("workflow_type"),
-                    WORKFLOW_ID_KEY: workflow_params.get("workflow_uid"),
-                    WORKFLOW_NOTE_KEY: workflow_params.get("workflow_note"),
-                    MX_KAPPA_SETTINGS_ID_KEY: mx_kappa_settings_id,
-                    MX_CHARACTERISATION_ID_KEY: workflow_params.get(
-                        "workflow_characterisation_id"
-                    ),
-                    MX_POSITION_ID_KEY: workflow_params.get("workflow_position_id"),
-                    GROUP_BY_KEY: workflow_params.get("workflow_group_by"),
-                }
+            params.title = dataset_name
+            params.folder_path = str(directory)
+            mx = params.MX
+            mx.dataCollectionId = _optional_str(
+                datacollection_dict.get("collection_id")
             )
+            mx.detectorDistance = distance
+            mx.directory = str(directory)
+            mx.exposureTime = oscillation_sequence["exposure_time"]
+            mx.positionName = _optional_str(datacollection_dict.get("position_name"))
+            mx.numberOfImages = oscillation_sequence["number_of_images"]
+            mx.oscillationRange = oscillation_sequence["range"]
+            mx.axis_start = oscillation_sequence["start"]
+            mx.oscillationOverlap = oscillation_sequence["overlap"]
+            mx.resolution = datacollection_dict.get("resolution")
+            mx.resolution_at_corner = datacollection_dict.get("resolutionAtCorner")
+            mx.scanType = scan_type
+            mx.startImageNumber = oscillation_sequence["start_image_number"]
+            mx.template = fileinfo["template"]
+            mx.kappa_settings_id = mx_kappa_settings_id
+            mx.characterisation_id = _optional_str(
+                workflow_params.get("workflow_characterisation_id")
+            )
+            mx.position_id = _optional_str(workflow_params.get("workflow_position_id"))
 
-            metadata[SAMPLE_TRACKING_CONTAINER_TYPE_KEY] = "UNIPUCK"
-            metadata[SAMPLE_TRACKING_CONTAINER_CAPACITY_KEY] = "16"
+            params.sample.name = sample_name
+            params.workflow.name = _optional_str(workflow_params.get("workflow_name"))
+            params.workflow.type = _optional_str(workflow_params.get("workflow_type"))
+            params.workflow.id = _optional_str(workflow_params.get("workflow_uid"))
+            params.workflow.note = _optional_str(workflow_params.get("workflow_note"))
+            params.group_by = workflow_params.get("workflow_group_by")
+
             position, sample_position = self._get_sample_position()
-            metadata[SAMPLE_CHANGER_POSITION_KEY] = position
-            metadata[SAMPLE_TRACKING_CONTAINER_POSITION_KEY] = sample_position
+            params.sample.changer.position = (
+                str(position) if position is not None else None
+            )
+            params.sample.tracking.container.type = "UNIPUCK"
+            params.sample.tracking.container.capacity = "16"
+            params.sample.tracking.container.position = (
+                str(sample_position) if sample_position is not None else None
+            )
 
             # Find sample by sampleId
             sample = HWR.beamline.lims.find_sample_by_sample_id(
@@ -1439,39 +1353,44 @@ class ICATLIMS(AbstractLims):
 
             try:
                 if sample is not None:
-                    metadata["SampleProtein_acronym"] = sample.get(PROTEIN_ACRONYM_KEY)
-                    metadata[SAMPLE_TRACKING_CONTAINER_ID_KEY] = sample.get(
-                        "containerCode"
-                    )  # containerCode instead of sampletrackingcontainer_id for ISPyB compatibility
-                    metadata[SAMPLE_TRACKING_PARCEL_ID_KEY] = sample.get(
-                        SAMPLE_TRACKING_PARCEL_ID_KEY
+                    params.sample.protein.acronym = _optional_str(
+                        sample.get(PROTEIN_ACRONYM_KEY)
                     )
-                    metadata[SAMPLE_TRACKING_PARCEL_NAME_KEY] = sample.get(
-                        SAMPLE_TRACKING_PARCEL_NAME_KEY
+                    # containerCode instead of sampletrackingcontainer_id for ISPyB compatibility
+                    params.sample.tracking.container.id = _optional_str(
+                        sample.get("containerCode")
+                    )
+                    params.sample.tracking.parcel.id = _optional_str(
+                        sample.get("SampleTrackingParcel_id")
+                    )
+                    params.sample.tracking.parcel.name = _optional_str(
+                        sample.get("SampleTrackingParcel_name")
                     )
             except RuntimeError as e:
                 logger.warning("Failed to add sample metadata.%s", e)
 
             try:
-                self.add_beamline_configuration_metadata(metadata, self.beamline_config)
+                self.add_beamline_configuration_metadata(
+                    params.instrument, self.beamline_config
+                )
             except RuntimeError as e:
                 logger.warning("Failed to add_beamline_configuration_metadata.%s", e)
 
-            # MX_axis_end
             try:
-                metadata["MX_axis_end"] = self._get_oscillation_end(
-                    oscillation_sequence
-                )
+                mx.axis_end = self._get_oscillation_end(oscillation_sequence)
             except RuntimeError:
                 logger.warning("Failed to get MX_axis_end")
 
-            # MX_axis_end
+            # Name of the rotation axis (e.g. "Omega"/"Phi"); axis_range is a
+            # numeric field and can't hold this string, unlike rotation_axis.
             try:
-                metadata["MX_axis_range"] = self._get_rotation_axis(
-                    oscillation_sequence
-                )
+                mx.rotation_axis = self._get_rotation_axis(oscillation_sequence)
             except RuntimeError:
                 logger.warning("Failed to get MX_axis_end")
+
+            params = params.finalize()
+            metadata = params.to_icat_dict()
+            metadata.update(extra)
 
             icat_metadata_path = Path(directory) / "metadata.json"
             with Path(icat_metadata_path).open("w") as f:

--- a/mxcubecore/model/tracking_model_objects.py
+++ b/mxcubecore/model/tracking_model_objects.py
@@ -1,9 +1,9 @@
 from typing import Optional
 
-from icat_plus_client.models.item import Item
+from pyicat_plus.client.models import ParcelItem
 
 
-class LoadedPuck(Item):
+class LoadedPuck(ParcelItem):
     puck_name: Optional[str] = None
     parcel_name: Optional[str] = None
     parcel_id: Optional[str] = None

--- a/poetry.lock
+++ b/poetry.lock
@@ -577,35 +577,36 @@ idna = ">=2.0.0"
 
 [[package]]
 name = "esrf-ontologies"
-version = "1.1.0"
+version = "2.1.0"
 description = "ESRF Ontologies"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "esrf_ontologies-1.1.0-py3-none-any.whl", hash = "sha256:c48789eab516d2bc4090b27471d5904e600358e80e14b72b94572705dfe88165"},
-    {file = "esrf_ontologies-1.1.0.tar.gz", hash = "sha256:d3fab908a148e54b0314abc44cb81d87662d37bbd37d7a57e48326b4d42b4259"},
+    {file = "esrf_ontologies-2.1.0-py3-none-any.whl", hash = "sha256:79938adb51a82709d3743253c7fb5b544f82fc585d0d511b5f7d537053ee4789"},
+    {file = "esrf_ontologies-2.1.0.tar.gz", hash = "sha256:17e56ee21d3fdb63d16873e65db55c5753fdf01549f9cfb9158ffecc6ea15ff6"},
 ]
 
 [package.extras]
-dev = ["black (>=22)", "esrf-ontologies[test]", "flake8 (>=4)", "owlready2"]
-doc = ["esrf-ontologies[test]", "pydata-sphinx-theme", "sphinx (>=4.5)", "sphinx-autodoc-typehints (>=1.16)"]
+dev = ["black (>=22)", "esrf-ontologies[test]", "flake8 (>=4)", "isort", "owlready2"]
+doc = ["esrf-ontologies[test]", "pydata-sphinx-theme", "sphinx (>=4.5,<9.0.0rc1)", "sphinx-autodoc-typehints (>=1.16)", "sphinx-copybutton"]
 test = ["pytest (>=7)"]
 
 [[package]]
 name = "esrf-pathlib"
-version = "0.6.0"
+version = "1.1.0"
 description = "A drop-in pathlib clone with ESRF-specific path utilities"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "esrf_pathlib-0.6.0.tar.gz", hash = "sha256:d8589936e8407a606210fed324e2ee97ab7896cf9314f67c06064ecb000d7687"},
+    {file = "esrf_pathlib-1.1.0-py3-none-any.whl", hash = "sha256:983027f6cf07c1309c8f960c8600447d7b3573baf102ccc6d340c82af1087e65"},
+    {file = "esrf_pathlib-1.1.0.tar.gz", hash = "sha256:a66a7c11791361811a99c85805c4834cc1782afc58750e8baa88d8c8c1d7c9d7"},
 ]
 
 [package.extras]
 dev = ["black (>=22)", "esrf-pathlib[test]", "flake8 (>=4.0)", "isort"]
-doc = ["esrf-pathlib[test]", "pydata-sphinx-theme", "sphinx (>=6.0)", "sphinx-autodoc-typehints"]
+doc = ["esrf-pathlib[test]", "pydata-sphinx-theme", "sphinx (>=6.0)", "sphinx-argparse", "sphinx-autodoc-typehints", "sphinx-copybutton"]
 test = ["pytest (>=7.0)"]
 
 [[package]]
@@ -700,6 +701,42 @@ files = [
     {file = "filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1"},
     {file = "filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1"},
 ]
+
+[[package]]
+name = "flexcache"
+version = "0.3"
+description = "Saves and loads to the cache a transformed versions of a source object."
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "flexcache-0.3-py3-none-any.whl", hash = "sha256:d43c9fea82336af6e0115e308d9d33a185390b8346a017564611f1466dcd2e32"},
+    {file = "flexcache-0.3.tar.gz", hash = "sha256:18743bd5a0621bfe2cf8d519e4c3bfdf57a269c15d1ced3fb4b64e0ff4600656"},
+]
+
+[package.dependencies]
+typing-extensions = "*"
+
+[package.extras]
+test = ["pytest", "pytest-cov", "pytest-mpl", "pytest-subtests"]
+
+[[package]]
+name = "flexparser"
+version = "0.4"
+description = "Parsing made fun ... using typing."
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "flexparser-0.4-py3-none-any.whl", hash = "sha256:3738b456192dcb3e15620f324c447721023c0293f6af9955b481e91d00179846"},
+    {file = "flexparser-0.4.tar.gz", hash = "sha256:266d98905595be2ccc5da964fe0a2c3526fbbffdc45b65b3146d75db992ef6b2"},
+]
+
+[package.dependencies]
+typing-extensions = "*"
+
+[package.extras]
+test = ["pytest", "pytest-cov", "pytest-mpl", "pytest-subtests"]
 
 [[package]]
 name = "fonttools"
@@ -1078,36 +1115,45 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "icat-esrf-definitions"
-version = "2.1.2"
+version = "3.5.0"
 description = "ESRF ICAT definitions"
 optional = true
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "icat_esrf_definitions-2.1.2.tar.gz", hash = "sha256:1af66f6dcad6f17e1873c26ae01de752ed2a2b51034ee773fd534a9d85d758b3"},
+    {file = "icat_esrf_definitions-3.5.0-py3-none-any.whl", hash = "sha256:3fa8e814e4f16f2e3b21bb4f426c6291fcd0beb4694fe5415e4a2bcd36da228a"},
+    {file = "icat_esrf_definitions-3.5.0.tar.gz", hash = "sha256:c002b236f4497e33fa48d57bce82f1ab1d3f7a752cd39941106f9ddf68e9bcfd"},
 ]
 
+[package.dependencies]
+esrf-ontologies = ">=2.1"
+pint = "*"
+pydantic = "*"
+typing_extensions = {version = "*", markers = "python_version < \"3.11\""}
+
 [package.extras]
-dev = ["pre-commit", "pytest"]
-test = ["pytest"]
+dev = ["datamodel-code-generator", "icat-esrf-definitions[test]", "pre-commit", "ruff", "tabulate"]
+doc = ["icat-esrf-definitions[test]", "pydata-sphinx-theme", "sphinx (>=4.5)", "sphinx-autodoc-typehints (>=1.16)", "sphinx-copybutton"]
+test = ["icat-esrf-definitions[xml]", "pytest", "silx"]
+xml = ["xmltodict"]
 
 [[package]]
 name = "icat-plus-client"
-version = "4.93.3"
+version = "4.95.5"
 description = "ICAT+ API"
 optional = true
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "icat_plus_client-4.93.3-py3-none-any.whl", hash = "sha256:c07d108d97c6fe54badb63e88ea07093ff8414289b031ca723ed8ea48ae26072"},
-    {file = "icat_plus_client-4.93.3.tar.gz", hash = "sha256:21c9ea3794000f501b89c107708bbbc4b5a6138478906deb6e21b97c4f1fcf15"},
+    {file = "icat_plus_client-4.95.5-py3-none-any.whl", hash = "sha256:497bbf3ea52c4da39dfdf30750b9b9286d9757b1da66c154dc656ed56edca39e"},
+    {file = "icat_plus_client-4.95.5.tar.gz", hash = "sha256:0415f9b83e2ced1c19992d3fa22c2d715856e69a9f7fbe031c844d4e69a05d14"},
 ]
 
 [package.dependencies]
 pydantic = ">=2"
-python-dateutil = "*"
+python-dateutil = ">=2.8.2"
 typing-extensions = ">=4.7.1"
-urllib3 = ">=1.25.3,<2.1.0"
+urllib3 = ">=1.25.3,<3.0.0"
 
 [[package]]
 name = "identify"
@@ -1949,12 +1995,78 @@ tests = ["check-manifest", "coverage (>=7.4.2)", "defusedxml", "markdown2", "ole
 xmp = ["defusedxml"]
 
 [[package]]
+name = "pint"
+version = "0.24.4"
+description = "Physical quantities module"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version == \"3.10\""
+files = [
+    {file = "Pint-0.24.4-py3-none-any.whl", hash = "sha256:aa54926c8772159fcf65f82cc0d34de6768c151b32ad1deb0331291c38fe7659"},
+    {file = "pint-0.24.4.tar.gz", hash = "sha256:35275439b574837a6cd3020a5a4a73645eb125ce4152a73a2f126bf164b91b80"},
+]
+
+[package.dependencies]
+flexcache = ">=0.3"
+flexparser = ">=0.4"
+platformdirs = ">=2.1.0"
+typing-extensions = ">=4.0.0"
+
+[package.extras]
+babel = ["babel (<=2.8)"]
+bench = ["pytest", "pytest-codspeed"]
+dask = ["dask"]
+mip = ["mip (>=1.13)"]
+numpy = ["numpy (>=1.23)"]
+pandas = ["pint-pandas (>=0.3)"]
+test = ["pytest", "pytest-benchmark", "pytest-cov", "pytest-mpl", "pytest-subtests"]
+testbase = ["pytest", "pytest-benchmark", "pytest-cov", "pytest-subtests"]
+uncertainties = ["uncertainties (>=3.1.6)"]
+xarray = ["xarray"]
+
+[[package]]
+name = "pint"
+version = "0.25.3"
+description = "Physical quantities module"
+optional = true
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "python_version == \"3.11\""
+files = [
+    {file = "pint-0.25.3-py3-none-any.whl", hash = "sha256:27eb25143bd5de9fcc4d5a4b484f16faf6b4615aa93ece6b3373a8c1a3c1b97d"},
+    {file = "pint-0.25.3.tar.gz", hash = "sha256:f8f5df6cf65314d74da1ade1bf96f8e3e4d0c41b51577ac53c49e7d44ca5acee"},
+]
+
+[package.dependencies]
+flexcache = ">=0.3"
+flexparser = ">=0.4"
+platformdirs = ">=2.1.0"
+typing-extensions = ">=4.0.0"
+
+[package.extras]
+all = ["babel (<=2.8)", "dask (<2025.3.0)", "matplotlib", "numpy (>=1.23)", "pint-pandas (>=0.3)", "scipy", "uncertainties (>=3.1.6)", "xarray"]
+babel = ["babel (<=2.8)"]
+codspeed = ["pytest", "pytest-benchmark", "pytest-codspeed", "pytest-cov", "pytest-mpl", "pytest-subtests"]
+dask = ["dask (<2025.3.0)"]
+docs = ["babel", "commonmark (==0.8.1)", "currencyconverter", "docutils", "graphviz", "ipykernel", "ipython (<=8.12)", "jupyter-client", "nbsphinx", "pooch", "pygments (>=2.4)", "recommonmark (==0.5.0)", "sciform", "scipy", "serialize", "sparse", "sphinx (>=6,<8.2)", "sphinx-book-theme (>=1.1.0)", "sphinx-copybutton", "sphinx-design"]
+matplotlib = ["matplotlib"]
+numpy = ["numpy (>=1.23)"]
+pandas = ["pint-pandas (>=0.3)"]
+scipy = ["scipy"]
+test = ["pytest", "pytest-benchmark", "pytest-cov", "pytest-subtests"]
+test-all = ["pytest", "pytest-benchmark", "pytest-cov", "pytest-mpl", "pytest-subtests"]
+test-mpl = ["pytest-mpl"]
+uncertainties = ["uncertainties (>=3.1.6)"]
+xarray = ["xarray"]
+
+[[package]]
 name = "platformdirs"
 version = "4.3.6"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
     {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
@@ -2254,32 +2366,33 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyicat-plus"
-version = "1.0.0"
+version = "3.0.0rc3"
 description = "Python client to ICAT+"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "pyicat_plus-1.0.0-py3-none-any.whl", hash = "sha256:9e6dbbef544c32e3ab8d37f79ab3152b991b18ab3893ad2e5baae5145f5f07f9"},
-    {file = "pyicat_plus-1.0.0.tar.gz", hash = "sha256:6517d3e03f11b49549d45cba51f66a9b2a20e6b7046cdf732b096ba686aa83ef"},
+    {file = "pyicat_plus-3.0.0rc3-py3-none-any.whl", hash = "sha256:9fefbc0de421c71224151ee3dacb35645d4442a5947bb3afa6f7114c955ca1af"},
+    {file = "pyicat_plus-3.0.0rc3.tar.gz", hash = "sha256:afe464172fc7ea9edd00fb1a4084a3344969d65787d6ca7c3c613558eaae1568"},
 ]
 
 [package.dependencies]
-esrf-ontologies = "*"
-esrf-pathlib = "*"
+esrf-ontologies = ">=2.1"
+esrf-pathlib = ">=1.0.0"
 h5py = "*"
-icat-esrf-definitions = "*"
+icat-esrf-definitions = ">=3.5"
+icat-plus-client = ">=4.95.5"
 numpy = "*"
+pillow = "*"
 querypool = "*"
 requests = "*"
 stompest = "*"
-tqdm = "*"
+xsdata = {version = "*", markers = "python_version >= \"3.9\""}
 
 [package.extras]
-bliss = ["blissdata[beacon]"]
-dev = ["black (>=25)", "flake8 (>=4)", "isort", "pep8-naming", "pyicat-plus[test]"]
-doc = ["pydata-sphinx-theme", "pyicat-plus[test]", "sphinx (>=4.5)", "sphinx-autodoc-typehints (>=1.16)", "sphinx-copybutton"]
-test = ["coilmq", "h5py (>=3.5)", "numpy (>=1.15)", "psutil", "pyicat-plus[bliss]", "pytest (>=7)", "pytest-timeout (>=2.1)", "stomp.py (>=7)", "xmltodict"]
+dev = ["pre-commit", "pyicat-plus[test]", "ruff", "xsdata[cli]"]
+doc = ["pydata-sphinx-theme", "pyicat-plus[test]", "sphinx (>=4.5)", "sphinx-autodoc-typehints (>=1.16)", "sphinx-copybutton", "sphinx-design"]
+test = ["coilmq", "h5py (>=3.5)", "numpy (>=1.15)", "psutil", "pytest (>=7)", "pytest-timeout (>=2.1)", "stomp.py (>=7)"]
 
 [[package]]
 name = "pyparsing"
@@ -2452,14 +2565,14 @@ dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "python-dateutil"
-version = "2.7.5"
+version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 groups = ["main"]
 files = [
-    {file = "python-dateutil-2.7.5.tar.gz", hash = "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"},
-    {file = "python_dateutil-2.7.5-py2.py3-none-any.whl", hash = "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93"},
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
 ]
 
 [package.dependencies]
@@ -3099,28 +3212,6 @@ files = [
 ]
 
 [[package]]
-name = "tqdm"
-version = "4.67.1"
-description = "Fast, Extensible Progress Meter"
-optional = true
-python-versions = ">=3.7"
-groups = ["main"]
-files = [
-    {file = "tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2"},
-    {file = "tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[package.extras]
-dev = ["nbval", "pytest (>=6)", "pytest-asyncio (>=0.24)", "pytest-cov", "pytest-timeout"]
-discord = ["requests"]
-notebook = ["ipywidgets (>=6)"]
-slack = ["slack-sdk"]
-telegram = ["requests"]
-
-[[package]]
 name = "typer"
 version = "0.20.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -3485,6 +3576,28 @@ files = [
 ]
 
 [[package]]
+name = "xsdata"
+version = "26.2"
+description = "Python XML Binding"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "xsdata-26.2-py3-none-any.whl", hash = "sha256:85a591a4405d903416afbd4a917e8dda8ea44641a3e66d72134bc2a31b3c16b0"},
+    {file = "xsdata-26.2.tar.gz", hash = "sha256:c631af71aaa75734f8ce92a08fcf8389d905dee2aab0b5032c9032e9071009a6"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.12.0"
+
+[package.extras]
+cli = ["click (>=8.0.0)", "jinja2 (>=3.0.0)", "ruff (>=0.9.8)", "toposort (>=1.9)"]
+docs = ["markdown-exec[ansi]", "mkdocs", "mkdocs-gen-files", "mkdocs-literate-nav", "mkdocs-material", "mkdocs-minify-plugin", "mkdocstrings[python]"]
+lxml = ["lxml (>=5.0.0)"]
+soap = ["requests (>=2.28.0)"]
+test = ["pre-commit (>=3.0.0)", "pytest (>=8.0.0)", "pytest-benchmark (>=4.0.0)", "pytest-cov (>=5.0.0)"]
+
+[[package]]
 name = "zope-event"
 version = "4.6"
 description = "Very basic event publishing system"
@@ -3554,4 +3667,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "1a88eb95cca2b671b5d48a720b34d3c3e3eb17b489592703a462695cb3b21ab8"
+content-hash = "caa55899de0d6e8873508d14f9b4d460bfc33e7f16c97d5fcf7399b10ad30fbe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,9 @@ PyTango = "^9.3.6"
 python-ldap = "^3.4.5"
 requests = "^2.33.0"
 colorama = "^0.4.6"
-pyicat-plus = {version = "^1.0.0", optional = true}
-icat-plus-client = {version = "4.93.3", optional = true}
+pyicat-plus = {version = ">=3.0.0rc1", optional = true}
+icat-esrf-definitions = {version = ">=3.4.0", optional = true}
+icat-plus-client = {version = ">=4.93.7", optional = true}
 mxcube-video-streamer = "^1.8.5"
 defusedxml = "0.7.1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,7 @@ PyTango = "^9.3.6"
 python-ldap = "^3.4.5"
 requests = "^2.33.0"
 colorama = "^0.4.6"
-pyicat-plus = {version = ">=3.0.0rc1", optional = true}
-icat-esrf-definitions = {version = ">=3.4.0", optional = true}
-icat-plus-client = {version = ">=4.93.7", optional = true}
+pyicat-plus = {version = ">=3.0.0rc3", optional = true, allow-prereleases = true}
 mxcube-video-streamer = "^1.8.5"
 defusedxml = "0.7.1"
 


### PR DESCRIPTION
This is a PR on another PR:

- Use `icat-plus-client` for REST calls through `pyicat-plus`.
- Use `esrf-icat-definitions` models for created ICAT dataset metadata.

Needs (edit: deployed to pypi)

- https://gitlab.esrf.fr/icat/pyicat-plus/-/merge_requests/253
- https://gitlab.esrf.fr/icat/hdf5-master-config/-/merge_requests/233