### PR TITLE
adapt to pyicat-plus 3.0.0rc5

### DIFF
--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any, List, Optional
 from zoneinfo import ZoneInfo
 
-from pydantic import ValidationError
 from pyicat_plus import errors as icat_errors
 from pyicat_plus.client import models as icat_models
 from pyicat_plus.client.main import IcatClient
@@ -241,11 +240,11 @@ class ICATLIMS(AbstractLims):
                 len(self.loaded_pucks),
             )
 
-            sampleInformationList: List[icat_models.SampleInformation] = []
+            sample_file_list: List[icat_models.SampleFile] = []
             # Download all sampleInformation for the investigation
             # This makes to perform a single call to the server instead of one per sample
             try:
-                sampleInformationList = self.icatClient.get_sample_information_list_by(
+                sample_file_list = self.icatClient.get_sample_files_by(
                     investigation_id=str(investigation_id)
                 )
             except Exception as e:
@@ -260,9 +259,7 @@ class ICATLIMS(AbstractLims):
                 msg += f"{puck.sample_changer_location}, containing {len(puck.content)} samples"
                 logger.debug(msg)
                 for tracking_sample in tracking_samples:
-                    sample = self.__to_sample(
-                        tracking_sample, puck, sampleInformationList
-                    )
+                    sample = self.__to_sample(tracking_sample, puck, sample_file_list)
                     self.samples.append(sample)
 
         except RuntimeError:
@@ -383,7 +380,7 @@ class ICATLIMS(AbstractLims):
         self,
         tracking_sample: icat_models.ParcelItem,
         protein_acronym: str,
-        sample_information: icat_models.SampleInformation | None,
+        sample_information: icat_models.SampleFile | None,
     ) -> dict[str, Any]:
         if not tracking_sample.processing_plan or tracking_sample.processing_plan == []:
             return {}
@@ -405,7 +402,7 @@ class ICATLIMS(AbstractLims):
         self,
         sample_sheet_id: str,
         protein_acronym: str,
-        sample_information: icat_models.SampleInformation | None,
+        sample_information: icat_models.SampleFile | None,
     ) -> List[Download]:
         cache_key = (sample_sheet_id, protein_acronym)
         logger.debug(f"Getting sample information for {protein_acronym}")
@@ -448,7 +445,7 @@ class ICATLIMS(AbstractLims):
         self,
         tracking_sample: icat_models.ParcelItem,
         puck: LoadedPuck,
-        sample_information_list: List[icat_models.SampleInformation],
+        sample_information_list: List[icat_models.SampleFile],
     ) -> dict[str, Any]:
         """
         Convert a tracking sample and associated metadata into the internal
@@ -1178,35 +1175,6 @@ class ICATLIMS(AbstractLims):
             ):
                 return "Omega"
         return "Phi"
-
-    def __get_sample_information_by(
-        self, sample_id: str
-    ) -> Optional[icat_models.SampleInformation]:
-        """
-        Fetches sample metadata and associated resources based on the sample ID.
-
-        Parameters:
-            sample_id (str): The unique identifier for the sample.
-
-        Returns:
-            Optional[SampleInformation]: Returns a SampleInformation object or None.
-        """
-        try:
-            sampleInformationList: List[icat_models.SampleInformation] = (
-                self.icatClient.get_sample_information_list_by(sample_id=str(sample_id))
-            )
-            if sampleInformationList is not None and len(sampleInformationList) > 0:
-                return sampleInformationList[0]
-            return None
-
-        except icat_errors.ApiException as e:
-            if e.status == 404:
-                logger.info("Sample %s not found (404)", sample_id)
-            else:
-                logger.exception("HTTP error for sample %s", sample_id)
-        except ValidationError:
-            logger.exception("Invalid response format for sample %s", sample_id)
-        return None
 
     def _download_resources(
         self,

--- a/poetry.lock
+++ b/poetry.lock
@@ -2366,14 +2366,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyicat-plus"
-version = "3.0.0rc3"
+version = "3.0.0rc5"
 description = "Python client to ICAT+"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "pyicat_plus-3.0.0rc3-py3-none-any.whl", hash = "sha256:9fefbc0de421c71224151ee3dacb35645d4442a5947bb3afa6f7114c955ca1af"},
-    {file = "pyicat_plus-3.0.0rc3.tar.gz", hash = "sha256:afe464172fc7ea9edd00fb1a4084a3344969d65787d6ca7c3c613558eaae1568"},
+    {file = "pyicat_plus-3.0.0rc5-py3-none-any.whl", hash = "sha256:137db31c9140a411844781c531613657da25b2343180df7c88970cc3f65a29e3"},
+    {file = "pyicat_plus-3.0.0rc5.tar.gz", hash = "sha256:a960fdcf281f89659c3d27c6c05543e19a850553b1faf9643b5c9bea1d911bb6"},
 ]
 
 [package.dependencies]
@@ -2384,6 +2384,7 @@ icat-esrf-definitions = ">=3.5"
 icat-plus-client = ">=4.95.5"
 numpy = "*"
 pillow = "*"
+pint = "<=0.25.3"
 querypool = "*"
 requests = "*"
 stompest = "*"
@@ -2391,7 +2392,7 @@ xsdata = {version = "*", markers = "python_version >= \"3.9\""}
 
 [package.extras]
 dev = ["pre-commit", "pyicat-plus[test]", "ruff", "xsdata[cli]"]
-doc = ["pydata-sphinx-theme", "pyicat-plus[test]", "sphinx (>=4.5)", "sphinx-autodoc-typehints (>=1.16)", "sphinx-copybutton", "sphinx-design"]
+doc = ["pydata-sphinx-theme", "pyicat-plus[test]", "sphinx (>=4.5)", "sphinx-argparse", "sphinx-autodoc-typehints (>=1.16)", "sphinx-copybutton", "sphinx-design"]
 test = ["coilmq", "h5py (>=3.5)", "numpy (>=1.15)", "psutil", "pytest (>=7)", "pytest-timeout (>=2.1)", "stomp.py (>=7)"]
 
 [[package]]
@@ -3667,4 +3668,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "caa55899de0d6e8873508d14f9b4d460bfc33e7f16c97d5fcf7399b10ad30fbe"
+content-hash = "f3f4f8fa22110f8b87bca7b4df5a5149f745d15fe363cf8bff1117f9daf2f5a4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ PyTango = "^9.3.6"
 python-ldap = "^3.4.5"
 requests = "^2.33.0"
 colorama = "^0.4.6"
-pyicat-plus = {version = ">=3.0.0rc3", optional = true, allow-prereleases = true}
+pyicat-plus = {version = ">=3.0.0rc5", optional = true, allow-prereleases = true}
 mxcube-video-streamer = "^1.8.5"
 defusedxml = "0.7.1"
 


### PR DESCRIPTION
needs 3.0.0rc5 released: https://pypi.org/project/pyicat-plus/3.0.0rc5/

- `get_sample_information_list_by` has been renamed `get_sample_files_by` and return type `SampleInformation` by `SampleFile`
- remove dead code