### PR TITLE
Update BlissRontecMCA

### DIFF
--- a/mxcubecore/HardwareObjects/BlissRontecMCA.py
+++ b/mxcubecore/HardwareObjects/BlissRontecMCA.py
@@ -1,19 +1,30 @@
+from mxcubecore import HardwareRepository as HWR
 from mxcubecore.BaseHardwareObjects import HardwareObject
-from mxcubecore.HardwareObjects.abstract.AbstractMCA import AbstractMCA
 from mxcubecore.TaskUtils import task
 
 
-class BlissRontecMCA(AbstractMCA, HardwareObject):
+class BlissRontecMCA(HardwareObject):
     def __init__(self, name):
-        AbstractMCA.__init__(self)
-        HardwareObject.__init__(self, name)
+        super().__init__(name)
         self.mca = None
-        self.calib_cf = []
 
     def init(self):
-        session = self.get_object_by_role("bliss_session")
-        obj_name = self.get_property("object_name")
-        self.mca = getattr(session, obj_name)
+        actuator_name = self.get_property("actuator_name")
+        try:
+            bliss_proxy = HWR.beamline.bliss_proxy
+            bliss_proxy.hardware.register(actuator_name)
+            self.mca = bliss_proxy.get_object(actuator_name)
+        except Exception as exc:
+            # BLISS object missing — run in offline/no-hardware mode
+            import logging
+
+            logging.getLogger("MX3.HWR").warning(
+                "BlissRontecMCA '%s': BLISS object '%s' not available (%s)",
+                self.name if hasattr(self, "name") else actuator_name,
+                actuator_name,
+                exc,
+            )
+            self.mca = None
 
     @task
     def read_raw_data(self, chmin=0, chmax=4095, save_data=False):


### PR DESCRIPTION
- Call bliss_proxy.hardware.register(actuator_name) before get_object(), matching the other Bliss hardware objects